### PR TITLE
Version 3.6 Build 4

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.6.3.76")>
+<Assembly: AssemblyFileVersion("3.6.4.77")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1088,6 +1088,18 @@ Namespace My
                 Me("colLogAutoFill") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property disableAutoScrollUponScrolling() As Boolean
+            Get
+                Return CType(Me("disableAutoScrollUponScrolling"),Boolean)
+            End Get
+            Set
+                Me("disableAutoScrollUponScrolling") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -263,5 +263,8 @@
     <Setting Name="colLogAutoFill" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="disableAutoScrollUponScrolling" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -10,6 +10,7 @@ Namespace SupportCode
     End Enum
 
     Module SupportCode
+        Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)
         Public ignoredList As New List(Of IgnoredClass)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -110,7 +110,12 @@ Namespace SyslogParser
                                   ParentForm.BtnSaveLogsToDisk.Enabled = True
 
                                   If ParentForm.ChkEnableAutoScroll.Checked And ParentForm.Logs.Rows.Count > 0 And ParentForm.intSortColumnIndex = 0 Then
-                                      ParentForm.Logs.FirstDisplayedScrollingRowIndex = If(ParentForm.sortOrder = SortOrder.Ascending, ParentForm.Logs.Rows.Count - 1, 0)
+                                      Try
+                                          boolIsProgrammaticScroll = True
+                                          ParentForm.Logs.FirstDisplayedScrollingRowIndex = If(ParentForm.sortOrder = SortOrder.Ascending, ParentForm.Logs.Rows.Count - 1, 0)
+                                      Finally
+                                          boolIsProgrammaticScroll = False
+                                      End Try
                                   End If
                               End Sub)
         End Sub

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -12,6 +12,8 @@ Public Class Alerts_History
     End Property
 
     Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+        strRawLogText = strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase)
+
         Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
             LogViewerInstance.LblLogDate.Text = $"Log Date: {strLogDate}"
             LogViewerInstance.LblSource.Text = $"Source IP Address: {strSourceIP}"

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -1,4 +1,5 @@
 ﻿Imports System.Reflection
+Imports Microsoft.VisualBasic.Logging
 
 Public Class Alerts_History
     Public Property DataToLoad As List(Of AlertsHistory)
@@ -25,6 +26,11 @@ Public Class Alerts_History
     End Sub
 
     Private Sub Alerts_History_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        If My.Settings.font IsNot Nothing Then
+            AlertHistoryList.DefaultCellStyle.Font = My.Settings.font
+            AlertHistoryList.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
+        End If
+
         Dim flags As BindingFlags = BindingFlags.NonPublic Or BindingFlags.Instance Or BindingFlags.SetProperty
         Dim propInfo As PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
         propInfo?.SetValue(AlertHistoryList, True, Nothing)

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -40,6 +40,7 @@ Partial Class Form1
         Me.LblLogFileSize = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblNumberOfIgnoredIncomingLogs = New System.Windows.Forms.ToolStripStatusLabel()
         Me.ChkEnableAutoScroll = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkDisableAutoScrollUponScrolling = New System.Windows.Forms.ToolStripMenuItem()
         Me.AutomaticallyCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
         Me.SaveTimer = New System.Windows.Forms.Timer(Me.components)
@@ -263,6 +264,13 @@ Partial Class Form1
         Me.ChkEnableAutoScroll.Size = New System.Drawing.Size(339, 22)
         Me.ChkEnableAutoScroll.Text = "Enable Auto Scroll"
         '
+        'ToolStripMenuItem
+        '
+        Me.ChkDisableAutoScrollUponScrolling.CheckOnClick = True
+        Me.ChkDisableAutoScrollUponScrolling.Name = "ChkDisableAutoScrollUponScrolling"
+        Me.ChkDisableAutoScrollUponScrolling.Size = New System.Drawing.Size(339, 22)
+        Me.ChkDisableAutoScrollUponScrolling.Text = "        Disable Auto Scroll upon scrolling"
+        '
         'BtnCheckForUpdates
         '
         Me.BtnCheckForUpdates.Name = "BtnCheckForUpdates"
@@ -420,7 +428,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.ImportExportSettingsToolStripMenuItem, Me.IncludeButtonsOnNotifications, Me.MinimizeToClockTray, Me.ColLogsAutoFill, Me.NotificationLength, Me.OpenWindowsExplorerToAppConfigFile, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.ImportExportSettingsToolStripMenuItem, Me.IncludeButtonsOnNotifications, Me.MinimizeToClockTray, Me.ColLogsAutoFill, Me.NotificationLength, Me.OpenWindowsExplorerToAppConfigFile, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -860,6 +868,7 @@ Partial Class Form1
     Friend WithEvents StatusStrip As StatusStrip
     Friend WithEvents NumberOfLogs As ToolStripStatusLabel
     Friend WithEvents ChkEnableAutoScroll As ToolStripMenuItem
+    Friend WithEvents ChkDisableAutoScrollUponScrolling As ToolStripMenuItem
     Friend WithEvents AutomaticallyCheckForUpdates As ToolStripMenuItem
     Friend WithEvents BtnClearLog As ToolStripMenuItem
     Friend WithEvents AlertsHistory As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -536,6 +536,8 @@ Public Class Form1
     End Sub
 
     Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+        strRawLogText = strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase)
+
         Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
             LogViewerInstance.LblLogDate.Text = $"Log Date: {strLogDate}"
             LogViewerInstance.LblSource.Text = $"Source IP Address: {strSourceIP}"
@@ -550,7 +552,7 @@ Public Class Form1
         If Logs.Rows.Count > 0 And Logs.SelectedCells.Count > 0 Then
             Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
-            Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData)
+            Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
             Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .MyParentForm = Me}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -253,6 +253,7 @@ Public Class Form1
         ChkShowLogTypeColumn.Checked = My.Settings.boolShowLogTypeColumn
         RemoveNumbersFromRemoteApp.Checked = My.Settings.RemoveNumbersFromRemoteApp
         IPv6Support.Checked = My.Settings.IPv6Support
+        ChkDisableAutoScrollUponScrolling.Checked = My.Settings.disableAutoScrollUponScrolling
     End Sub
 
     Private Sub LoadAndDeserializeArrays()
@@ -1536,10 +1537,14 @@ Public Class Form1
     End Sub
 
     Private Sub Logs_Scroll(sender As Object, e As ScrollEventArgs) Handles Logs.Scroll
-        If Not boolIsProgrammaticScroll And My.Settings.autoScroll Then
+        If Not boolIsProgrammaticScroll And ChkEnableAutoScroll.Checked And ChkDisableAutoScrollUponScrolling.Checked Then
             My.Settings.autoScroll = False
             ChkEnableAutoScroll.Checked = False
         End If
+    End Sub
+
+    Private Sub ChkDisableAutoScrollUponScrolling_Click(sender As Object, e As EventArgs) Handles ChkDisableAutoScrollUponScrolling.Click
+        My.Settings.disableAutoScrollUponScrolling = ChkDisableAutoScrollUponScrolling.Checked
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -371,7 +371,10 @@ Public Class Form1
         ColRemoteProcess.Width = My.Settings.RemoteProcessHeaderSize
         ColLog.Width = My.Settings.columnLogSize
 
-        If My.Settings.font IsNot Nothing Then Logs.DefaultCellStyle.Font = My.Settings.font
+        If My.Settings.font IsNot Nothing Then
+            Logs.DefaultCellStyle.Font = My.Settings.font
+            Logs.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
+        End If
 
         boolDoneLoading = True
 
@@ -1448,6 +1451,9 @@ Public Class Form1
 
             If FontDialog.ShowDialog() = DialogResult.OK Then
                 My.Settings.font = FontDialog.Font
+
+                Logs.DefaultCellStyle.Font = My.Settings.font
+                Logs.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
 
                 DataHandling.WriteLogsToDisk()
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -143,7 +143,12 @@ Public Class Form1
 
     Public Sub SelectLatestLogEntry()
         If ChkEnableAutoScroll.Checked AndAlso Logs.Rows.Count > 0 AndAlso intSortColumnIndex = 0 Then
-            Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0)
+            Try
+                boolIsProgrammaticScroll = True
+                Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0)
+            Finally
+                boolIsProgrammaticScroll = False
+            End Try
         End If
     End Sub
 
@@ -1522,6 +1527,13 @@ Public Class Form1
     Private Sub ColLogsAutoFill_Click(sender As Object, e As EventArgs) Handles ColLogsAutoFill.Click
         My.Settings.colLogAutoFill = ColLogsAutoFill.Checked
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
+    End Sub
+
+    Private Sub Logs_Scroll(sender As Object, e As ScrollEventArgs) Handles Logs.Scroll
+        If Not boolIsProgrammaticScroll And My.Settings.autoScroll Then
+            My.Settings.autoScroll = False
+            ChkEnableAutoScroll.Checked = False
+        End If
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -23,7 +23,7 @@ Public Class IgnoredLogsAndSearchResults
         If Logs.Rows.Count > 0 And Logs.SelectedCells.Count > 0 Then
             Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
-            Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData)
+            Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
             Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -101,7 +101,10 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub Ignored_Logs_and_Search_Results_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        If My.Settings.font IsNot Nothing Then Logs.DefaultCellStyle.Font = My.Settings.font
+        If My.Settings.font IsNot Nothing Then
+            Logs.DefaultCellStyle.Font = My.Settings.font
+            Logs.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
+        End If
 
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -27,7 +27,7 @@ Public Class LogViewer
 
     Private Sub ChkShowRawLog_Click(sender As Object, e As EventArgs) Handles ChkShowRawLog.Click
         My.Settings.boolShowRawLogOnLogViewer = ChkShowRawLog.Checked
-        LogText.Text = If(ChkShowRawLog.Checked, strRawLogText, strLogText)
+        LogText.Text = If(ChkShowRawLog.Checked, strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase), strLogText)
         If MyParentForm IsNot Nothing Then MyParentForm.ShowRawLogOnLogViewer.Checked = ChkShowRawLog.Checked
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -84,7 +84,7 @@ Partial Class ViewLogBackups
         '
         'ColFileDate
         '
-        Me.ColFileDate.HeaderText = "Date"
+        Me.ColFileDate.HeaderText = "Creation Date"
         Me.ColFileDate.Name = "ColFileDate"
         Me.ColFileDate.ReadOnly = True
         Me.ColFileDate.Width = 240

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -136,7 +136,11 @@ Public Class ViewLogBackups
         Invoke(Sub()
                    listOfDataGridViewRows = listOfDataGridViewRows.OrderBy(Function(row As MyDataGridViewFileRow) row.fileDate).ToList()
 
-                   FileList.DefaultCellStyle.Font = My.Settings.font
+                   If My.Settings.font IsNot Nothing Then
+                       FileList.DefaultCellStyle.Font = My.Settings.font
+                       FileList.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
+                   End If
+
                    FileList.Rows.Clear()
                    FileList.Rows.AddRange(listOfDataGridViewRows.ToArray())
                    lblNumberOfFiles.Text = $"Number of Files: {intFileCount:N0}"

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -261,6 +261,9 @@
             <setting name="colLogAutoFill" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="disableAutoScrollUponScrolling" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Fixed a bug in which {newline} control codes were visible on the "Log Viewer" windows when the "Show Raw Log Text" was enabled and the log entry had line feeds.
- Made it so that scrolling in the logs DataGridView will disable Auto Scroll.
- Changed the Date header on the "View Log Backups" window to read "Creation Date".
- Brought the user's font preference to the columns of the various DataGrids used in the program.
- Added code to be able to disable the function that disables Auto Scroll upon scrolling in the DataGridView. By default, this function is enabled.