### PR TITLE
Version 3.7 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.6.4.77")>
+<Assembly: AssemblyFileVersion("3.7.1.78")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1112,6 +1112,18 @@ Namespace My
                 Me("viewLogBackupsHiddenColumnSize") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("50")>  _
+        Public Property columnAlertedSize() As Integer
+            Get
+                Return CType(Me("columnAlertedSize"),Integer)
+            End Get
+            Set
+                Me("columnAlertedSize") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1124,6 +1124,18 @@ Namespace My
                 Me("columnAlertedSize") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("150")>  _
+        Public Property columnFileNameSize() As Integer
+            Get
+                Return CType(Me("columnFileNameSize"),Integer)
+            End Get
+            Set
+                Me("columnFileNameSize") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1100,6 +1100,18 @@ Namespace My
                 Me("disableAutoScrollUponScrolling") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+        Public Property viewLogBackupsHiddenColumnSize() As Integer
+            Get
+                Return CType(Me("viewLogBackupsHiddenColumnSize"),Integer)
+            End Get
+            Set
+                Me("viewLogBackupsHiddenColumnSize") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -266,5 +266,8 @@
     <Setting Name="disableAutoScrollUponScrolling" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="viewLogBackupsHiddenColumnSize" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">60</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -269,5 +269,8 @@
     <Setting Name="viewLogBackupsHiddenColumnSize" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">60</Value>
     </Setting>
+    <Setting Name="columnAlertedSize" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -272,5 +272,8 @@
     <Setting Name="columnAlertedSize" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">50</Value>
     </Setting>
+    <Setting Name="columnFileNameSize" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">150</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -42,6 +42,8 @@ Public Class SavedData
                     .Cells(ColumnIndex_Alerted).Style.Font = My.Settings.font
                     .Cells(ColumnIndex_ServerTime).Style.Font = My.Settings.font
                 End If
+
+                .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
             End With
 
             Return MyDataGridViewRow

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -11,7 +11,7 @@ Public Class SavedData
     Public DateObject, ServerDate As Date
     Public BoolAlerted As Boolean = False
 
-    Public Function MakeDataGridRow(ByRef dataGrid As DataGridView, height As Integer) As MyDataGridViewRow
+    Public Function MakeDataGridRow(ByRef dataGrid As DataGridView) As MyDataGridViewRow
         Using MyDataGridViewRow As New MyDataGridViewRow
             With MyDataGridViewRow
                 .CreateCells(dataGrid)
@@ -28,7 +28,6 @@ Public Class SavedData
                 .Cells(ColumnIndex_ServerTime).Value = If(ServerDate = Date.MinValue, "", ToIso8601Format(ServerDate))
                 .DateObject = DateObject
                 .BoolAlerted = BoolAlerted
-                .MinimumHeight = height
                 .RawLogData = rawLogData
                 .AlertText = alertText
                 .alertType = alertType
@@ -74,7 +73,7 @@ Public Class AlertsHistory
     Public strTime, strAlertText, strIP, strLog, strRawLog As String
     Public alertType As AlertType
 
-    Public Function MakeDataGridRow(ByRef dataGrid As DataGridView, height As Integer) As AlertsHistoryDataGridViewRow
+    Public Function MakeDataGridRow(ByRef dataGrid As DataGridView) As AlertsHistoryDataGridViewRow
         Using AlertsHistoryDataGridViewRow As New AlertsHistoryDataGridViewRow
             With AlertsHistoryDataGridViewRow
                 .CreateCells(dataGrid)

--- a/Free SysLog/Support Code/MyDataGridViewRow.vb
+++ b/Free SysLog/Support Code/MyDataGridViewRow.vb
@@ -26,6 +26,7 @@
             End With
         Next
 
+        newDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
         Return newDataGridRow
     End Function
 End Class

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -9,7 +9,7 @@ Namespace NotificationLimiter
         ' Time after which an unused entry is considered stale (in minutes)
         Private Const CleanupThresholdInMinutes As Integer = 10
 
-        Public Sub ShowNotification(timeout As Integer, tipTitle As String, tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+        Public Sub ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
             ' Get the current time
             Dim currentTime As Date = Date.Now
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -171,34 +171,6 @@ Namespace SupportCode
             child.Location = New Point(childLeft, childTop)
         End Sub
 
-        Public Function GetMinimumHeight(strInput As String, font As Font, maxWidth As Integer, dgv As DataGridView) As Integer
-            ' Validate parameters
-            If font Is Nothing OrElse dgv Is Nothing Then Throw New ArgumentNullException("Font and DataGridView cannot be null.")
-            If maxWidth <= 0 Then Throw New ArgumentException("MaxWidth must be greater than 0.")
-            If strInput Is Nothing Then strInput = ""
-
-            ' Split text into lines
-            Dim lines As String() = strInput.Split(New String() {vbCrLf}, StringSplitOptions.None)
-            Dim totalHeight As Integer = 0
-
-            ' Pre-calculate blank line height
-            Dim blankLineHeight As Integer = TextRenderer.MeasureText(" ", font, New Size(maxWidth, Integer.MaxValue), TextFormatFlags.WordBreak).Height
-
-            ' Measure each line
-            For Each line As String In lines
-                Dim currentLine As String = If(String.IsNullOrEmpty(line), " ", line)
-                totalHeight += TextRenderer.MeasureText(currentLine, font, New Size(maxWidth, Integer.MaxValue), TextFormatFlags.WordBreak).Height
-            Next
-
-            ' Account for padding and buffer
-            Dim padding As Padding = dgv.DefaultCellStyle.Padding
-            Dim bufferPerLine As Integer = 2 ' Adjustable buffer
-            totalHeight += padding.Top + padding.Bottom + (bufferPerLine * lines.Length)
-
-            ' Return the calculated height
-            Return totalHeight
-        End Function
-
         Public Function IsRegexPatternValid(pattern As String) As Boolean
             Try
                 Dim regex As New RegularExpressions.Regex(pattern)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -171,9 +171,32 @@ Namespace SupportCode
             child.Location = New Point(childLeft, childTop)
         End Sub
 
-        Public Function GetMinimumHeight(strInput As String, font As Font, maxWidth As Integer) As Integer
-            Dim textSize As Size = TextRenderer.MeasureText(strInput, font, New Size(maxWidth, Integer.MaxValue), TextFormatFlags.WordBreak)
-            Return textSize.Height + 10
+        Public Function GetMinimumHeight(strInput As String, font As Font, maxWidth As Integer, dgv As DataGridView) As Integer
+            ' Validate parameters
+            If font Is Nothing OrElse dgv Is Nothing Then Throw New ArgumentNullException("Font and DataGridView cannot be null.")
+            If maxWidth <= 0 Then Throw New ArgumentException("MaxWidth must be greater than 0.")
+            If strInput Is Nothing Then strInput = ""
+
+            ' Split text into lines
+            Dim lines As String() = strInput.Split(New String() {vbCrLf}, StringSplitOptions.None)
+            Dim totalHeight As Integer = 0
+
+            ' Pre-calculate blank line height
+            Dim blankLineHeight As Integer = TextRenderer.MeasureText(" ", font, New Size(maxWidth, Integer.MaxValue), TextFormatFlags.WordBreak).Height
+
+            ' Measure each line
+            For Each line As String In lines
+                Dim currentLine As String = If(String.IsNullOrEmpty(line), " ", line)
+                totalHeight += TextRenderer.MeasureText(currentLine, font, New Size(maxWidth, Integer.MaxValue), TextFormatFlags.WordBreak).Height
+            Next
+
+            ' Account for padding and buffer
+            Dim padding As Padding = dgv.DefaultCellStyle.Padding
+            Dim bufferPerLine As Integer = 2 ' Adjustable buffer
+            totalHeight += padding.Top + padding.Bottom + (bufferPerLine * lines.Length)
+
+            ' Return the calculated height
+            Return totalHeight
         End Function
 
         Public Function IsRegexPatternValid(pattern As String) As Boolean

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -459,7 +459,7 @@ Namespace SyslogParser
                         End If
                     End If
 
-                    NotificationLimiter.ShowNotification(1, "Log Alert", strAlertText, ToolTipIcon, strLogText, strLogData, strSourceIP, strRawLogText)
+                    NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogData, strSourceIP, strRawLogText)
                     strOutgoingAlertText = strAlertText
                     Return True
                 End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -38,7 +38,7 @@ Namespace SyslogParser
                                    AlertType:=AlertType.None,
                                    dataGrid:=dataGrid)
 
-            MyDataGridViewRow.MinimumHeight = GetMinimumHeight(strLogText, My.Settings.font, My.Settings.columnLogSize)
+            MyDataGridViewRow.MinimumHeight = GetMinimumHeight(strLogText, My.Settings.font, My.Settings.columnLogSize, dataGrid)
 
             Return MyDataGridViewRow
         End Function
@@ -64,7 +64,7 @@ Namespace SyslogParser
                     .RawLogData = strRawLogText
                     .AlertText = strAlertText
                     .alertType = AlertType
-                    .MinimumHeight = GetMinimumHeight(strLog, ParentForm.Logs.DefaultCellStyle.Font, ParentForm.ColLog.Width)
+                    .MinimumHeight = GetMinimumHeight(strLog, ParentForm.Logs.DefaultCellStyle.Font, ParentForm.ColLog.Width, dataGrid)
 
                     If My.Settings.font IsNot Nothing Then
                         .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -38,6 +38,7 @@ Namespace SyslogParser
                                    AlertType:=AlertType.None,
                                    dataGrid:=dataGrid)
 
+            MyDataGridViewRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
             Return MyDataGridViewRow
         End Function
 
@@ -73,6 +74,8 @@ Namespace SyslogParser
                         .Cells(ColumnIndex_Alerted).Style.Font = My.Settings.font
                         .Cells(ColumnIndex_ServerTime).Style.Font = My.Settings.font
                     End If
+
+                    .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
                 End With
 
                 Return MyDataGridViewRow

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -38,8 +38,6 @@ Namespace SyslogParser
                                    AlertType:=AlertType.None,
                                    dataGrid:=dataGrid)
 
-            MyDataGridViewRow.MinimumHeight = GetMinimumHeight(strLogText, My.Settings.font, My.Settings.columnLogSize, dataGrid)
-
             Return MyDataGridViewRow
         End Function
 
@@ -64,7 +62,6 @@ Namespace SyslogParser
                     .RawLogData = strRawLogText
                     .AlertText = strAlertText
                     .alertType = AlertType
-                    .MinimumHeight = GetMinimumHeight(strLog, ParentForm.Logs.DefaultCellStyle.Font, ParentForm.ColLog.Width, dataGrid)
 
                     If My.Settings.font IsNot Nothing Then
                         .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -48,7 +48,7 @@ Public Class Alerts_History
             Dim listOfDataRows As New List(Of AlertsHistoryDataGridViewRow)
 
             For Each item As AlertsHistory In DataToLoad
-                listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList, SupportCode.GetMinimumHeight(item.strAlertText, AlertHistoryList.DefaultCellStyle.Font, colAlert.Width)))
+                listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList, SupportCode.GetMinimumHeight(item.strAlertText, AlertHistoryList.DefaultCellStyle.Font, colAlert.Width, AlertHistoryList)))
             Next
 
             AlertHistoryList.Rows.AddRange(listOfDataRows.ToArray)
@@ -111,7 +111,7 @@ Public Class Alerts_History
                     Dim listOfDataRows As New List(Of AlertsHistoryDataGridViewRow)
 
                     For Each item As AlertsHistory In data
-                        listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList, SupportCode.GetMinimumHeight(item.strAlertText, AlertHistoryList.DefaultCellStyle.Font, colAlert.Width)))
+                        listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList, SupportCode.GetMinimumHeight(item.strAlertText, AlertHistoryList.DefaultCellStyle.Font, colAlert.Width, AlertHistoryList)))
                     Next
 
                     AlertHistoryList.Rows.Clear()

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -48,7 +48,7 @@ Public Class Alerts_History
             Dim listOfDataRows As New List(Of AlertsHistoryDataGridViewRow)
 
             For Each item As AlertsHistory In DataToLoad
-                listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList, SupportCode.GetMinimumHeight(item.strAlertText, AlertHistoryList.DefaultCellStyle.Font, colAlert.Width, AlertHistoryList)))
+                listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList))
             Next
 
             AlertHistoryList.Rows.AddRange(listOfDataRows.ToArray)
@@ -111,7 +111,7 @@ Public Class Alerts_History
                     Dim listOfDataRows As New List(Of AlertsHistoryDataGridViewRow)
 
                     For Each item As AlertsHistory In data
-                        listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList, SupportCode.GetMinimumHeight(item.strAlertText, AlertHistoryList.DefaultCellStyle.Font, colAlert.Width, AlertHistoryList)))
+                        listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList))
                     Next
 
                     AlertHistoryList.Rows.Clear()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -338,6 +338,8 @@ Public Class Form1
         ColTime.HeaderCell.Style.Padding = New Padding(0, 0, 1, 0)
         ColIPAddress.HeaderCell.Style.Padding = New Padding(0, 0, 2, 0)
 
+        Logs.DefaultCellStyle.Padding = New Padding(0, 20, 0, 20) ' Left, Top, Right, Bottom
+
         ColTime.HeaderCell.SortGlyphDirection = SortOrder.Ascending
         Icon = Icon.ExtractAssociatedIcon(strEXEPath)
         Location = VerifyWindowLocation(My.Settings.windowLocation, Me)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -760,7 +760,7 @@ Public Class Form1
 
         AddHandler worker.RunWorkerCompleted, Sub()
                                                   If listOfSearchResults.Count > 0 Then
-                                                      Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = listOfSearchResults, .Text = "Search Results", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search}
+                                                      Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.search) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = listOfSearchResults, .Text = "Search Results"}
                                                       searchResultsWindow.LogsLoadedInLabel.Visible = True
                                                       searchResultsWindow.LogsLoadedInLabel.Text = $"Search took {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
                                                       searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
@@ -840,7 +840,7 @@ Public Class Form1
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
         If IgnoredLogsAndSearchResultsInstance Is Nothing Then
-            IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = IgnoredLogs, .Text = "Ignored Logs", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored}
+            IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = IgnoredLogs, .Text = "Ignored Logs"}
             IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
             IgnoredLogsAndSearchResultsInstance.Show()
         Else
@@ -1298,7 +1298,7 @@ Public Class Form1
     Private Sub BtnOpenLogForViewing_Click(sender As Object, e As EventArgs) Handles BtnOpenLogForViewing.Click
         Using OpenFileDialog As New OpenFileDialog With {.Title = "Open Log File", .Filter = "JSON File|*.json"}
             If OpenFileDialog.ShowDialog() = DialogResult.OK Then
-                Dim logFileViewer As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = Me, .Icon = Icon, .Text = "Log File Viewer", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer, .strFileToLoad = OpenFileDialog.FileName, .boolLoadExternalData = True}
+                Dim logFileViewer As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.viewer) With {.MainProgramForm = Me, .Icon = Icon, .Text = "Log File Viewer", .strFileToLoad = OpenFileDialog.FileName, .boolLoadExternalData = True}
                 logFileViewer.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                 logFileViewer.Show(Me)
             End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -175,7 +175,7 @@ Public Class Form1
             If MinimizeToClockTray.Checked Then ShowInTaskbar = WindowState <> FormWindowState.Minimized
 
             For Each item As MyDataGridViewRow In Logs.Rows
-                item.Height = GetMinimumHeight(item.Cells(ColumnIndex_IPAddress).Value, Logs.DefaultCellStyle.Font, ColLog.Width)
+                item.Height = GetMinimumHeight(item.Cells(ColumnIndex_IPAddress).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
             Next
 
             Logs.Invalidate()
@@ -464,7 +464,7 @@ Public Class Form1
                     Invoke(Sub() LoadingProgressBar.Visible = True)
 
                     For Each item As SavedData In collectionOfSavedData
-                        listOfLogEntries.Add(item.MakeDataGridRow(Logs, GetMinimumHeight(item.log, Logs.DefaultCellStyle.Font, ColLog.Width)))
+                        listOfLogEntries.Add(item.MakeDataGridRow(Logs, GetMinimumHeight(item.log, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)))
                         intProgress += 1
                         Invoke(Sub() LoadingProgressBar.Value = intProgress / collectionOfSavedData.Count * 100)
                     Next

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -152,10 +152,15 @@ Public Class Form1
         End If
     End Sub
 
+    Private Sub Form1_ResizeBegin(sender As Object, e As EventArgs) Handles Me.ResizeBegin
+        Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None
+    End Sub
+
     Private Sub Form1_ResizeEnd(sender As Object, e As EventArgs) Handles Me.ResizeEnd
         My.Settings.mainWindowSize = Size
         Threading.Thread.Sleep(100)
         SelectLatestLogEntry()
+        Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
     End Sub
 
     Private Sub Form1_Resize(sender As Object, e As EventArgs) Handles Me.Resize
@@ -173,10 +178,6 @@ Public Class Form1
 
             If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.BtnViewMainWindow.Enabled = WindowState = FormWindowState.Minimized
             If MinimizeToClockTray.Checked Then ShowInTaskbar = WindowState <> FormWindowState.Minimized
-
-            For Each item As MyDataGridViewRow In Logs.Rows
-                item.MinimumHeight = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
-            Next
 
             Logs.Invalidate()
             Logs.Refresh()
@@ -464,7 +465,7 @@ Public Class Form1
                     Invoke(Sub() LoadingProgressBar.Visible = True)
 
                     For Each item As SavedData In collectionOfSavedData
-                        listOfLogEntries.Add(item.MakeDataGridRow(Logs, GetMinimumHeight(item.log, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)))
+                        listOfLogEntries.Add(item.MakeDataGridRow(Logs))
                         intProgress += 1
                         Invoke(Sub() LoadingProgressBar.Value = intProgress / collectionOfSavedData.Count * 100)
                     Next
@@ -485,6 +486,7 @@ Public Class Form1
 
                                Logs.SelectedRows(0).Selected = False
                                UpdateLogCount()
+                               Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
                            End Sub)
                 End SyncLock
             Catch ex As Newtonsoft.Json.JsonSerializationException

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -763,6 +763,7 @@ Public Class Form1
                                                       Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = listOfSearchResults, .Text = "Search Results", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search}
                                                       searchResultsWindow.LogsLoadedInLabel.Visible = True
                                                       searchResultsWindow.LogsLoadedInLabel.Text = $"Search took {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
+                                                      searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                                                       searchResultsWindow.ShowDialog(Me)
                                                   Else
                                                       MsgBox("Search terms not found.", MsgBoxStyle.Information, Text)
@@ -840,6 +841,7 @@ Public Class Form1
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
         If IgnoredLogsAndSearchResultsInstance Is Nothing Then
             IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = IgnoredLogs, .Text = "Ignored Logs", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored}
+            IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
             IgnoredLogsAndSearchResultsInstance.Show()
         Else
             IgnoredLogsAndSearchResultsInstance.WindowState = FormWindowState.Normal
@@ -1297,6 +1299,7 @@ Public Class Form1
         Using OpenFileDialog As New OpenFileDialog With {.Title = "Open Log File", .Filter = "JSON File|*.json"}
             If OpenFileDialog.ShowDialog() = DialogResult.OK Then
                 Dim logFileViewer As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = Me, .Icon = Icon, .Text = "Log File Viewer", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer, .strFileToLoad = OpenFileDialog.FileName, .boolLoadExternalData = True}
+                logFileViewer.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                 logFileViewer.Show(Me)
             End If
         End Using

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -371,6 +371,7 @@ Public Class Form1
         ColHostname.Width = My.Settings.HostnameWidth
         ColRemoteProcess.Width = My.Settings.RemoteProcessHeaderSize
         ColLog.Width = My.Settings.columnLogSize
+        ColAlerts.Width = My.Settings.columnAlertedSize
 
         If My.Settings.font IsNot Nothing Then
             Logs.DefaultCellStyle.Font = My.Settings.font
@@ -643,6 +644,7 @@ Public Class Form1
             My.Settings.HostnameWidth = ColHostname.Width
             My.Settings.RemoteProcessHeaderSize = ColRemoteProcess.Width
             My.Settings.columnLogSize = ColLog.Width
+            My.Settings.columnAlertedSize = ColAlerts.Width
         End If
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -175,7 +175,7 @@ Public Class Form1
             If MinimizeToClockTray.Checked Then ShowInTaskbar = WindowState <> FormWindowState.Minimized
 
             For Each item As MyDataGridViewRow In Logs.Rows
-                item.Height = GetMinimumHeight(item.Cells(ColumnIndex_IPAddress).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
+                item.MinimumHeight = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
             Next
 
             Logs.Invalidate()

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -48,6 +48,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.LogsContextMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkCaseInsensitiveSearch = New System.Windows.Forms.CheckBox()
+        Me.ChkColLogsAutoFill = New System.Windows.Forms.CheckBox()
         Me.ChkRegExSearch = New System.Windows.Forms.CheckBox()
         Me.BtnSearch = New System.Windows.Forms.Button()
         Me.TxtSearchTerms = New System.Windows.Forms.TextBox()
@@ -164,7 +165,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ColAlerts.ToolTipText = "True or False. Indicates if the log entry triggered an alert from this program."
         Me.ColAlerts.Width = 50
         '
-        'ColSyslogHeader
+        'ColRemoteProcess
         '
         Me.ColRemoteProcess.HeaderText = "Remote Process"
         Me.ColRemoteProcess.Name = "ColRemoteProcess"
@@ -237,6 +238,17 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ChkCaseInsensitiveSearch.UseVisualStyleBackColor = True
         Me.ChkCaseInsensitiveSearch.Visible = False
         '
+        'ChkColLogsAutoFill
+        '
+        Me.ChkColLogsAutoFill.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkColLogsAutoFill.AutoSize = True
+        Me.ChkColLogsAutoFill.Location = New System.Drawing.Point(597, 382)
+        Me.ChkColLogsAutoFill.Name = "ChkColLogsAutoFill"
+        Me.ChkColLogsAutoFill.Size = New System.Drawing.Size(124, 17)
+        Me.ChkColLogsAutoFill.TabIndex = 29
+        Me.ChkColLogsAutoFill.Text = "Logs Column AutoFill"
+        Me.ChkColLogsAutoFill.UseVisualStyleBackColor = True
+        '
         'ChkRegExSearch
         '
         Me.ChkRegExSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -306,6 +318,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1152, 425)
+        Me.Controls.Add(Me.ChkColLogsAutoFill)
         Me.Controls.Add(Me.BtnViewMainWindow)
         Me.Controls.Add(Me.BtnExport)
         Me.Controls.Add(Me.Logs)
@@ -355,4 +368,5 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents ColHostname As DataGridViewTextBoxColumn
     Friend WithEvents ExportSelectedLogsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents LogsLoadedInLabel As ToolStripStatusLabel
+    Friend WithEvents ChkColLogsAutoFill As CheckBox
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -16,9 +16,12 @@ Partial Class IgnoredLogsAndSearchResults
 
     Private Shadows parentForm As Object
 
-    Public Sub New(parentForm As Object)
+    Public Sub New(parentForm As Object, WindowDisplayMode As SupportCode.IgnoreOrSearchWindowDisplayMode)
         InitializeComponent()
         Me.parentForm = parentForm
+
+        _WindowDisplayMode = WindowDisplayMode
+        If WindowDisplayMode = SupportCode.IgnoreOrSearchWindowDisplayMode.search Then ChkColLogsAutoFill.Location = New Point(12, 382)
     End Sub
 
     'Required by the Windows Form Designer

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -465,7 +465,7 @@ Public Class IgnoredLogsAndSearchResults
     Private Sub IgnoredLogsAndSearchResults_Resize(sender As Object, e As EventArgs) Handles Me.Resize
         If boolDoneLoading Then
             For Each item As MyDataGridViewRow In Logs.Rows
-                item.Height = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
+                item.MinimumHeight = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
             Next
         End If
     End Sub

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -357,7 +357,7 @@ Public Class IgnoredLogsAndSearchResults
                 Dim listOfLogEntries As New List(Of MyDataGridViewRow)
 
                 For Each item As SavedData In collectionOfSavedData
-                    listOfLogEntries.Add(item.MakeDataGridRow(Logs, GetMinimumHeight(item.log, Logs.DefaultCellStyle.Font, ColLog.Width)))
+                    listOfLogEntries.Add(item.MakeDataGridRow(Logs, GetMinimumHeight(item.log, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)))
                 Next
 
                 Invoke(Sub()
@@ -465,7 +465,7 @@ Public Class IgnoredLogsAndSearchResults
     Private Sub IgnoredLogsAndSearchResults_Resize(sender As Object, e As EventArgs) Handles Me.Resize
         If boolDoneLoading Then
             For Each item As MyDataGridViewRow In Logs.Rows
-                item.Height = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width)
+                item.Height = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
             Next
         End If
     End Sub

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -342,6 +342,7 @@ Public Class IgnoredLogsAndSearchResults
                 .CreateCells(dataGrid)
                 .Cells(ColumnIndex_ComputedTime).Value = Now.ToString
                 .Cells(ColumnIndex_LogText).Value = strLog
+                .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
             End With
 
             Return MyDataGridViewRow

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -426,6 +426,7 @@ Public Class IgnoredLogsAndSearchResults
         AddHandler worker.RunWorkerCompleted, Sub()
                                                   If listOfSearchResults.Count > 0 Then
                                                       Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MainProgramForm, .Icon = Icon, .LogsToBeDisplayed = listOfSearchResults, .Text = "Search Results", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search}
+                                                      searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                                                       searchResultsWindow.ShowDialog(Me)
                                                   Else
                                                       MsgBox("Search terms not found.", MsgBoxStyle.Information, Text)
@@ -439,6 +440,7 @@ Public Class IgnoredLogsAndSearchResults
 
     Private Sub OpenLogFileForViewingToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles OpenLogFileForViewingToolStripMenuItem.Click
         Dim logFileViewer As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MainProgramForm, .Icon = Icon, .Text = "Log File Viewer", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer, .strFileToLoad = Path.Combine(strPathToDataBackupFolder, Logs.SelectedRows(0).Cells(ColumnIndex_FileName).Value), .boolLoadExternalData = True}
+        logFileViewer.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
         logFileViewer.Show(Me)
     End Sub
 
@@ -458,6 +460,16 @@ Public Class IgnoredLogsAndSearchResults
             For Each item As MyDataGridViewRow In Logs.Rows
                 item.Height = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width)
             Next
+        End If
+    End Sub
+
+    Private Sub ChkColLogsAutoFill_Click(sender As Object, e As EventArgs) Handles ChkColLogsAutoFill.Click
+        My.Settings.colLogAutoFill = ChkColLogsAutoFill.Checked
+        ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
+
+        If MainProgramForm IsNot Nothing Then
+            MainProgramForm.ColLogsAutoFill.Checked = ChkColLogsAutoFill.Checked
+            MainProgramForm.ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
         End If
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -88,6 +88,10 @@ Public Class IgnoredLogsAndSearchResults
         OpenLogViewerWindow()
     End Sub
 
+    Private Sub Ignored_Logs_and_Search_Results_ResizeBegin(sender As Object, e As EventArgs) Handles Me.ResizeBegin
+        Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None
+    End Sub
+
     Private Sub Ignored_Logs_and_Search_Results_ResizeEnd(sender As Object, e As EventArgs) Handles Me.ResizeEnd
         If boolDoneLoading Then
             If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
@@ -98,6 +102,8 @@ Public Class IgnoredLogsAndSearchResults
                 My.Settings.logFileViewerSize = Size
             End If
         End If
+
+        Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
     End Sub
 
     Private Sub Logs_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles Logs.ColumnWidthChanged
@@ -113,6 +119,7 @@ Public Class IgnoredLogsAndSearchResults
         End If
 
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
+        Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
 
         If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
             BtnClearIgnoredLogs.Visible = True
@@ -357,7 +364,7 @@ Public Class IgnoredLogsAndSearchResults
                 Dim listOfLogEntries As New List(Of MyDataGridViewRow)
 
                 For Each item As SavedData In collectionOfSavedData
-                    listOfLogEntries.Add(item.MakeDataGridRow(Logs, GetMinimumHeight(item.log, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)))
+                    listOfLogEntries.Add(item.MakeDataGridRow(Logs))
                 Next
 
                 Invoke(Sub()
@@ -460,14 +467,6 @@ Public Class IgnoredLogsAndSearchResults
 
     Private Sub ExportSelectedLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ExportSelectedLogsToolStripMenuItem.Click
         DataHandling.ExportSelectedLogs(Logs.SelectedRows)
-    End Sub
-
-    Private Sub IgnoredLogsAndSearchResults_Resize(sender As Object, e As EventArgs) Handles Me.Resize
-        If boolDoneLoading Then
-            For Each item As MyDataGridViewRow In Logs.Rows
-                item.MinimumHeight = GetMinimumHeight(item.Cells(ColumnIndex_LogText).Value, Logs.DefaultCellStyle.Font, ColLog.Width, Logs)
-            Next
-        End If
     End Sub
 
     Private Sub ChkColLogsAutoFill_Click(sender As Object, e As EventArgs) Handles ChkColLogsAutoFill.Click

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -7,7 +7,7 @@ Imports Free_SysLog.SupportCode
 
 Public Class IgnoredLogsAndSearchResults
     Public LogsToBeDisplayed As List(Of MyDataGridViewRow)
-    Public WindowDisplayMode As IgnoreOrSearchWindowDisplayMode
+    Private _WindowDisplayMode As IgnoreOrSearchWindowDisplayMode
     Private m_SortingColumn1, m_SortingColumn2 As ColumnHeader
     Private boolDoneLoading As Boolean = False
     Public MainProgramForm As Form1
@@ -90,11 +90,11 @@ Public Class IgnoredLogsAndSearchResults
 
     Private Sub Ignored_Logs_and_Search_Results_ResizeEnd(sender As Object, e As EventArgs) Handles Me.ResizeEnd
         If boolDoneLoading Then
-            If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+            If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
                 My.Settings.ignoredWindowSize = Size
-            ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search Then
+            ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search Then
                 My.Settings.searchWindowSize = Size
-            ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
+            ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
                 My.Settings.logFileViewerSize = Size
             End If
         End If
@@ -114,10 +114,10 @@ Public Class IgnoredLogsAndSearchResults
 
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
 
-        If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+        If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
             BtnClearIgnoredLogs.Visible = True
             BtnViewMainWindow.Visible = True
-        ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
+        ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
             BtnExport.Visible = False
             BtnViewMainWindow.Visible = True
 
@@ -128,13 +128,13 @@ Public Class IgnoredLogsAndSearchResults
             BtnSearch.Visible = True
         End If
 
-        If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+        If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
             Size = My.Settings.ignoredWindowSize
             Location = VerifyWindowLocation(My.Settings.ignoredWindowLocation, Me)
-        ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search Then
+        ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search Then
             Size = My.Settings.searchWindowSize
             Location = VerifyWindowLocation(My.Settings.searchWindowLocation, Me)
-        ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
+        ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
             Size = My.Settings.logFileViewerSize
             Location = VerifyWindowLocation(My.Settings.logFileViewerLocation, Me)
         End If
@@ -165,18 +165,18 @@ Public Class IgnoredLogsAndSearchResults
         Logs.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 
-        If WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
+        If _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
             Logs.Rows.AddRange(LogsToBeDisplayed.ToArray())
             SortLogsByDateObject(0, SortOrder.Ascending)
 
-            If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+            If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
                 LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
             Else
                 LblCount.Text = $"Number of search results: {LogsToBeDisplayed.Count:N0}"
             End If
         End If
 
-        If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then
+        If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then
             Dim worker As New BackgroundWorker()
             AddHandler worker.DoWork, Sub() LoadData(strFileToLoad)
             AddHandler worker.RunWorkerCompleted, Sub()
@@ -204,11 +204,11 @@ Public Class IgnoredLogsAndSearchResults
         MyBase.WndProc(m)
 
         If m.Msg = WM_EXITSIZEMOVE AndAlso boolDoneLoading Then
-            If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+            If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
                 My.Settings.ignoredWindowLocation = Location
-            ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search Then
+            ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search Then
                 My.Settings.searchWindowLocation = Location
-            ElseIf WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
+            ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
                 My.Settings.logFileViewerLocation = Location
             End If
         End If
@@ -311,7 +311,7 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub LogsContextMenu_Opening(sender As Object, e As CancelEventArgs) Handles LogsContextMenu.Opening
-        If WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then
+        If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then
             ExportSelectedLogsToolStripMenuItem.Visible = True
             CopyLogTextToolStripMenuItem.Visible = False
             CreateAlertToolStripMenuItem.Visible = False
@@ -432,7 +432,7 @@ Public Class IgnoredLogsAndSearchResults
 
         AddHandler worker.RunWorkerCompleted, Sub()
                                                   If listOfSearchResults.Count > 0 Then
-                                                      Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MainProgramForm, .Icon = Icon, .LogsToBeDisplayed = listOfSearchResults, .Text = "Search Results", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search}
+                                                      Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.search) With {.MainProgramForm = MainProgramForm, .Icon = Icon, .LogsToBeDisplayed = listOfSearchResults, .Text = "Search Results"}
                                                       searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                                                       searchResultsWindow.ShowDialog(Me)
                                                   Else
@@ -446,7 +446,7 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub OpenLogFileForViewingToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles OpenLogFileForViewingToolStripMenuItem.Click
-        Dim logFileViewer As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MainProgramForm, .Icon = Icon, .Text = "Log File Viewer", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer, .strFileToLoad = Path.Combine(strPathToDataBackupFolder, Logs.SelectedRows(0).Cells(ColumnIndex_FileName).Value), .boolLoadExternalData = True}
+        Dim logFileViewer As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.viewer) With {.MainProgramForm = MainProgramForm, .Icon = Icon, .Text = "Log File Viewer", .strFileToLoad = Path.Combine(strPathToDataBackupFolder, Logs.SelectedRows(0).Cells(ColumnIndex_FileName).Value), .boolLoadExternalData = True}
         logFileViewer.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
         logFileViewer.Show(Me)
     End Sub

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -100,6 +100,12 @@ Public Class IgnoredLogsAndSearchResults
         End If
     End Sub
 
+    Private Sub Logs_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles Logs.ColumnWidthChanged
+        If boolDoneLoading Then
+            My.Settings.columnFileNameSize = ColFileName.Width
+        End If
+    End Sub
+
     Private Sub Ignored_Logs_and_Search_Results_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If My.Settings.font IsNot Nothing Then
             Logs.DefaultCellStyle.Font = My.Settings.font
@@ -141,6 +147,7 @@ Public Class IgnoredLogsAndSearchResults
         ColRemoteProcess.Width = My.Settings.RemoteProcessHeaderSize
         ColLog.Width = My.Settings.columnLogSize
         ColAlerts.Width = My.Settings.columnAlertedSize
+        ColFileName.Width = My.Settings.columnFileNameSize
 
         LoadColumnOrders(Logs.Columns, My.Settings.logsColumnOrder)
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -140,6 +140,7 @@ Public Class IgnoredLogsAndSearchResults
         ColHostname.Width = My.Settings.HostnameWidth
         ColRemoteProcess.Width = My.Settings.RemoteProcessHeaderSize
         ColLog.Width = My.Settings.columnLogSize
+        ColAlerts.Width = My.Settings.columnAlertedSize
 
         LoadColumnOrders(Logs.Columns, My.Settings.logsColumnOrder)
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -118,6 +118,8 @@ Public Class ViewLogBackups
 
                                                        .Cells(4).Value = If(boolIsHidden, "Yes", "No")
                                                        .Cells(4).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+
+                                                       .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
                                                    End With
 
 
@@ -311,6 +313,7 @@ Public Class ViewLogBackups
                                                                                          If regexCompiledObject.IsMatch(item.log) Then
                                                                                              myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
                                                                                              myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
+                                                                                             myDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
                                                                                              If My.Settings.font IsNot Nothing Then myDataGridRow.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
                                                                                              SyncLock listOfSearchResults ' Ensure thread safety
                                                                                                  listOfSearchResults.Add(myDataGridRow)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -274,6 +274,8 @@ Public Class ViewLogBackups
         Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.search) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Search Results"}
         searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
 
+        If My.Settings.font IsNot Nothing Then searchResultsWindow.Logs.DefaultCellStyle.Font = My.Settings.font
+
         BtnSearch.Enabled = False
 
         Dim worker As New BackgroundWorker()
@@ -305,7 +307,7 @@ Public Class ViewLogBackups
 
                                                                                      For Each item As SavedData In dataFromFile
                                                                                          If regexCompiledObject.IsMatch(item.log) Then
-                                                                                             myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize))
+                                                                                             myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize, searchResultsWindow.Logs))
                                                                                              myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
                                                                                              If My.Settings.font IsNot Nothing Then myDataGridRow.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
                                                                                              SyncLock listOfSearchResults ' Ensure thread safety
@@ -318,7 +320,7 @@ Public Class ViewLogBackups
 
                                           For Each item As SavedData In currentLogs
                                               If regexCompiledObject.IsMatch(item.log) Then
-                                                  myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize))
+                                                  myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize, searchResultsWindow.Logs))
                                                   myDataGridRow.Cells(ColumnIndex_FileName).Value = "Current Log Data"
                                                   listOfSearchResults.Add(myDataGridRow)
                                                   myDataGridRow = Nothing

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -192,6 +192,7 @@ Public Class ViewLogBackups
 
             If File.Exists(fileName) Then
                 Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Log Viewer", .strFileToLoad = fileName, .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer, .boolLoadExternalData = True}
+                searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                 searchResultsWindow.ShowDialog(Me)
             End If
         End If
@@ -272,6 +273,7 @@ Public Class ViewLogBackups
         Dim listOfSearchResults2 As New List(Of MyDataGridViewRow)
         Dim regexCompiledObject As Regex = Nothing
         Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Search Results", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search}
+        searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
 
         BtnSearch.Enabled = False
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -4,7 +4,6 @@ Imports System.ComponentModel
 Imports System.Threading.Tasks
 Imports Free_SysLog.SupportCode
 Imports System.Threading
-Imports Microsoft.VisualBasic.Logging
 
 Public Class ViewLogBackups
     Public MyParentForm As Form1

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -190,7 +190,7 @@ Public Class ViewLogBackups
             Dim fileName As String = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
 
             If File.Exists(fileName) Then
-                Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Log Viewer", .strFileToLoad = fileName, .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer, .boolLoadExternalData = True}
+                Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.viewer) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Log Viewer", .strFileToLoad = fileName, .boolLoadExternalData = True}
                 searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                 searchResultsWindow.ShowDialog(Me)
             End If
@@ -271,7 +271,7 @@ Public Class ViewLogBackups
         Dim listOfSearchResults As New HashSet(Of MyDataGridViewRow)()
         Dim listOfSearchResults2 As New List(Of MyDataGridViewRow)
         Dim regexCompiledObject As Regex = Nothing
-        Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Search Results", .WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.search}
+        Dim searchResultsWindow As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.search) With {.MainProgramForm = MyParentForm, .Icon = Icon, .Text = "Search Results"}
         searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
 
         BtnSearch.Enabled = False

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -166,6 +166,7 @@ Public Class ViewLogBackups
         ColFileName.Width = My.Settings.ColViewLogBackupsFileName
         ColFileSize.Width = My.Settings.ColViewLogBackupsFileSize
         colEntryCount.Width = My.Settings.viewLogBackupsEntryCountColumnSize
+        colHidden.Width = My.Settings.viewLogBackupsHiddenColumnSize
 
         LoadColumnOrders(FileList.Columns, My.Settings.fileListColumnOrder)
 
@@ -445,6 +446,7 @@ Public Class ViewLogBackups
             My.Settings.ColViewLogBackupsFileName = ColFileName.Width
             My.Settings.ColViewLogBackupsFileSize = ColFileSize.Width
             My.Settings.viewLogBackupsEntryCountColumnSize = colEntryCount.Width
+            My.Settings.viewLogBackupsHiddenColumnSize = colHidden.Width
         End If
     End Sub
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -306,6 +306,7 @@ Public Class ViewLogBackups
                                                                                          If regexCompiledObject.IsMatch(item.log) Then
                                                                                              myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize))
                                                                                              myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
+                                                                                             If My.Settings.font IsNot Nothing Then myDataGridRow.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
                                                                                              SyncLock listOfSearchResults ' Ensure thread safety
                                                                                                  listOfSearchResults.Add(myDataGridRow)
                                                                                              End SyncLock

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -4,6 +4,7 @@ Imports System.ComponentModel
 Imports System.Threading.Tasks
 Imports Free_SysLog.SupportCode
 Imports System.Threading
+Imports Microsoft.VisualBasic.Logging
 
 Public Class ViewLogBackups
     Public MyParentForm As Form1
@@ -160,6 +161,7 @@ Public Class ViewLogBackups
 
         FileList.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor}
         FileList.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
+        FileList.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
 
         ColFileDate.Width = My.Settings.ColViewLogBackupsFileDate
         ColFileName.Width = My.Settings.ColViewLogBackupsFileName
@@ -307,7 +309,7 @@ Public Class ViewLogBackups
 
                                                                                      For Each item As SavedData In dataFromFile
                                                                                          If regexCompiledObject.IsMatch(item.log) Then
-                                                                                             myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize, searchResultsWindow.Logs))
+                                                                                             myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
                                                                                              myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
                                                                                              If My.Settings.font IsNot Nothing Then myDataGridRow.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
                                                                                              SyncLock listOfSearchResults ' Ensure thread safety
@@ -320,7 +322,7 @@ Public Class ViewLogBackups
 
                                           For Each item As SavedData In currentLogs
                                               If regexCompiledObject.IsMatch(item.log) Then
-                                                  myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs, GetMinimumHeight(item.log, searchResultsWindow.Logs.DefaultCellStyle.Font, My.Settings.columnLogSize, searchResultsWindow.Logs))
+                                                  myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
                                                   myDataGridRow.Cells(ColumnIndex_FileName).Value = "Current Log Data"
                                                   listOfSearchResults.Add(myDataGridRow)
                                                   myDataGridRow = Nothing

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -264,6 +264,9 @@
             <setting name="disableAutoScrollUponScrolling" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="viewLogBackupsHiddenColumnSize" serializeAs="String">
+                <value>60</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -267,6 +267,9 @@
             <setting name="viewLogBackupsHiddenColumnSize" serializeAs="String">
                 <value>60</value>
             </setting>
+            <setting name="columnAlertedSize" serializeAs="String">
+                <value>50</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -270,6 +270,9 @@
             <setting name="columnAlertedSize" serializeAs="String">
                 <value>50</value>
             </setting>
+            <setting name="columnFileNameSize" serializeAs="String">
+                <value>150</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Added code to save the width of the Hidden column on the "View Log Backups" window.
- Added code to save the width of the Alerted column.
- Fixed a bug in which the filename displayed on the "Ignored Logs and Search Results" window didn't have the user's font preference applied to it when searching from the "View Log Backups" window.
- Added a control to disable the autofill for the log column to the "Ignored Logs and Search Results" window.
- Added code to save the width of the "File Name" column on the "Ignored Logs and Search Results" window.
- Auto-sizing of DataGridView Rows is now a thing. Row heights should now be perfect.
- Added padding to all DataGridView rows.