### PR TITLE
Version 3.7 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.7.1.78")>
+<Assembly: AssemblyFileVersion("3.7.2.79")>

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -317,11 +317,15 @@ Namespace checkForUpdates
                         If response = ProcessUpdateXMLResponse.newVersion Then
                             SyncLock windowObject.dataGridLockObject
                                 windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"New version detected... {remoteVersion} Build {remoteBuild}.", windowObject.Logs))
+                                windowObject.UpdateLogCount()
+                                windowObject.SelectLatestLogEntry()
                             End SyncLock
 
                             If BackgroundThreadMessageBox($"An update to {strProgramName} (version {remoteVersion} Build {remoteBuild}) is available to be downloaded, do you want to download and update to this new version?", strMessageBoxTitleText) = MsgBoxResult.Yes Then
                                 SyncLock windowObject.dataGridLockObject
                                     windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Beginning program update process.", windowObject.Logs))
+                                    windowObject.UpdateLogCount()
+                                    windowObject.SelectLatestLogEntry()
                                 End SyncLock
 
                                 DownloadAndPerformUpdate()
@@ -331,18 +335,24 @@ Namespace checkForUpdates
                         ElseIf response = ProcessUpdateXMLResponse.noUpdateNeeded AndAlso boolShowMessageBox Then
                             SyncLock windowObject.dataGridLockObject
                                 windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("You already have the latest version, there is no need to update this program.", windowObject.Logs))
+                                windowObject.UpdateLogCount()
+                                windowObject.SelectLatestLogEntry()
                             End SyncLock
 
                             windowObject.Invoke(Sub() MsgBox($"You already have the latest version, there is no need to update this program.{vbCrLf}{vbCrLf}Your current version is v{versionString}.", MsgBoxStyle.Information, strMessageBoxTitleText))
                         ElseIf (response = ProcessUpdateXMLResponse.parseError Or response = ProcessUpdateXMLResponse.exceptionError) AndAlso boolShowMessageBox Then
                             SyncLock windowObject.dataGridLockObject
                                 windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"There was an error when trying to parse the response from the server. The XML data from the server is below...{vbCrLf}{vbCrLf}{xmlData}", windowObject.Logs, "Error, Local"))
+                                windowObject.UpdateLogCount()
+                                windowObject.SelectLatestLogEntry()
                             End SyncLock
 
                             windowObject.Invoke(Sub() MsgBox("There was an error when trying to parse the response from the server.", MsgBoxStyle.Critical, strMessageBoxTitleText))
                         ElseIf response = ProcessUpdateXMLResponse.newerVersionThanWebSite AndAlso boolShowMessageBox Then
                             SyncLock windowObject.dataGridLockObject
                                 windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("This is weird, you have a version that's newer than what's listed on the web site.", windowObject.Logs))
+                                windowObject.UpdateLogCount()
+                                windowObject.SelectLatestLogEntry()
                             End SyncLock
 
                             windowObject.Invoke(Sub() MsgBox("This is weird, you have a version that's newer than what's listed on the web site.", MsgBoxStyle.Information, strMessageBoxTitleText))
@@ -350,6 +360,8 @@ Namespace checkForUpdates
                     Else
                         SyncLock windowObject.dataGridLockObject
                             windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("There was an error checking for updates.", windowObject.Logs, "Error, Local"))
+                            windowObject.UpdateLogCount()
+                            windowObject.SelectLatestLogEntry()
                         End SyncLock
 
                         If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("There was an error checking for updates.", MsgBoxStyle.Information, strMessageBoxTitleText))
@@ -358,6 +370,8 @@ Namespace checkForUpdates
                     ' Ok, we crashed but who cares; but we log it.
                     SyncLock windowObject.dataGridLockObject
                         windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", windowObject.Logs, "Error, Local"))
+                        windowObject.UpdateLogCount()
+                        windowObject.SelectLatestLogEntry()
                     End SyncLock
                 Finally
                     windowObject.Invoke(Sub()

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -23,7 +23,7 @@ Namespace SyslogParser
             End Set
         End Property
 
-        Public Function MakeLocalDataGridRowEntry(strLogText As String, ByRef dataGrid As DataGridView) As MyDataGridViewRow
+        Public Function MakeLocalDataGridRowEntry(strLogText As String, ByRef dataGrid As DataGridView, Optional strLogType As String = "Informational, Local") As MyDataGridViewRow
             Dim MyDataGridViewRow As MyDataGridViewRow = MakeDataGridRow(serverTimeStamp:=Now,
                                    dateObject:=Now,
                                    strTime:=Now.ToString,
@@ -31,7 +31,7 @@ Namespace SyslogParser
                                    strHostname:="Local",
                                    strRemoteProcess:=Nothing,
                                    strLog:=strLogText,
-                                   strLogType:="Informational, Local",
+                                   strLogType:=strLogType,
                                    boolAlerted:=False,
                                    strRawLogText:=Nothing,
                                    strAlertText:=Nothing,

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -55,6 +55,7 @@ Partial Class Alerts
         Me.TxtLogText = New System.Windows.Forms.TextBox()
         Me.Label1 = New System.Windows.Forms.Label()
         Me.Label4 = New System.Windows.Forms.Label()
+        Me.BtnCancel = New System.Windows.Forms.Button()
         Me.ListViewMenu.SuspendLayout()
         CType(Me.IconPictureBox, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -342,11 +343,22 @@ Partial Class Alerts
         Me.Label4.TabIndex = 38
         Me.Label4.Text = "Add Alert"
         '
+        'BtnCancel
+        '
+        Me.BtnCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.BtnCancel.Location = New System.Drawing.Point(83, 424)
+        Me.BtnCancel.Name = "BtnCancel"
+        Me.BtnCancel.Size = New System.Drawing.Size(75, 23)
+        Me.BtnCancel.TabIndex = 39
+        Me.BtnCancel.Text = "Cancel"
+        Me.BtnCancel.UseVisualStyleBackColor = True
+        '
         'Alerts
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(987, 458)
+        Me.Controls.Add(Me.BtnCancel)
         Me.Controls.Add(Me.Label4)
         Me.Controls.Add(Me.lblRegExBackReferences)
         Me.Controls.Add(Me.ChkEnabled)
@@ -412,4 +424,5 @@ Partial Class Alerts
     Friend WithEvents TxtLogText As TextBox
     Friend WithEvents Label1 As Label
     Friend WithEvents Label4 As Label
+    Friend WithEvents BtnCancel As Button
 End Class

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -41,6 +41,7 @@ Public Class Alerts
     End Function
 
     Private Sub Alerts_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        BtnCancel.Visible = False
         Location = VerifyWindowLocation(My.Settings.alertsLocation, Me)
         Dim MyIgnoredListViewItem As New List(Of AlertsListViewItem)
 
@@ -116,6 +117,7 @@ Public Class Alerts
 
     Private Sub EditItem()
         If AlertsListView.SelectedItems.Count > 0 Then
+            BtnCancel.Visible = True
             AlertsListView.Enabled = False
             boolEditMode = True
             BtnAdd.Text = "Save"
@@ -405,5 +407,21 @@ Public Class Alerts
 
         BtnUp.Enabled = AlertsListView.SelectedIndices(0) <> 0
         BtnDown.Enabled = AlertsListView.SelectedIndices(0) <> AlertsListView.Items.Count - 1
+    End Sub
+
+    Private Sub BtnCancel_Click(sender As Object, e As EventArgs) Handles BtnCancel.Click
+        AlertsListView.Enabled = True
+        BtnAdd.Text = "Add"
+        Label4.Text = "Add Alert"
+        boolEditMode = False
+        boolChanged = True
+        TxtAlertText.Text = Nothing
+        TxtLogText.Text = Nothing
+        IconPictureBox.Image = Nothing
+        AlertTypeComboBox.SelectedIndex = -1
+        ChkCaseSensitive.Checked = False
+        ChkRegex.Checked = False
+        ChkEnabled.Checked = True
+        BtnCancel.Visible = False
     End Sub
 End Class

--- a/Free SysLog/Windows/Configure SysLog Mirror Servers.Designer.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Servers.Designer.vb
@@ -48,6 +48,7 @@ Partial Class ConfigureSysLogMirrorServers
         Me.Label1 = New System.Windows.Forms.Label()
         Me.SeparatingLine = New System.Windows.Forms.Label()
         Me.Label4 = New System.Windows.Forms.Label()
+        Me.BtnCancel = New System.Windows.Forms.Button()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -270,11 +271,22 @@ Partial Class ConfigureSysLogMirrorServers
         Me.Label4.TabIndex = 28
         Me.Label4.Text = "Add Server"
         '
+        'BtnCancel
+        '
+        Me.BtnCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.BtnCancel.Location = New System.Drawing.Point(93, 365)
+        Me.BtnCancel.Name = "BtnCancel"
+        Me.BtnCancel.Size = New System.Drawing.Size(75, 23)
+        Me.BtnCancel.TabIndex = 40
+        Me.BtnCancel.Text = "Cancel"
+        Me.BtnCancel.UseVisualStyleBackColor = True
+        '
         'ConfigureSysLogMirrorServers
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(637, 400)
+        Me.Controls.Add(Me.BtnCancel)
         Me.Controls.Add(Me.Label4)
         Me.Controls.Add(Me.SeparatingLine)
         Me.Controls.Add(Me.txtName)
@@ -331,4 +343,5 @@ Partial Class ConfigureSysLogMirrorServers
     Friend WithEvents Label1 As Label
     Friend WithEvents SeparatingLine As Label
     Friend WithEvents Label4 As Label
+    Friend WithEvents BtnCancel As Button
 End Class

--- a/Free SysLog/Windows/Configure SysLog Mirror Servers.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Servers.vb
@@ -8,6 +8,7 @@ Public Class ConfigureSysLogMirrorServers
     Private boolDoneLoading As Boolean = False
 
     Private Sub ConfigureSysLogMirrorServers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        BtnCancel.Visible = False
         Location = SupportCode.VerifyWindowLocation(My.Settings.syslogProxyLocation, Me)
         If My.Settings.ServersToSendTo IsNot Nothing AndAlso My.Settings.ServersToSendTo.Count > 0 Then
             Dim SysLogProxyServer As SysLogProxyServer
@@ -46,6 +47,7 @@ Public Class ConfigureSysLogMirrorServers
 
     Private Sub EditItem()
         If servers.SelectedItems.Count > 0 Then
+            BtnCancel.Visible = True
             servers.Enabled = False
             boolEditMode = True
             BtnAddServer.Text = "Save"
@@ -245,5 +247,17 @@ Public Class ConfigureSysLogMirrorServers
             servers.Items.Insert(selectedIndex + 1, item)
             servers.Items(selectedIndex + 1).Selected = True
         End If
+    End Sub
+
+    Private Sub BtnCancel_Click(sender As Object, e As EventArgs) Handles BtnCancel.Click
+        servers.Enabled = True
+        BtnAddServer.Text = "Add"
+        Label4.Text = "Add Server"
+        boolEditMode = False
+        txtIP.Text = Nothing
+        txtName.Text = Nothing
+        txtPort.Text = Nothing
+        chkEnabled.Checked = True
+        BtnCancel.Visible = False
     End Sub
 End Class

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -84,6 +84,7 @@ Partial Class Form1
         Me.ConfigureAlertsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ConfigureHostnames = New System.Windows.Forms.ToolStripMenuItem()
         Me.ColumnControls = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ClearNotificationLimits = New System.Windows.Forms.ToolStripMenuItem()
         Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -428,10 +429,16 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.ImportExportSettingsToolStripMenuItem, Me.IncludeButtonsOnNotifications, Me.MinimizeToClockTray, Me.ColLogsAutoFill, Me.NotificationLength, Me.OpenWindowsExplorerToAppConfigFile, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ClearNotificationLimits, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.ImportExportSettingsToolStripMenuItem, Me.IncludeButtonsOnNotifications, Me.MinimizeToClockTray, Me.ColLogsAutoFill, Me.NotificationLength, Me.OpenWindowsExplorerToAppConfigFile, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
+        '
+        'ClearNotificationLimits
+        '
+        Me.ClearNotificationLimits.Name = "ClearNotificationLimits"
+        Me.ClearNotificationLimits.Size = New System.Drawing.Size(239, 22)
+        Me.ClearNotificationLimits.Text = "Clear Notification Limits"
         '
         'ColumnControls
         '
@@ -919,6 +926,7 @@ Partial Class Form1
     Friend WithEvents ConfigureAlertsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ConfigureHostnames As ToolStripMenuItem
     Friend WithEvents ColumnControls As ToolStripMenuItem
+    Friend WithEvents ClearNotificationLimits As ToolStripMenuItem
     Friend WithEvents ColLogsAutoFill As ToolStripMenuItem
     Friend WithEvents AboutToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CloseMe As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -145,7 +145,7 @@ Public Class Form1
         If ChkEnableAutoScroll.Checked AndAlso Logs.Rows.Count > 0 AndAlso intSortColumnIndex = 0 Then
             Try
                 boolIsProgrammaticScroll = True
-                Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0)
+                Logs.BeginInvoke(Sub() Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0))
             Finally
                 boolIsProgrammaticScroll = False
             End Try

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1556,6 +1556,13 @@ Public Class Form1
         My.Settings.disableAutoScrollUponScrolling = ChkDisableAutoScrollUponScrolling.Checked
     End Sub
 
+    Private Sub ClearNotificationLimits_Click(sender As Object, e As EventArgs) Handles ClearNotificationLimits.Click
+        If NotificationLimiter.lastNotificationTime IsNot Nothing AndAlso NotificationLimiter.lastNotificationTime.Count > 0 Then
+            NotificationLimiter.lastNotificationTime.Clear()
+            MsgBox("Done.", MsgBoxStyle.Information, Text)
+        End If
+    End Sub
+
 #Region "-- SysLog Server Code --"
     Sub SysLogThread()
         Try

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -46,6 +46,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkRegex = New System.Windows.Forms.CheckBox()
         Me.TxtIgnored = New System.Windows.Forms.TextBox()
         Me.Label1 = New System.Windows.Forms.Label()
+        Me.BtnCancel = New System.Windows.Forms.Button()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -264,11 +265,22 @@ Partial Class IgnoredWordsAndPhrases
         Me.Label1.Text = "Ignored"
         Me.Label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         '
+        'BtnCancel
+        '
+        Me.BtnCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.BtnCancel.Location = New System.Drawing.Point(83, 348)
+        Me.BtnCancel.Name = "BtnCancel"
+        Me.BtnCancel.Size = New System.Drawing.Size(75, 23)
+        Me.BtnCancel.TabIndex = 45
+        Me.BtnCancel.Text = "Cancel"
+        Me.BtnCancel.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(799, 378)
+        Me.Controls.Add(Me.BtnCancel)
         Me.Controls.Add(Me.ChkEnabled)
         Me.Controls.Add(Me.ChkCaseSensitive)
         Me.Controls.Add(Me.ChkRegex)
@@ -318,4 +330,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents ChkRegex As CheckBox
     Friend WithEvents TxtIgnored As TextBox
     Friend WithEvents Label1 As Label
+    Friend WithEvents BtnCancel As Button
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -75,6 +75,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
+        BtnCancel.Visible = False
         Location = VerifyWindowLocation(My.Settings.ignoredWordsLocation, Me)
         Dim MyIgnoredListViewItem As New List(Of MyIgnoredListViewItem)
 
@@ -148,6 +149,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub EditItem()
         If IgnoredListView.SelectedItems.Count > 0 Then
+            BtnCancel.Visible = True
             IgnoredListView.Enabled = False
             boolEditMode = True
             BtnAdd.Text = "Save"
@@ -310,5 +312,18 @@ Public Class IgnoredWordsAndPhrases
 
         BtnUp.Enabled = IgnoredListView.SelectedIndices(0) <> 0
         BtnDown.Enabled = IgnoredListView.SelectedIndices(0) <> IgnoredListView.Items.Count - 1
+    End Sub
+
+    Private Sub BtnCancel_Click(sender As Object, e As EventArgs) Handles BtnCancel.Click
+        IgnoredListView.Enabled = True
+        BtnAdd.Text = "Add"
+        Label4.Text = "Add Ignored Words and Phrases"
+        boolEditMode = False
+        boolChanged = True
+        TxtIgnored.Text = Nothing
+        ChkCaseSensitive.Checked = False
+        ChkRegex.Checked = False
+        ChkEnabled.Checked = True
+        BtnCancel.Visible = False
     End Sub
 End Class

--- a/Free SysLog/Windows/Replacements.Designer.vb
+++ b/Free SysLog/Windows/Replacements.Designer.vb
@@ -49,6 +49,7 @@ Partial Class Replacements
         Me.TxtReplace = New System.Windows.Forms.TextBox()
         Me.Label1 = New System.Windows.Forms.Label()
         Me.Label3 = New System.Windows.Forms.Label()
+        Me.BtnCancel = New System.Windows.Forms.Button()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -290,11 +291,22 @@ Partial Class Replacements
         Me.Label3.TabIndex = 34
         Me.Label3.Text = "Add Replacement"
         '
+        'BtnCancel
+        '
+        Me.BtnCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.BtnCancel.Location = New System.Drawing.Point(93, 521)
+        Me.BtnCancel.Name = "BtnCancel"
+        Me.BtnCancel.Size = New System.Drawing.Size(75, 23)
+        Me.BtnCancel.TabIndex = 46
+        Me.BtnCancel.Text = "Cancel"
+        Me.BtnCancel.UseVisualStyleBackColor = True
+        '
         'Replacements
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(969, 553)
+        Me.Controls.Add(Me.BtnCancel)
         Me.Controls.Add(Me.Label3)
         Me.Controls.Add(Me.ChkEnabled)
         Me.Controls.Add(Me.ChkCaseSensitive)
@@ -350,4 +362,5 @@ Partial Class Replacements
     Friend WithEvents TxtReplace As TextBox
     Friend WithEvents Label1 As Label
     Friend WithEvents Label3 As Label
+    Friend WithEvents BtnCancel As Button
 End Class

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -79,6 +79,7 @@ Public Class Replacements
     End Sub
 
     Private Sub Replacements_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        BtnCancel.Visible = False
         Location = VerifyWindowLocation(My.Settings.replacementsLocation, Me)
         Dim listOfReplacementsToAdd As New List(Of MyReplacementsListViewItem)
 
@@ -148,6 +149,7 @@ Public Class Replacements
 
     Private Sub EditItem()
         If ReplacementsListView.SelectedItems.Count > 0 Then
+            BtnCancel.Visible = True
             ReplacementsListView.Enabled = False
             boolEditMode = True
             BtnAdd.Text = "Save"
@@ -329,5 +331,19 @@ Public Class Replacements
 
         BtnUp.Enabled = ReplacementsListView.SelectedIndices(0) <> 0
         BtnDown.Enabled = ReplacementsListView.SelectedIndices(0) <> ReplacementsListView.Items.Count - 1
+    End Sub
+
+    Private Sub BtnCancel_Click(sender As Object, e As EventArgs) Handles BtnCancel.Click
+        ReplacementsListView.Enabled = True
+        BtnAdd.Text = "Add"
+        Label3.Text = "Add Replacement"
+        boolEditMode = False
+        boolChanged = True
+        TxtReplace.Text = Nothing
+        TxtReplaceWith.Text = Nothing
+        ChkCaseSensitive.Checked = False
+        ChkRegex.Checked = False
+        ChkEnabled.Checked = True
+        BtnCancel.Visible = False
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -72,7 +72,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(1010, 299)
+        Me.FileList.Size = New System.Drawing.Size(1010, 272)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -137,7 +137,7 @@ Partial Class ViewLogBackups
         '
         Me.BtnView.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnView.Enabled = False
-        Me.BtnView.Location = New System.Drawing.Point(13, 316)
+        Me.BtnView.Location = New System.Drawing.Point(14, 290)
         Me.BtnView.Name = "BtnView"
         Me.BtnView.Size = New System.Drawing.Size(75, 23)
         Me.BtnView.TabIndex = 2
@@ -148,7 +148,7 @@ Partial Class ViewLogBackups
         '
         Me.BtnDelete.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnDelete.Enabled = False
-        Me.BtnDelete.Location = New System.Drawing.Point(94, 316)
+        Me.BtnDelete.Location = New System.Drawing.Point(95, 290)
         Me.BtnDelete.Name = "BtnDelete"
         Me.BtnDelete.Size = New System.Drawing.Size(75, 23)
         Me.BtnDelete.TabIndex = 3
@@ -158,7 +158,7 @@ Partial Class ViewLogBackups
         'BtnRefresh
         '
         Me.BtnRefresh.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnRefresh.Location = New System.Drawing.Point(175, 316)
+        Me.BtnRefresh.Location = New System.Drawing.Point(176, 290)
         Me.BtnRefresh.Name = "BtnRefresh"
         Me.BtnRefresh.Size = New System.Drawing.Size(95, 23)
         Me.BtnRefresh.TabIndex = 4
@@ -186,7 +186,7 @@ Partial Class ViewLogBackups
         Me.ChkCaseInsensitiveSearch.AutoSize = True
         Me.ChkCaseInsensitiveSearch.Checked = True
         Me.ChkCaseInsensitiveSearch.CheckState = System.Windows.Forms.CheckState.Checked
-        Me.ChkCaseInsensitiveSearch.Location = New System.Drawing.Point(586, 321)
+        Me.ChkCaseInsensitiveSearch.Location = New System.Drawing.Point(390, 321)
         Me.ChkCaseInsensitiveSearch.Name = "ChkCaseInsensitiveSearch"
         Me.ChkCaseInsensitiveSearch.Size = New System.Drawing.Size(109, 17)
         Me.ChkCaseInsensitiveSearch.TabIndex = 33
@@ -197,7 +197,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkRegExSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkRegExSearch.AutoSize = True
-        Me.ChkRegExSearch.Location = New System.Drawing.Point(517, 321)
+        Me.ChkRegExSearch.Location = New System.Drawing.Point(321, 321)
         Me.ChkRegExSearch.Name = "ChkRegExSearch"
         Me.ChkRegExSearch.Size = New System.Drawing.Size(63, 17)
         Me.ChkRegExSearch.TabIndex = 32
@@ -207,7 +207,7 @@ Partial Class ViewLogBackups
         'BtnSearch
         '
         Me.BtnSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnSearch.Location = New System.Drawing.Point(694, 317)
+        Me.BtnSearch.Location = New System.Drawing.Point(498, 317)
         Me.BtnSearch.Name = "BtnSearch"
         Me.BtnSearch.Size = New System.Drawing.Size(52, 23)
         Me.BtnSearch.TabIndex = 31
@@ -217,16 +217,16 @@ Partial Class ViewLogBackups
         'TxtSearchTerms
         '
         Me.TxtSearchTerms.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.TxtSearchTerms.Location = New System.Drawing.Point(363, 318)
+        Me.TxtSearchTerms.Location = New System.Drawing.Point(95, 319)
         Me.TxtSearchTerms.Name = "TxtSearchTerms"
-        Me.TxtSearchTerms.Size = New System.Drawing.Size(148, 20)
+        Me.TxtSearchTerms.Size = New System.Drawing.Size(220, 20)
         Me.TxtSearchTerms.TabIndex = 30
         '
         'LblSearchLabel
         '
         Me.LblSearchLabel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.LblSearchLabel.AutoSize = True
-        Me.LblSearchLabel.Location = New System.Drawing.Point(276, 321)
+        Me.LblSearchLabel.Location = New System.Drawing.Point(8, 322)
         Me.LblSearchLabel.Name = "LblSearchLabel"
         Me.LblSearchLabel.Size = New System.Drawing.Size(81, 13)
         Me.LblSearchLabel.TabIndex = 29
@@ -241,9 +241,9 @@ Partial Class ViewLogBackups
         '
         'ChkShowHidden
         '
-        Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHidden.AutoSize = True
-        Me.ChkShowHidden.Location = New System.Drawing.Point(752, 320)
+        Me.ChkShowHidden.Location = New System.Drawing.Point(277, 294)
         Me.ChkShowHidden.Name = "ChkShowHidden"
         Me.ChkShowHidden.Size = New System.Drawing.Size(114, 17)
         Me.ChkShowHidden.TabIndex = 34
@@ -259,9 +259,9 @@ Partial Class ViewLogBackups
         '
         'ChkShowHiddenAsGray
         '
-        Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHiddenAsGray.AutoSize = True
-        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(872, 320)
+        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(397, 294)
         Me.ChkShowHiddenAsGray.Name = "ChkShowHiddenAsGray"
         Me.ChkShowHiddenAsGray.Size = New System.Drawing.Size(153, 17)
         Me.ChkShowHiddenAsGray.TabIndex = 35
@@ -311,7 +311,7 @@ Partial Class ViewLogBackups
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(1051, 403)
+        Me.MinimumSize = New System.Drawing.Size(866, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -72,7 +72,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(1010, 272)
+        Me.FileList.Size = New System.Drawing.Size(559, 272)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -170,7 +170,7 @@ Partial Class ViewLogBackups
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.lblTotalNumberOfHiddenLogs, Me.LblTotalDiskSpace})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(1035, 22)
+        Me.StatusStrip1.Size = New System.Drawing.Size(584, 22)
         Me.StatusStrip1.TabIndex = 5
         Me.StatusStrip1.Text = "StatusStrip1"
         '
@@ -295,7 +295,7 @@ Partial Class ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(1035, 364)
+        Me.ClientSize = New System.Drawing.Size(584, 364)
         Me.Controls.Add(Me.ChkShowHiddenAsGray)
         Me.Controls.Add(Me.ChkShowHidden)
         Me.Controls.Add(Me.ChkCaseInsensitiveSearch)
@@ -311,7 +311,7 @@ Partial Class ViewLogBackups
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(866, 403)
+        Me.MinimumSize = New System.Drawing.Size(600, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)


### PR DESCRIPTION
- Added code to be able to manually clear the Notification Limiter.
- We now log data when checking for updates.
- Did some rearrangements of GUI elements on the "View Log Backups" window.
- Resized some GUI elements on the "View Log Backups" window.
- Added a "Cancel" button to the bottom of the Alerts, "Configure SysLog Mirror Servers", "Ignored Words and Phrases", and Replaceements windows.
- Fixed scrolling to the bottom of of the logs DataGrid upon program load.