### PR TITLE
Version 3.7 Build 3

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.7.2.79")>
+<Assembly: AssemblyFileVersion("3.7.3.80")>

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -232,6 +232,7 @@ Public Class Form1
         IgnoredLogsToolStripMenuItem.Visible = ChkEnableRecordingOfIgnoredLogs.Checked
         ZerooutIgnoredLogsCounterToolStripMenuItem.Visible = Not ChkEnableRecordingOfIgnoredLogs.Checked
         ChkEnableAutoScroll.Checked = My.Settings.autoScroll
+        ChkDisableAutoScrollUponScrolling.Enabled = ChkEnableAutoScroll.Checked
         ChkEnableAutoSave.Checked = My.Settings.autoSave
         ChkEnableConfirmCloseToolStripItem.Checked = My.Settings.boolConfirmClose
         LblAutoSaved.Visible = ChkEnableAutoSave.Checked
@@ -636,6 +637,7 @@ Public Class Form1
 
     Private Sub ChkAutoScroll_Click(sender As Object, e As EventArgs) Handles ChkEnableAutoScroll.Click
         My.Settings.autoScroll = ChkEnableAutoScroll.Checked
+        ChkDisableAutoScrollUponScrolling.Enabled = ChkEnableAutoScroll.Checked
     End Sub
 
     Private Sub Logs_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles Logs.ColumnWidthChanged

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -143,12 +143,11 @@ Public Class Form1
 
     Public Sub SelectLatestLogEntry()
         If ChkEnableAutoScroll.Checked AndAlso Logs.Rows.Count > 0 AndAlso intSortColumnIndex = 0 Then
-            Try
-                boolIsProgrammaticScroll = True
-                Logs.BeginInvoke(Sub() Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0))
-            Finally
-                boolIsProgrammaticScroll = False
-            End Try
+            boolIsProgrammaticScroll = True
+            Logs.BeginInvoke(Sub()
+                                 Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0)
+                                 boolIsProgrammaticScroll = False
+                             End Sub)
         End If
     End Sub
 


### PR DESCRIPTION
- Made it so that the "Disable Auto Scroll Upon Scrolling" checkbox is disabled if the "Enable Auto Scroll" is unchecked.
- Fixed a TOC/TOU (Time of Check/Time of Use) bug in the auto-scrolling logic of the Logs DataGridView. 0e60016