### PR TITLE
Version 3.7 Build 4

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.7.3.80")>
+<Assembly: AssemblyFileVersion("3.7.4.81")>

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -207,7 +207,7 @@ Namespace SupportCode
         Public Sub SendMessageToTCPSysLogServer(strMessage As String, intPort As Integer)
             Try
                 Using tcpClient As New TcpClient()
-                    tcpClient.Connect(Net.IPAddress.Loopback, intPort)
+                    tcpClient.Connect(GetLocalIPAddress(), intPort)
 
                     Using networkStream As NetworkStream = tcpClient.GetStream()
                         Dim data As Byte() = Encoding.UTF8.GetBytes(strMessage)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -1,6 +1,7 @@
 ﻿Imports System.Net
 Imports System.Net.Sockets
 Imports System.Text
+Imports System.Net.NetworkInformation
 
 Namespace SupportCode
     Public Enum IgnoreOrSearchWindowDisplayMode As Byte
@@ -180,10 +181,22 @@ Namespace SupportCode
             End Try
         End Function
 
+        Private Function GetLocalIPAddress() As IPAddress
+            For Each ni As NetworkInterface In NetworkInterface.GetAllNetworkInterfaces()
+                If ni.OperationalStatus = OperationalStatus.Up AndAlso ni.NetworkInterfaceType <> NetworkInterfaceType.Loopback Then
+                    For Each ip As UnicastIPAddressInformation In ni.GetIPProperties().UnicastAddresses
+                        If ip.Address.AddressFamily = AddressFamily.InterNetwork Then Return ip.Address
+                    Next
+                End If
+            Next
+
+            Throw New Exception("No active network adapter with an IPv4 address found.")
+        End Function
+
         Public Sub SendMessageToSysLogServer(strMessage As String, intPort As Integer)
             Try
                 Using udpClient As New UdpClient()
-                    udpClient.Connect(Net.IPAddress.Loopback, intPort)
+                    udpClient.Connect(GetLocalIPAddress(), intPort)
                     Dim data As Byte() = Encoding.UTF8.GetBytes(strMessage)
                     udpClient.Send(data, data.Length)
                 End Using

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -183,14 +183,14 @@ Namespace SupportCode
 
         Private Function GetLocalIPAddress() As IPAddress
             For Each ni As NetworkInterface In NetworkInterface.GetAllNetworkInterfaces()
-                If ni.OperationalStatus = OperationalStatus.Up AndAlso ni.NetworkInterfaceType <> NetworkInterfaceType.Loopback Then
+                If ni.OperationalStatus = OperationalStatus.Up AndAlso ni.NetworkInterfaceType <> NetworkInterfaceType.Loopback AndAlso ni.NetworkInterfaceType <> NetworkInterfaceType.Tunnel Then
                     For Each ip As UnicastIPAddressInformation In ni.GetIPProperties().UnicastAddresses
                         If ip.Address.AddressFamily = AddressFamily.InterNetwork Then Return ip.Address
                     Next
                 End If
             Next
 
-            Throw New Exception("No active network adapter with an IPv4 address found.")
+            Throw New Exception("No active network adapter with a matching IP address found.")
         End Function
 
         Public Sub SendMessageToSysLogServer(strMessage As String, intPort As Integer)

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -126,10 +126,13 @@ Partial Class Form1
         Me.NotificationLengthLong = New System.Windows.Forms.ToolStripMenuItem()
         Me.NotificationLengthShort = New System.Windows.Forms.ToolStripMenuItem()
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
+        Me.IconMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ReOpenToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.StatusStrip.SuspendLayout()
         Me.MenuStrip.SuspendLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.LogsMenu.SuspendLayout()
+        Me.IconMenu.SuspendLayout()
         Me.SuspendLayout()
         '
         'NotificationLength
@@ -677,6 +680,7 @@ Partial Class Form1
         '
         'NotifyIcon
         '
+        Me.NotifyIcon.ContextMenuStrip = Me.IconMenu
         Me.NotifyIcon.Text = "NotifyIcon"
         Me.NotifyIcon.Visible = True
         '
@@ -841,6 +845,18 @@ Partial Class Form1
         Me.LoadingProgressBar.TabIndex = 19
         Me.LoadingProgressBar.Visible = False
         '
+        'IconMenu
+        '
+        Me.IconMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ReOpenToolStripMenuItem})
+        Me.IconMenu.Name = "IconMenu"
+        Me.IconMenu.Size = New System.Drawing.Size(181, 48)
+        '
+        'ReOpenToolStripMenuItem
+        '
+        Me.ReOpenToolStripMenuItem.Name = "ReOpenToolStripMenuItem"
+        Me.ReOpenToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.ReOpenToolStripMenuItem.Text = "Re-Open"
+        '
         'Form1
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -865,6 +881,7 @@ Partial Class Form1
         Me.MenuStrip.PerformLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).EndInit()
         Me.LogsMenu.ResumeLayout(False)
+        Me.IconMenu.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -973,4 +990,6 @@ Partial Class Form1
     Friend WithEvents NotificationLength As ToolStripMenuItem
     Friend WithEvents NotificationLengthLong As ToolStripMenuItem
     Friend WithEvents NotificationLengthShort As ToolStripMenuItem
+    Friend WithEvents IconMenu As ContextMenuStrip
+    Friend WithEvents ReOpenToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1564,6 +1564,10 @@ Public Class Form1
         End If
     End Sub
 
+    Private Sub ReOpenToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ReOpenToolStripMenuItem.Click
+        RestoreWindow()
+    End Sub
+
 #Region "-- SysLog Server Code --"
     Sub SysLogThread()
         Try

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -160,10 +160,13 @@ Public Class Form1
         Threading.Thread.Sleep(100)
         SelectLatestLogEntry()
         Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
+        boolIsProgrammaticScroll = False
     End Sub
 
     Private Sub Form1_Resize(sender As Object, e As EventArgs) Handles Me.Resize
         If boolDoneLoading Then
+            boolIsProgrammaticScroll = True
+
             If WindowState = FormWindowState.Minimized Then
                 If My.Settings.boolDeselectItemsWhenMinimizing Then
                     Logs.ClearSelection()


### PR DESCRIPTION
- Fixed sending UDP packets from within the same system. This will make the restoring of the window from "Minimize to Clock Tray" function properly.
- Added a menu to the clock tray icon with an item to re-open the program window.
- Fixed a bug where "Auto Scroll" would be disabled if you minimized the program with "Minimize to Clock Tray" enabled.