### PR TITLE
Version 3.8 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.7.4.81")>
+<Assembly: AssemblyFileVersion("3.8.1.82")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1136,6 +1136,18 @@ Namespace My
                 Me("columnFileNameSize") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property boolDebug() As Boolean
+            Get
+                Return CType(Me("boolDebug"),Boolean)
+            End Get
+            Set
+                Me("boolDebug") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -275,5 +275,8 @@
     <Setting Name="columnFileNameSize" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">150</Value>
     </Setting>
+    <Setting Name="boolDebug" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -348,7 +348,7 @@ Namespace checkForUpdates
                             Else
                                 windowObject.Invoke(Sub() MsgBox("The update will not be downloaded.", MsgBoxStyle.Information, strMessageBoxTitleText))
                             End If
-                        ElseIf response = ProcessUpdateXMLResponse.noUpdateNeeded AndAlso boolShowMessageBox Then
+                        ElseIf response = ProcessUpdateXMLResponse.noUpdateNeeded Then
                             If boolDebugBuild Or My.Settings.boolDebug Then
                                 SyncLock windowObject.dataGridLockObject
                                     windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("You already have the latest version, there is no need to update this program.", windowObject.Logs))
@@ -357,7 +357,9 @@ Namespace checkForUpdates
                                 End SyncLock
                             End If
 
-                            windowObject.Invoke(Sub() MsgBox($"You already have the latest version, there is no need to update this program.{vbCrLf}{vbCrLf}Your current version is v{versionString}.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                            If boolShowMessageBox Then
+                                windowObject.Invoke(Sub() MsgBox($"You already have the latest version, there is no need to update this program.{vbCrLf}{vbCrLf}Your current version is v{versionString}.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                            End If
                         ElseIf (response = ProcessUpdateXMLResponse.parseError Or response = ProcessUpdateXMLResponse.exceptionError) AndAlso boolShowMessageBox Then
                             If boolDebugBuild Or My.Settings.boolDebug Then
                                 SyncLock windowObject.dataGridLockObject

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -298,11 +298,13 @@ Namespace checkForUpdates
 
             If Not My.Computer.Network.IsAvailable Then
                 windowObject.Invoke(Sub()
-                                        SyncLock windowObject.dataGridLockObject
-                                            windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("No Internet connection detected.", windowObject.Logs, "Error, Local"))
-                                            windowObject.UpdateLogCount()
-                                            windowObject.SelectLatestLogEntry()
-                                        End SyncLock
+                                        If boolDebugBuild Or My.Settings.boolDebug Then
+                                            SyncLock windowObject.dataGridLockObject
+                                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("No Internet connection detected.", windowObject.Logs, "Error, Local"))
+                                                windowObject.UpdateLogCount()
+                                                windowObject.SelectLatestLogEntry()
+                                            End SyncLock
+                                        End If
 
                                         MsgBox("No Internet connection detected.", MsgBoxStyle.Information, strMessageBoxTitleText)
                                     End Sub)
@@ -316,55 +318,75 @@ Namespace checkForUpdates
                         Dim remoteBuild As String = Nothing
                         Dim response As ProcessUpdateXMLResponse = ProcessUpdateXMLData(xmlData, remoteVersion, remoteBuild)
 
-                        If response = ProcessUpdateXMLResponse.newVersion Then
+                        If boolDebugBuild Or My.Settings.boolDebug Then
                             SyncLock windowObject.dataGridLockObject
-                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"New version detected... {remoteVersion} Build {remoteBuild}.", windowObject.Logs))
+                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The following data was received from the URL ""{programUpdateCheckerXMLFile}""...{vbCrLf}{SyslogParser.ConvertLineFeeds(xmlData)}", windowObject.Logs))
                                 windowObject.UpdateLogCount()
                                 windowObject.SelectLatestLogEntry()
                             End SyncLock
+                        End If
 
-                            If BackgroundThreadMessageBox($"An update to {strProgramName} (version {remoteVersion} Build {remoteBuild}) is available to be downloaded, do you want to download and update to this new version?", strMessageBoxTitleText) = MsgBoxResult.Yes Then
+                        If response = ProcessUpdateXMLResponse.newVersion Then
+                            If boolDebugBuild Or My.Settings.boolDebug Then
                                 SyncLock windowObject.dataGridLockObject
-                                    windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Beginning program update process.", windowObject.Logs))
+                                    windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"New version detected... {remoteVersion} Build {remoteBuild}.", windowObject.Logs))
                                     windowObject.UpdateLogCount()
                                     windowObject.SelectLatestLogEntry()
                                 End SyncLock
+                            End If
+
+                            If BackgroundThreadMessageBox($"An update to {strProgramName} (version {remoteVersion} Build {remoteBuild}) is available to be downloaded, do you want to download and update to this new version?", strMessageBoxTitleText) = MsgBoxResult.Yes Then
+                                If boolDebugBuild Or My.Settings.boolDebug Then
+                                    SyncLock windowObject.dataGridLockObject
+                                        windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Beginning program update process.", windowObject.Logs))
+                                        windowObject.UpdateLogCount()
+                                        windowObject.SelectLatestLogEntry()
+                                    End SyncLock
+                                End If
 
                                 DownloadAndPerformUpdate()
                             Else
                                 windowObject.Invoke(Sub() MsgBox("The update will not be downloaded.", MsgBoxStyle.Information, strMessageBoxTitleText))
                             End If
                         ElseIf response = ProcessUpdateXMLResponse.noUpdateNeeded AndAlso boolShowMessageBox Then
-                            SyncLock windowObject.dataGridLockObject
-                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("You already have the latest version, there is no need to update this program.", windowObject.Logs))
-                                windowObject.UpdateLogCount()
-                                windowObject.SelectLatestLogEntry()
-                            End SyncLock
+                            If boolDebugBuild Or My.Settings.boolDebug Then
+                                SyncLock windowObject.dataGridLockObject
+                                    windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("You already have the latest version, there is no need to update this program.", windowObject.Logs))
+                                    windowObject.UpdateLogCount()
+                                    windowObject.SelectLatestLogEntry()
+                                End SyncLock
+                            End If
 
                             windowObject.Invoke(Sub() MsgBox($"You already have the latest version, there is no need to update this program.{vbCrLf}{vbCrLf}Your current version is v{versionString}.", MsgBoxStyle.Information, strMessageBoxTitleText))
                         ElseIf (response = ProcessUpdateXMLResponse.parseError Or response = ProcessUpdateXMLResponse.exceptionError) AndAlso boolShowMessageBox Then
-                            SyncLock windowObject.dataGridLockObject
-                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"There was an error when trying to parse the response from the server. The XML data from the server is below...{vbCrLf}{vbCrLf}{xmlData}", windowObject.Logs, "Error, Local"))
-                                windowObject.UpdateLogCount()
-                                windowObject.SelectLatestLogEntry()
-                            End SyncLock
+                            If boolDebugBuild Or My.Settings.boolDebug Then
+                                SyncLock windowObject.dataGridLockObject
+                                    windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"There was an error when trying to parse the response from the server. The XML data from the server is below...{vbCrLf}{vbCrLf}{xmlData}", windowObject.Logs, "Error, Local"))
+                                    windowObject.UpdateLogCount()
+                                    windowObject.SelectLatestLogEntry()
+                                End SyncLock
+                            End If
 
                             windowObject.Invoke(Sub() MsgBox("There was an error when trying to parse the response from the server.", MsgBoxStyle.Critical, strMessageBoxTitleText))
                         ElseIf response = ProcessUpdateXMLResponse.newerVersionThanWebSite AndAlso boolShowMessageBox Then
-                            SyncLock windowObject.dataGridLockObject
-                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("This is weird, you have a version that's newer than what's listed on the web site.", windowObject.Logs))
-                                windowObject.UpdateLogCount()
-                                windowObject.SelectLatestLogEntry()
-                            End SyncLock
+                            If boolDebugBuild Or My.Settings.boolDebug Then
+                                SyncLock windowObject.dataGridLockObject
+                                    windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("This is weird, you have a version that's newer than what's listed on the web site.", windowObject.Logs))
+                                    windowObject.UpdateLogCount()
+                                    windowObject.SelectLatestLogEntry()
+                                End SyncLock
+                            End If
 
                             windowObject.Invoke(Sub() MsgBox("This is weird, you have a version that's newer than what's listed on the web site.", MsgBoxStyle.Information, strMessageBoxTitleText))
                         End If
                     Else
-                        SyncLock windowObject.dataGridLockObject
-                            windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("There was an error checking for updates.", windowObject.Logs, "Error, Local"))
-                            windowObject.UpdateLogCount()
-                            windowObject.SelectLatestLogEntry()
-                        End SyncLock
+                        If boolDebugBuild Or My.Settings.boolDebug Then
+                            SyncLock windowObject.dataGridLockObject
+                                windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("There was an error checking for updates.", windowObject.Logs, "Error, Local"))
+                                windowObject.UpdateLogCount()
+                                windowObject.SelectLatestLogEntry()
+                            End SyncLock
+                        End If
 
                         If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("There was an error checking for updates.", MsgBoxStyle.Information, strMessageBoxTitleText))
                     End If

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -300,6 +300,8 @@ Namespace checkForUpdates
                 windowObject.Invoke(Sub()
                                         SyncLock windowObject.dataGridLockObject
                                             windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("No Internet connection detected.", windowObject.Logs, "Error, Local"))
+                                            windowObject.UpdateLogCount()
+                                            windowObject.SelectLatestLogEntry()
                                         End SyncLock
 
                                         MsgBox("No Internet connection detected.", MsgBoxStyle.Information, strMessageBoxTitleText)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -27,7 +27,6 @@ Namespace SupportCode
         Public strPathToDataFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog")
         Public strPathToDataBackupFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog", "Backup")
         Public strPathToDataFile As String = IO.Path.Combine(strPathToDataFolder, "log.json")
-        Public Const strNoProxyString As String = "noproxy|"
         Public Const strProxiedString As String = "proxied|"
         Public Const strQuote As String = Chr(34)
         Public Const strViewLog As String = "viewlog"

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -44,6 +44,12 @@ Namespace SupportCode
         Public Const ColumnIndex_Alerted As Integer = 7
         Public Const ColumnIndex_FileName As Integer = 8
 
+#If DEBUG Then
+        Public Const boolDebugBuild As Boolean = True
+#Else
+        Public Const boolDebugBuild As Boolean = False
+#End If
+
         Public Function SaveColumnOrders(columns As DataGridViewColumnCollection) As Specialized.StringCollection
             Try
                 Dim SpecializedStringCollection As New Specialized.StringCollection

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -222,7 +222,7 @@ Namespace SyslogParser
             Return parsedDate
         End Function
 
-        Private Function ConvertLineFeeds(strInput As String) As String
+        Public Function ConvertLineFeeds(strInput As String) As String
             strInput = strInput.Replace(vbCrLf, vbLf) ' Temporarily replace all CRLF with LF
             strInput = strInput.Replace(vbCr, vbLf)   ' Convert standalone CR to LF
             strInput = strInput.Replace(vbLf, vbCrLf) ' Finally, replace all LF with CRLF

--- a/Free SysLog/Support Code/Namespace Code/Task Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Task Handling.vb
@@ -39,6 +39,7 @@ Namespace TaskHandling
                             Dim dblSeconds As Double = DirectCast(trigger, LogonTrigger).Delay.TotalSeconds
 
                             If dblSeconds > 0 Then
+                                ParentForm.StartUpDelay.Checked = True
                                 ParentForm.StartUpDelay.Text = $"        Startup Delay ({dblSeconds} {If(dblSeconds = 1, "Second", "Seconds")})"
                             End If
                         End If

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -120,6 +120,7 @@ Partial Class Form1
         Me.ConfigureSysLogMirrorServers = New System.Windows.Forms.ToolStripMenuItem()
         Me.ConfigureTimeBetweenSameNotifications = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkDeselectItemAfterMinimizingWindow = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkDebug = New System.Windows.Forms.ToolStripMenuItem()
         Me.BackupFileNameDateFormatChooser = New System.Windows.Forms.ToolStripMenuItem()
         Me.MinimizeToClockTray = New System.Windows.Forms.ToolStripMenuItem()
         Me.NotificationLength = New System.Windows.Forms.ToolStripMenuItem()
@@ -314,6 +315,14 @@ Partial Class Form1
         Me.MinimizeToClockTray.Size = New System.Drawing.Size(339, 22)
         Me.MinimizeToClockTray.Text = "Minimize to Clock Tray"
         '
+        'ChkDebug
+        '
+        Me.ChkDebug.CheckOnClick = True
+        Me.ChkDebug.Name = "ChkDebug"
+        Me.ChkDebug.Size = New System.Drawing.Size(339, 22)
+        Me.ChkDebug.Text = "Debug Mode"
+        Me.ChkDebug.ToolTipText = "Enables debug data from the program to be written to the Syslog Data."
+        '
         'ChkDeselectItemAfterMinimizingWindow
         '
         Me.ChkDeselectItemAfterMinimizingWindow.CheckOnClick = True
@@ -432,7 +441,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ClearNotificationLimits, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.ImportExportSettingsToolStripMenuItem, Me.IncludeButtonsOnNotifications, Me.MinimizeToClockTray, Me.ColLogsAutoFill, Me.NotificationLength, Me.OpenWindowsExplorerToAppConfigFile, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ClearNotificationLimits, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.ImportExportSettingsToolStripMenuItem, Me.IncludeButtonsOnNotifications, Me.MinimizeToClockTray, Me.ColLogsAutoFill, Me.NotificationLength, Me.OpenWindowsExplorerToAppConfigFile, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -976,6 +985,7 @@ Partial Class Form1
     Friend WithEvents CreateReplacementToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents LblItemsSelected As ToolStripStatusLabel
     Friend WithEvents ChkDeselectItemAfterMinimizingWindow As ToolStripMenuItem
+    Friend WithEvents ChkDebug As ToolStripMenuItem
     Friend WithEvents ChkShowAlertedColumn As ToolStripMenuItem
     Friend WithEvents RemoveNumbersFromRemoteApp As ToolStripMenuItem
     Friend WithEvents ShowRawLogOnLogViewer As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1113,6 +1113,20 @@ Public Class Form1
                 End If
             End If
         End If
+
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(e.X, e.Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None
+        End If
+    End Sub
+
+    Private Sub Logs_MouseUp(sender As Object, e As MouseEventArgs) Handles Logs.MouseUp
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(e.X, e.Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
+        End If
     End Sub
 
     Private Sub OpenLogViewerToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles OpenLogViewerToolStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1623,7 +1623,7 @@ Public Class Form1
                         Catch ex As Newtonsoft.Json.JsonSerializationException
                         End Try
                     Else
-                        If serversList.Count > 0 Then
+                        If serversList IsNot Nothing AndAlso serversList.Count > 0 Then
                             Threading.ThreadPool.QueueUserWorkItem(Sub()
                                                                        ProxiedSysLogData = New ProxiedSysLogData() With {.ip = strSourceIP, .log = strReceivedData}
                                                                        Dim strDataToSend As String = strProxiedString & Newtonsoft.Json.JsonConvert.SerializeObject(ProxiedSysLogData)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -329,10 +329,6 @@ Public Class Form1
 
         TaskHandling.ConvertRegistryRunCommandToTask()
 
-        If My.Settings.boolCheckForUpdates Then Threading.ThreadPool.QueueUserWorkItem(Sub()
-                                                                                           Dim checkForUpdatesClassObject As New checkForUpdates.CheckForUpdatesClass(Me)
-                                                                                           checkForUpdatesClassObject.CheckForUpdates(False)
-                                                                                       End Sub)
         If My.Settings.DeleteOldLogsAtMidnight Then CreateNewMidnightTimer()
 
         ChangeLogAutosaveIntervalToolStripMenuItem.Text = $"        Change Log Autosave Interval ({My.Settings.autoSaveMinutes} Minutes)"
@@ -433,6 +429,11 @@ Public Class Form1
     End Sub
 
     Private Sub RunWorkerCompleted(sender As Object, e As RunWorkerCompletedEventArgs)
+        If My.Settings.boolCheckForUpdates Then Threading.ThreadPool.QueueUserWorkItem(Sub()
+                                                                                           Dim checkForUpdatesClassObject As New checkForUpdates.CheckForUpdatesClass(Me)
+                                                                                           checkForUpdatesClassObject.CheckForUpdates(False)
+                                                                                       End Sub)
+
         If boolDoWeOwnTheMutex Then
             serverThread = New Threading.Thread(AddressOf SysLogThread) With {.Name = "UDP Server Thread", .Priority = Threading.ThreadPriority.Normal}
             serverThread.Start()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1626,12 +1626,14 @@ Public Class Form1
                         If serversList.Count > 0 AndAlso Not strReceivedData.StartsWith(strNoProxyString, StringComparison.OrdinalIgnoreCase) Then
                             Threading.ThreadPool.QueueUserWorkItem(Sub()
                                                                        ProxiedSysLogData = New ProxiedSysLogData() With {.ip = strSourceIP, .log = strReceivedData}
+                                                                       Dim strDataToSend As String = strProxiedString & Newtonsoft.Json.JsonConvert.SerializeObject(ProxiedSysLogData)
 
                                                                        For Each item As SysLogProxyServer In serversList
-                                                                           SendMessageToSysLogServer(strProxiedString & Newtonsoft.Json.JsonConvert.SerializeObject(ProxiedSysLogData), item.ip, item.port)
+                                                                           SendMessageToSysLogServer(strDataToSend, item.ip, item.port)
                                                                        Next
 
                                                                        ProxiedSysLogData = Nothing
+                                                                       strDataToSend = Nothing
                                                                    End Sub)
                         End If
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -258,6 +258,7 @@ Public Class Form1
         RemoveNumbersFromRemoteApp.Checked = My.Settings.RemoveNumbersFromRemoteApp
         IPv6Support.Checked = My.Settings.IPv6Support
         ChkDisableAutoScrollUponScrolling.Checked = My.Settings.disableAutoScrollUponScrolling
+        ChkDebug.Checked = My.Settings.boolDebug
     End Sub
 
     Private Sub LoadAndDeserializeArrays()
@@ -1585,6 +1586,10 @@ Public Class Form1
         RestoreWindow()
     End Sub
 
+    Private Sub ChkDebug_Click(sender As Object, e As EventArgs) Handles ChkDebug.Click
+        My.Settings.boolDebug = ChkDebug.Checked
+    End Sub
+
 #Region "-- SysLog Server Code --"
     Sub SysLogThread()
         Try
@@ -1669,6 +1674,10 @@ Public Class Form1
         End If
 
         Await Threading.Tasks.Task.Delay(100)
+
+        If boolDebugBuild Or ChkDebug.Checked Then
+            Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Restore command received.", Logs))
+        End If
 
         SelectLatestLogEntry()
     End Sub

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1623,7 +1623,7 @@ Public Class Form1
                         Catch ex As Newtonsoft.Json.JsonSerializationException
                         End Try
                     Else
-                        If serversList.Count > 0 AndAlso Not strReceivedData.StartsWith(strNoProxyString, StringComparison.OrdinalIgnoreCase) Then
+                        If serversList.Count > 0 Then
                             Threading.ThreadPool.QueueUserWorkItem(Sub()
                                                                        ProxiedSysLogData = New ProxiedSysLogData() With {.ip = strSourceIP, .log = strReceivedData}
                                                                        Dim strDataToSend As String = strProxiedString & Newtonsoft.Json.JsonConvert.SerializeObject(ProxiedSysLogData)
@@ -1637,7 +1637,6 @@ Public Class Form1
                                                                    End Sub)
                         End If
 
-                        If strReceivedData.StartsWith(strNoProxyString) Then strReceivedData = strReceivedData.Replace(strNoProxyString, "", StringComparison.OrdinalIgnoreCase)
                         SyslogParser.ProcessIncomingLog(strReceivedData, strSourceIP)
                     End If
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -112,6 +112,22 @@ Public Class IgnoredLogsAndSearchResults
         End If
     End Sub
 
+    Private Sub Logs_MouseDown(sender As Object, e As MouseEventArgs) Handles Logs.MouseDown
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(e.X, e.Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None
+        End If
+    End Sub
+
+    Private Sub Logs_MouseUp(sender As Object, e As MouseEventArgs) Handles Logs.MouseUp
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(e.X, e.Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
+        End If
+    End Sub
+
     Private Sub Ignored_Logs_and_Search_Results_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If My.Settings.font IsNot Nothing Then
             Logs.DefaultCellStyle.Font = My.Settings.font

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -368,7 +368,7 @@ Public Class IgnoredLogsAndSearchResults
     Private Sub LoadData(strFileName As String)
         Dim stopWatch As Stopwatch = Stopwatch.StartNew
 
-        Invoke(Sub() Logs.Rows.Add(MakeDataGridRow(Now, "Loading data and populating data grid... Please Wait.", Logs)))
+        Logs.Invoke(Sub() Logs.Rows.Add(MakeDataGridRow(Now, "Loading data and populating data grid... Please Wait.", Logs)))
 
         Dim collectionOfSavedData As New List(Of SavedData)
 
@@ -384,12 +384,12 @@ Public Class IgnoredLogsAndSearchResults
                     listOfLogEntries.Add(item.MakeDataGridRow(Logs))
                 Next
 
-                Invoke(Sub()
-                           Logs.Rows.Clear()
-                           Logs.Rows.AddRange(listOfLogEntries.ToArray)
-                           LogsLoadedInLabel.Visible = True
-                           LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
-                       End Sub)
+                Logs.Invoke(Sub()
+                                Logs.Rows.Clear()
+                                Logs.Rows.AddRange(listOfLogEntries.ToArray)
+                                LogsLoadedInLabel.Visible = True
+                                LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
+                            End Sub)
             End If
         Catch ex As Newtonsoft.Json.JsonSerializationException
             SyslogParser.AddToLogList(Nothing, Net.IPAddress.Loopback.ToString, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -462,4 +462,20 @@ Public Class ViewLogBackups
     Private Sub ViewLogBackups_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         My.Settings.fileListColumnOrder = SaveColumnOrders(FileList.Columns)
     End Sub
+
+    Private Sub FileList_MouseDown(sender As Object, e As MouseEventArgs) Handles FileList.MouseDown
+        Dim hitTest As DataGridView.HitTestInfo = FileList.HitTest(e.X, e.Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            FileList.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None
+        End If
+    End Sub
+
+    Private Sub FileList_MouseUp(sender As Object, e As MouseEventArgs) Handles FileList.MouseUp
+        Dim hitTest As DataGridView.HitTestInfo = FileList.HitTest(e.X, e.Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            FileList.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
+        End If
+    End Sub
 End Class

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -273,6 +273,9 @@
             <setting name="columnFileNameSize" serializeAs="String">
                 <value>150</value>
             </setting>
+            <setting name="boolDebug" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Added code to hopefully improve performance while resizing columns in the various DataGridViews.
- Moved the invocation of code from the form object of the "Ignored Logs and Search Results" window to the logs DataGridView in hopes of improving performance upon load.
- Forgot to make the "Startup Delay" checkbox checked if there's a startup delay.
- Included some code optimizations when sending data to other instances of Free Syslog on the network.
- Removed the strNoProxyString constant, it's no longer used in the code.
- Put a null check for the serversList variable before launching into the thread to send syslog data to other instances of Free Syslog on the network.
- Forgot calls to UpdateLogCount() and SelectLatestLogEntry() in the "Check for Updates.vb" file.
- Added the ability to turn on debug data without the need for the program to be a debug build.
- Made it so that check for update data is only logged when debug mode is enabled or if the build is a debug build.
- Made it so that the check for update code is ran only after all log data is reloaded at program launch.