### PR TITLE
Version 3.8 Build 3

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.8.2.83")>
+<Assembly: AssemblyFileVersion("3.8.3.84")>

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -326,10 +326,7 @@ Namespace checkForUpdates
 
             If Not My.Computer.Network.IsAvailable Then
                 windowObject.Invoke(Sub()
-                                        If boolDebugBuild Or My.Settings.boolDebug Then
-                                            MakeLogEntry("No Internet connection detected.")
-                                        End If
-
+                                        MakeLogEntry("No Internet connection detected.")
                                         MsgBox("No Internet connection detected.", MsgBoxStyle.Information, strMessageBoxTitleText)
                                     End Sub)
             Else

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -281,9 +281,7 @@ Namespace checkForUpdates
                 Dim dblDOTNETVersion As Double = Double.Parse($"{Environment.Version.Major}.{Environment.Version.Minor}")
                 Dim strOSName As String
 
-                If intOSMajorVersion = 5 And intOSMinorVersion = 0 Then
-                    strOSName = "Windows 2000"
-                ElseIf intOSMajorVersion = 5 And intOSMinorVersion = 1 Then
+                If intOSMajorVersion = 5 And intOSMinorVersion = 1 Then
                     strOSName = "Windows XP"
                 ElseIf intOSMajorVersion = 6 And intOSMinorVersion = 0 Then
                     strOSName = "Windows Vista"

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -370,20 +370,26 @@ Namespace checkForUpdates
                                 MakeLogEntry($"There was an error when trying to parse the response from the server. The XML data from the server is below...{vbCrLf}{vbCrLf}{xmlData}")
                             End If
 
-                            If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("There was an error when trying to parse the response from the server.", MsgBoxStyle.Critical, strMessageBoxTitleText))
+                            If boolShowMessageBox Then
+                                windowObject.Invoke(Sub() MsgBox("There was an error when trying to parse the response from the server.", MsgBoxStyle.Critical, strMessageBoxTitleText))
+                            End If
                         ElseIf response = ProcessUpdateXMLResponse.newerVersionThanWebSite Then
                             If boolDebugBuild Or My.Settings.boolDebug Then
                                 MakeLogEntry("This is weird, you have a version that's newer than what's listed on the web site.")
                             End If
 
-                            If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("This is weird, you have a version that's newer than what's listed on the web site.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                            If boolShowMessageBox Then
+                                windowObject.Invoke(Sub() MsgBox("This is weird, you have a version that's newer than what's listed on the web site.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                            End If
                         End If
                     Else
                         If boolDebugBuild Or My.Settings.boolDebug Then
                             MakeLogEntry("There was an error checking for updates.")
                         End If
 
-                        If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("There was an error checking for updates.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                        If boolShowMessageBox Then
+                            windowObject.Invoke(Sub() MsgBox("There was an error checking for updates.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                        End If
                     End If
                 Catch ex As Exception
                     ' Ok, we crashed but who cares; but we log it.

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -365,18 +365,18 @@ Namespace checkForUpdates
                             If boolShowMessageBox Then
                                 windowObject.Invoke(Sub() MsgBox($"You already have the latest version, there is no need to update this program.{vbCrLf}{vbCrLf}Your current version is v{versionString}.", MsgBoxStyle.Information, strMessageBoxTitleText))
                             End If
-                        ElseIf (response = ProcessUpdateXMLResponse.parseError Or response = ProcessUpdateXMLResponse.exceptionError) AndAlso boolShowMessageBox Then
+                        ElseIf response = ProcessUpdateXMLResponse.parseError Or response = ProcessUpdateXMLResponse.exceptionError Then
                             If boolDebugBuild Or My.Settings.boolDebug Then
                                 MakeLogEntry($"There was an error when trying to parse the response from the server. The XML data from the server is below...{vbCrLf}{vbCrLf}{xmlData}")
                             End If
 
-                            windowObject.Invoke(Sub() MsgBox("There was an error when trying to parse the response from the server.", MsgBoxStyle.Critical, strMessageBoxTitleText))
-                        ElseIf response = ProcessUpdateXMLResponse.newerVersionThanWebSite AndAlso boolShowMessageBox Then
+                            If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("There was an error when trying to parse the response from the server.", MsgBoxStyle.Critical, strMessageBoxTitleText))
+                        ElseIf response = ProcessUpdateXMLResponse.newerVersionThanWebSite Then
                             If boolDebugBuild Or My.Settings.boolDebug Then
                                 MakeLogEntry("This is weird, you have a version that's newer than what's listed on the web site.")
                             End If
 
-                            windowObject.Invoke(Sub() MsgBox("This is weird, you have a version that's newer than what's listed on the web site.", MsgBoxStyle.Information, strMessageBoxTitleText))
+                            If boolShowMessageBox Then windowObject.Invoke(Sub() MsgBox("This is weird, you have a version that's newer than what's listed on the web site.", MsgBoxStyle.Information, strMessageBoxTitleText))
                         End If
                     Else
                         If boolDebugBuild Or My.Settings.boolDebug Then

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -107,31 +107,31 @@ Partial Class ViewLogBackups
         '
         Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.UnhideToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(113, 92)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(181, 114)
         '
         'DeleteToolStripMenuItem
         '
         Me.DeleteToolStripMenuItem.Name = "DeleteToolStripMenuItem"
-        Me.DeleteToolStripMenuItem.Size = New System.Drawing.Size(112, 22)
+        Me.DeleteToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.DeleteToolStripMenuItem.Text = "&Delete"
         '
         'ViewToolStripMenuItem
         '
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(112, 22)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.ViewToolStripMenuItem.Text = "&View"
         '
         'HideToolStripMenuItem
         '
         Me.HideToolStripMenuItem.Name = "HideToolStripMenuItem"
-        Me.HideToolStripMenuItem.Size = New System.Drawing.Size(112, 22)
+        Me.HideToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
         Me.HideToolStripMenuItem.Text = "Hide"
         '
         'UnhideToolStripMenuItem
         '
         Me.UnhideToolStripMenuItem.Name = "UnhideToolStripMenuItem"
-        Me.UnhideToolStripMenuItem.Size = New System.Drawing.Size(112, 22)
-        Me.UnhideToolStripMenuItem.Text = "Unhide"
+        Me.UnhideToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.UnhideToolStripMenuItem.Text = "Unhide/Show"
         '
         'BtnView
         '

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<img src="https://img.shields.io/badge/license-GPL-green"> <a href="https://hits.seeyoufarm.com"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Ftrparky%2FFree-SysLog&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false"/></a>
 # Free SysLog
 This is the open source repository for the Free SysLog program.
 ![image](https://github.com/trparky/Free-SysLog/assets/32105035/8b0783ef-c5b1-4450-870f-0af30c0ee23a)
@@ -7,4 +8,4 @@ As of October 24th, 2024, this project is now licensed under the GPL License.
 Please refer to the LICENSE file for the updated terms. Previous versions were licensed under the MIT License.
 
 ## Contributions
-We welcome contributions to Free SysLog! If you’ve made improvements or fixes, please submit a pull request. All contributions must comply with the GPLv3 license, which means any modifications you make should also be shared with the community.
+We welcome contributions to Free SysLog! If youâ€™ve made improvements or fixes, please submit a pull request. All contributions must comply with the GPLv3 license, which means any modifications you make should also be shared with the community.


### PR DESCRIPTION
- Made a change to a menu item on the "View Log Backups" window.
- Removed references to Windows 2000 from the GetFullOSVersionString() function in the "Check for Updates.vb" file.
- Additional bug fixes to the "Check for Updates.vb" file when it comes to debug logging.
- Made the "No Internet connection detected." log mandatory.
- Simplified some code in the "Check for Updates.vb" file.