### PR TITLE
Version 3.8 Build 6

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.8.5.86")>
+<Assembly: AssemblyFileVersion("3.8.6.87")>

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -127,18 +127,6 @@ Namespace checkForUpdates
             httpHelper.AddHTTPHeader("PROGRAM_VERSION", versionString)
             httpHelper.AddHTTPHeader("OPERATING_SYSTEM", GetFullOSVersionString())
 
-            httpHelper.SetURLPreProcessor = Function(strURLInput As String) As String
-                                                Try
-                                                    If Not strURLInput.Trim.StartsWith("http", StringComparison.OrdinalIgnoreCase) Then
-                                                        Return $"https://{strURLInput}"
-                                                    Else
-                                                        Return strURLInput
-                                                    End If
-                                                Catch ex As Exception
-                                                    Return strURLInput
-                                                End Try
-                                            End Function
-
             Return httpHelper
         End Function
 

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -203,6 +203,7 @@ Namespace checkForUpdates
                                         windowObject.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry(strLogText, windowObject.Logs))
                                         windowObject.UpdateLogCount()
                                         windowObject.SelectLatestLogEntry()
+                                        windowObject.BtnSaveLogsToDisk.Enabled = True
 
                                         If boolSaveLogData Then windowObject.SaveLogsToDiskSub()
                                     End Sub)

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -126,7 +126,6 @@ Namespace checkForUpdates
             httpHelper.AddHTTPHeader("PROGRAM_NAME", strProgramName)
             httpHelper.AddHTTPHeader("PROGRAM_VERSION", versionString)
             httpHelper.AddHTTPHeader("OPERATING_SYSTEM", GetFullOSVersionString())
-            If File.Exists("dontcount") Then httpHelper.AddHTTPCookie("dontcount", "True", "www.toms-world.org", False)
 
             httpHelper.SetURLPreProcessor = Function(strURLInput As String) As String
                                                 Try

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -22,9 +22,9 @@ Namespace checkForUpdates
 
     Class CheckForUpdatesClass
         ' Change these variables whenever you import this module into a program's code to handle software updates.
-        Private Const updaterURL As String = "www.toms-world.org/download/updater.exe"
-        Private Const updaterSHA256URL As String = "www.toms-world.org/download/updater.exe.sha2"
-        Private Const programUpdateCheckerXMLFile As String = "www.toms-world.org/updates/freesyslog_update.xml"
+        Private Const updaterURL As String = "https://www.toms-world.org/download/updater.exe"
+        Private Const updaterSHA256URL As String = "https://www.toms-world.org/download/updater.exe.sha2"
+        Private Const programUpdateCheckerXMLFile As String = "https://www.toms-world.org/updates/freesyslog_update.xml"
         Private Const programCode As String = "freesyslog"
         ' Change these variables whenever you import this module into a program's code to handle software updates.
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -102,6 +102,9 @@ Namespace SyslogParser
             ParentForm.Invoke(Sub()
                                   SyncLock ParentForm.dataGridLockObject
                                       ParentForm.Logs.Rows.Add(MakeLocalDataGridRowEntry(strLogText, ParentForm.Logs))
+                                      ParentForm.UpdateLogCount()
+                                      ParentForm.SelectLatestLogEntry()
+                                      ParentForm.BtnSaveLogsToDisk.Enabled = True
                                       If ParentForm.intSortColumnIndex = 0 And ParentForm.sortOrder = SortOrder.Descending Then ParentForm.SortLogsByDateObjectNoLocking(ParentForm.intSortColumnIndex, SortOrder.Descending)
                                   End SyncLock
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -67,7 +67,9 @@ Public Class Form1
 
             Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The program deleted {oldLogCount:N0} log {If(oldLogCount = 1, "entry", "entries")} at midnight.", Logs))
 
+            UpdateLogCount()
             SelectLatestLogEntry()
+            BtnSaveLogsToDisk.Enabled = True
 
             NumberOfLogs.Text = $"Number of Log Entries: {Logs.Rows.Count:N0}"
         End SyncLock
@@ -1686,6 +1688,9 @@ Public Class Form1
 
         If boolDebugBuild Or ChkDebug.Checked Then
             Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Restore command received.", Logs))
+            SelectLatestLogEntry()
+            UpdateLogCount()
+            BtnSaveLogsToDisk.Enabled = True
         End If
 
         SelectLatestLogEntry()


### PR DESCRIPTION
- Added code to re-enable the "Save Logs to Disk" menu item.
- Removed the "dontcount" cookie from the check for update code.
- Removed the URL String Pre-Processor function from the check for update code.
- Made all URLs used for checking for updates HTTPS URLs since we no longer have to deal with Windows XP that doesn't support modern SSL encryption methods.