### PR TITLE
Version 3.9 Build 1

### DIFF
--- a/Free SysLog/FodyWeavers.xml
+++ b/Free SysLog/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
-</Weavers>

--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -141,6 +141,12 @@
     <Compile Include="Windows\Clear logs older than.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Windows\Close Free SysLog Dialog.Designer.vb">
+      <DependentUpon>Close Free SysLog Dialog.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\Close Free SysLog Dialog.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Windows\Configure SysLog Mirror Clients.Designer.vb">
       <DependentUpon>Configure SysLog Mirror Clients.vb</DependentUpon>
     </Compile>
@@ -243,6 +249,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\Clear logs older than.resx">
       <DependentUpon>Clear logs older than.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Windows\Close Free SysLog Dialog.resx">
+      <DependentUpon>Close Free SysLog Dialog.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\Configure SysLog Mirror Clients.resx">
       <DependentUpon>Configure SysLog Mirror Clients.vb</DependentUpon>

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.8.6.87")>
+<Assembly: AssemblyFileVersion("3.9.1.88")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.12.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -1158,6 +1158,18 @@ Namespace My
             End Get
             Set
                 Me("ConfirmDelete") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property IgnoreSearchResultLimits() As Boolean
+            Get
+                Return CType(Me("IgnoreSearchResultLimits"),Boolean)
+            End Get
+            Set
+                Me("IgnoreSearchResultLimits") = value
             End Set
         End Property
     End Class

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -281,5 +281,8 @@
     <Setting Name="ConfirmDelete" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="IgnoreSearchResultLimits" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -51,7 +51,9 @@ Public Class Alerts_History
                 listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList))
             Next
 
+            AlertHistoryList.SuspendLayout()
             AlertHistoryList.Rows.AddRange(listOfDataRows.ToArray)
+            AlertHistoryList.ResumeLayout()
         End If
 
         boolDoneLoading = True
@@ -114,8 +116,10 @@ Public Class Alerts_History
                         listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList))
                     Next
 
+                    AlertHistoryList.SuspendLayout()
                     AlertHistoryList.Rows.Clear()
                     AlertHistoryList.Rows.AddRange(listOfDataRows.ToArray)
+                    AlertHistoryList.ResumeLayout()
                 End If
             End With
         End If

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -5,28 +5,13 @@ Public Class Alerts
     Public boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
 
-    Private Function GetToolTipIconImage(icon As ToolTipIcon) As Image
-        Select Case icon
-            Case ToolTipIcon.None
-                Return Nothing
-            Case ToolTipIcon.Info
-                Return SystemIcons.Information.ToBitmap()
-            Case ToolTipIcon.Warning
-                Return SystemIcons.Warning.ToBitmap()
-            Case ToolTipIcon.Error
-                Return SystemIcons.Error.ToBitmap()
-            Case Else
-                Return Nothing
-        End Select
-    End Function
-
     Private Sub AlertTypeComboBox_SelectedIndexChanged(sender As Object, e As EventArgs) Handles AlertTypeComboBox.SelectedIndexChanged
         If AlertTypeComboBox.SelectedIndex = 0 Then
-            IconPictureBox.Image = GetToolTipIconImage(ToolTipIcon.Warning)
+            IconPictureBox.Image = SystemIcons.Warning.ToBitmap()
         ElseIf AlertTypeComboBox.SelectedIndex = 1 Then
-            IconPictureBox.Image = GetToolTipIconImage(ToolTipIcon.Error)
+            IconPictureBox.Image = SystemIcons.Error.ToBitmap()
         ElseIf AlertTypeComboBox.SelectedIndex = 2 Then
-            IconPictureBox.Image = GetToolTipIconImage(ToolTipIcon.Info)
+            IconPictureBox.Image = SystemIcons.Information.ToBitmap()
         ElseIf AlertTypeComboBox.SelectedIndex = 3 Then
             IconPictureBox.Image = Nothing
         End If
@@ -132,13 +117,13 @@ Public Class Alerts
             ChkRegex.Checked = selectedItemObject.BoolRegex
 
             If selectedItemObject.AlertType = AlertType.Warning Then
-                IconPictureBox.Image = GetToolTipIconImage(ToolTipIcon.Warning)
+                IconPictureBox.Image = SystemIcons.Warning.ToBitmap()
                 AlertTypeComboBox.SelectedIndex = 0
             ElseIf selectedItemObject.AlertType = AlertType.ErrorMsg Then
-                IconPictureBox.Image = GetToolTipIconImage(ToolTipIcon.Error)
+                IconPictureBox.Image = SystemIcons.Error.ToBitmap()
                 AlertTypeComboBox.SelectedIndex = 1
             ElseIf selectedItemObject.AlertType = AlertType.Info Then
-                IconPictureBox.Image = GetToolTipIconImage(ToolTipIcon.Info)
+                IconPictureBox.Image = SystemIcons.Information.ToBitmap()
                 AlertTypeComboBox.SelectedIndex = 2
             ElseIf selectedItemObject.AlertType = AlertType.None Then
                 IconPictureBox.Image = Nothing

--- a/Free SysLog/Windows/Clear logs older than.vb
+++ b/Free SysLog/Windows/Clear logs older than.vb
@@ -1,6 +1,5 @@
 ﻿Public Class ClearLogsOlderThan
     Public dateChosenDate As Date
-    Public boolSuccess As Boolean = False
 
     Private Sub Clear_logs_older_than_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         DateTimePicker.MinDate = Date.Now.AddDays(-15)
@@ -14,10 +13,13 @@
 
     Private Sub DateTimePicker_ValueChanged(sender As Object, e As EventArgs) Handles DateTimePicker.ValueChanged
         BtnClearLogs.Enabled = True
-        boolSuccess = True
+        DialogResult = DialogResult.OK
     End Sub
 
     Private Sub Clear_logs_older_than_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
-        If e.KeyCode = Keys.Escape Then Close()
+        If e.KeyCode = Keys.Escape Then
+            DialogResult = DialogResult.Cancel
+            Close()
+        End If
     End Sub
 End Class

--- a/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
@@ -1,0 +1,115 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class CloseFreeSysLogDialog
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.Panel1 = New System.Windows.Forms.Panel()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.PictureBox1 = New System.Windows.Forms.PictureBox()
+        Me.BtnNo = New System.Windows.Forms.Button()
+        Me.BtnYes = New System.Windows.Forms.Button()
+        Me.BtnMinimize = New System.Windows.Forms.Button()
+        Me.Panel1.SuspendLayout()
+        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
+        '
+        'Panel1
+        '
+        Me.Panel1.BackColor = System.Drawing.Color.White
+        Me.Panel1.Controls.Add(Me.Label1)
+        Me.Panel1.Controls.Add(Me.PictureBox1)
+        Me.Panel1.Location = New System.Drawing.Point(0, 0)
+        Me.Panel1.Name = "Panel1"
+        Me.Panel1.Size = New System.Drawing.Size(293, 58)
+        Me.Panel1.TabIndex = 2
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.Location = New System.Drawing.Point(50, 14)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(220, 13)
+        Me.Label1.TabIndex = 3
+        Me.Label1.Text = "Are you sure you want to close Free SysLog?"
+        '
+        'PictureBox1
+        '
+        Me.PictureBox1.Location = New System.Drawing.Point(12, 14)
+        Me.PictureBox1.Name = "PictureBox1"
+        Me.PictureBox1.Size = New System.Drawing.Size(32, 32)
+        Me.PictureBox1.TabIndex = 2
+        Me.PictureBox1.TabStop = False
+        '
+        'BtnNo
+        '
+        Me.BtnNo.Location = New System.Drawing.Point(123, 64)
+        Me.BtnNo.Name = "BtnNo"
+        Me.BtnNo.Size = New System.Drawing.Size(75, 23)
+        Me.BtnNo.TabIndex = 0
+        Me.BtnNo.Text = "&No"
+        Me.BtnNo.UseVisualStyleBackColor = True
+        '
+        'BtnYes
+        '
+        Me.BtnYes.Location = New System.Drawing.Point(42, 64)
+        Me.BtnYes.Name = "BtnYes"
+        Me.BtnYes.Size = New System.Drawing.Size(75, 23)
+        Me.BtnYes.TabIndex = 2
+        Me.BtnYes.Text = "&Yes"
+        Me.BtnYes.UseVisualStyleBackColor = True
+        '
+        'BtnMinimize
+        '
+        Me.BtnMinimize.Location = New System.Drawing.Point(204, 64)
+        Me.BtnMinimize.Name = "BtnMinimize"
+        Me.BtnMinimize.Size = New System.Drawing.Size(75, 23)
+        Me.BtnMinimize.TabIndex = 1
+        Me.BtnMinimize.Text = "&Minimize"
+        Me.BtnMinimize.UseVisualStyleBackColor = True
+        '
+        'CloseFreeSysLogDialog
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(291, 96)
+        Me.Controls.Add(Me.BtnMinimize)
+        Me.Controls.Add(Me.BtnYes)
+        Me.Controls.Add(Me.BtnNo)
+        Me.Controls.Add(Me.Panel1)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "CloseFreeSysLogDialog"
+        Me.Text = "Close Free SysLog?"
+        Me.Panel1.ResumeLayout(False)
+        Me.Panel1.PerformLayout()
+        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.ResumeLayout(False)
+
+    End Sub
+    Friend WithEvents Panel1 As Panel
+    Friend WithEvents Label1 As Label
+    Friend WithEvents PictureBox1 As PictureBox
+    Friend WithEvents BtnNo As Button
+    Friend WithEvents BtnYes As Button
+    Friend WithEvents BtnMinimize As Button
+End Class

--- a/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
@@ -30,6 +30,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnYes = New System.Windows.Forms.Button()
         Me.BtnMinimize = New System.Windows.Forms.Button()
         Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ChkConfirmClose = New System.Windows.Forms.CheckBox()
         Me.Panel1.SuspendLayout()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -91,11 +92,22 @@ Partial Class CloseFreeSysLogDialog
         Me.ToolTip.SetToolTip(Me.BtnMinimize, "Can be activated by pressing the M key.")
         Me.BtnMinimize.UseVisualStyleBackColor = True
         '
+        'ChkConfirmClose
+        '
+        Me.ChkConfirmClose.AutoSize = True
+        Me.ChkConfirmClose.Location = New System.Drawing.Point(12, 93)
+        Me.ChkConfirmClose.Name = "ChkConfirmClose"
+        Me.ChkConfirmClose.Size = New System.Drawing.Size(90, 17)
+        Me.ChkConfirmClose.TabIndex = 3
+        Me.ChkConfirmClose.Text = "Confirm Close"
+        Me.ChkConfirmClose.UseVisualStyleBackColor = True
+        '
         'CloseFreeSysLogDialog
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(291, 96)
+        Me.ClientSize = New System.Drawing.Size(291, 116)
+        Me.Controls.Add(Me.ChkConfirmClose)
         Me.Controls.Add(Me.BtnMinimize)
         Me.Controls.Add(Me.BtnYes)
         Me.Controls.Add(Me.BtnNo)
@@ -110,6 +122,7 @@ Partial Class CloseFreeSysLogDialog
         Me.Panel1.PerformLayout()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
+        Me.PerformLayout()
 
     End Sub
     Friend WithEvents Panel1 As Panel
@@ -119,4 +132,5 @@ Partial Class CloseFreeSysLogDialog
     Friend WithEvents BtnYes As Button
     Friend WithEvents BtnMinimize As Button
     Friend WithEvents ToolTip As ToolTip
+    Friend WithEvents ChkConfirmClose As CheckBox
 End Class

--- a/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
@@ -22,12 +22,14 @@ Partial Class CloseFreeSysLogDialog
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.Panel1 = New System.Windows.Forms.Panel()
         Me.Label1 = New System.Windows.Forms.Label()
         Me.PictureBox1 = New System.Windows.Forms.PictureBox()
         Me.BtnNo = New System.Windows.Forms.Button()
         Me.BtnYes = New System.Windows.Forms.Button()
         Me.BtnMinimize = New System.Windows.Forms.Button()
+        Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
         Me.Panel1.SuspendLayout()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -66,6 +68,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnNo.Size = New System.Drawing.Size(75, 23)
         Me.BtnNo.TabIndex = 0
         Me.BtnNo.Text = "&No"
+        Me.ToolTip.SetToolTip(Me.BtnNo, "Can be activated by pressing the N key.")
         Me.BtnNo.UseVisualStyleBackColor = True
         '
         'BtnYes
@@ -75,6 +78,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnYes.Size = New System.Drawing.Size(75, 23)
         Me.BtnYes.TabIndex = 2
         Me.BtnYes.Text = "&Yes"
+        Me.ToolTip.SetToolTip(Me.BtnYes, "Can be activated by pressing the Y key.")
         Me.BtnYes.UseVisualStyleBackColor = True
         '
         'BtnMinimize
@@ -84,6 +88,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnMinimize.Size = New System.Drawing.Size(75, 23)
         Me.BtnMinimize.TabIndex = 1
         Me.BtnMinimize.Text = "&Minimize"
+        Me.ToolTip.SetToolTip(Me.BtnMinimize, "Can be activated by pressing the M key.")
         Me.BtnMinimize.UseVisualStyleBackColor = True
         '
         'CloseFreeSysLogDialog
@@ -113,4 +118,5 @@ Partial Class CloseFreeSysLogDialog
     Friend WithEvents BtnNo As Button
     Friend WithEvents BtnYes As Button
     Friend WithEvents BtnMinimize As Button
+    Friend WithEvents ToolTip As ToolTip
 End Class

--- a/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
@@ -96,6 +96,7 @@ Partial Class CloseFreeSysLogDialog
         Me.Controls.Add(Me.BtnNo)
         Me.Controls.Add(Me.Panel1)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "CloseFreeSysLogDialog"

--- a/Free SysLog/Windows/Close Free SysLog Dialog.resx
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.resx
@@ -120,4 +120,7 @@
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Free SysLog/Windows/Close Free SysLog Dialog.resx
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Free SysLog/Windows/Close Free SysLog Dialog.resx
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Free SysLog/Windows/Close Free SysLog Dialog.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.vb
@@ -1,8 +1,10 @@
 ﻿Public Class CloseFreeSysLogDialog
+    Public Property MyParentForm As Form1
 
     Private Sub Close_Free_SysLog_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         Media.SystemSounds.Asterisk.Play()
         PictureBox1.Image = SystemIcons.Question.ToBitmap()
+        ChkConfirmClose.Checked = My.Settings.boolConfirmClose
     End Sub
 
     Private Sub BtnYes_Click(sender As Object, e As EventArgs) Handles BtnYes.Click
@@ -28,5 +30,10 @@
         ElseIf e.KeyCode = Keys.M Then
             BtnMinimize.PerformClick()
         End If
+    End Sub
+
+    Private Sub ChkConfirmClose_Click(sender As Object, e As EventArgs) Handles ChkConfirmClose.Click
+        My.Settings.boolConfirmClose = ChkConfirmClose.Checked
+        If MyParentForm IsNot Nothing Then MyParentForm.ChkEnableConfirmCloseToolStripItem.Checked = ChkConfirmClose.Checked
     End Sub
 End Class

--- a/Free SysLog/Windows/Close Free SysLog Dialog.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.vb
@@ -1,0 +1,22 @@
+﻿Public Class CloseFreeSysLogDialog
+
+    Private Sub Close_Free_SysLog_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Media.SystemSounds.Asterisk.Play()
+        PictureBox1.Image = SystemIcons.Question.ToBitmap()
+    End Sub
+
+    Private Sub BtnYes_Click(sender As Object, e As EventArgs) Handles BtnYes.Click
+        DialogResult = DialogResult.Yes
+        Close()
+    End Sub
+
+    Private Sub BtnNo_Click(sender As Object, e As EventArgs) Handles BtnNo.Click
+        DialogResult = DialogResult.No
+        Close()
+    End Sub
+
+    Private Sub BtnMinimize_Click(sender As Object, e As EventArgs) Handles BtnMinimize.Click
+        DialogResult = DialogResult.Cancel
+        Close()
+    End Sub
+End Class

--- a/Free SysLog/Windows/Close Free SysLog Dialog.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.vb
@@ -19,4 +19,14 @@
         DialogResult = DialogResult.Cancel
         Close()
     End Sub
+
+    Private Sub CloseFreeSysLogDialog_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
+        If e.KeyCode = Keys.Y Then
+            BtnYes.PerformClick()
+        ElseIf e.KeyCode = Keys.N Then
+            BtnNo.PerformClick()
+        ElseIf e.KeyCode = Keys.M Then
+            BtnMinimize.PerformClick()
+        End If
+    End Sub
 End Class

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -489,8 +489,10 @@ Public Class Form1
 
                 SyncLock dataGridLockObject
                     Invoke(Sub()
+                               Logs.SuspendLayout()
                                Logs.Rows.Clear()
                                Logs.Rows.AddRange(listOfLogEntries.ToArray)
+                               Logs.ResumeLayout()
 
                                SelectLatestLogEntry()
 
@@ -519,6 +521,7 @@ Public Class Form1
 
         SyncLock dataGridLockObject
             Invoke(Sub()
+                       Logs.SuspendLayout()
                        Logs.Rows.Clear()
 
                        Dim listOfLogEntries As New List(Of MyDataGridViewRow) From {
@@ -528,6 +531,7 @@ Public Class Form1
                        }
 
                        Logs.Rows.AddRange(listOfLogEntries.ToArray)
+                       Logs.ResumeLayout()
                        UpdateLogCount()
                    End Sub)
         End SyncLock
@@ -840,8 +844,10 @@ Public Class Form1
 
         Array.Sort(rows, Function(row1 As MyDataGridViewRow, row2 As MyDataGridViewRow) comparer.Compare(row1, row2))
 
+        Logs.SuspendLayout()
         Logs.Rows.Clear()
         Logs.Rows.AddRange(rows)
+        Logs.ResumeLayout()
 
         Logs.Enabled = True
         Logs.AllowUserToOrderColumns = True
@@ -927,11 +933,14 @@ Public Class Form1
 
                         If MsgBox("Do you want to make a backup of the logs before deleting them?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then MakeLogBackup()
 
+                        Logs.SuspendLayout()
                         Logs.Rows.Clear()
                         Logs.Rows.AddRange(newListOfLogs.ToArray)
 
                         Dim intCountDifference As Integer = intOldCount - Logs.Rows.Count
                         Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {intCountDifference:N0} log {If(intCountDifference = 1, "entry", "entries")}.", Logs))
+
+                        Logs.ResumeLayout()
 
                         SelectLatestLogEntry()
                     End SyncLock
@@ -1036,11 +1045,14 @@ Public Class Form1
                 Logs.Enabled = True
                 Logs.AllowUserToOrderColumns = True
 
+                Logs.SuspendLayout()
                 Logs.Rows.Clear()
                 Logs.Rows.AddRange(newListOfLogs.ToArray)
 
                 Dim intCountDifference As Integer = intOldCount - Logs.Rows.Count
                 Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {intCountDifference:N0} log {If(intCountDifference = 1, "entry", "entries")}.", Logs))
+
+                Logs.ResumeLayout()
 
                 SelectLatestLogEntry()
             End SyncLock

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -922,7 +922,7 @@ Public Class Form1
             ClearLogsOlderThanInstance.LblLogCount.Text = $"Number of Log Entries: {Logs.Rows.Count:N0}"
             ClearLogsOlderThanInstance.ShowDialog(Me)
 
-            If ClearLogsOlderThanInstance.boolSuccess Then
+            If ClearLogsOlderThanInstance.DialogResult = DialogResult.OK Then
                 Try
                     Dim dateChosenDate As Date = ClearLogsOlderThanInstance.dateChosenDate
 
@@ -1260,7 +1260,7 @@ Public Class Form1
 
                 IntegerInputForm.ShowDialog(Me)
 
-                If IntegerInputForm.boolSuccess Then
+                If IntegerInputForm.DialogResult = DialogResult.OK Then
                     If IntegerInputForm.intResult < 1 Or IntegerInputForm.intResult > 65535 Then
                         MsgBox("The port number must be in the range of 1 - 65535.", MsgBoxStyle.Critical, Text)
                     Else
@@ -1299,7 +1299,7 @@ Public Class Form1
 
             IntegerInputForm.ShowDialog(Me)
 
-            If IntegerInputForm.boolSuccess Then
+            If IntegerInputForm.DialogResult = DialogResult.OK Then
                 ChangeLogAutosaveIntervalToolStripMenuItem.Text = $"Change Log Autosave Interval ({IntegerInputForm.intResult} Minutes)"
                 SaveTimer.Interval = TimeSpan.FromMinutes(IntegerInputForm.intResult).TotalMilliseconds
                 My.Settings.autoSaveMinutes = IntegerInputForm.intResult
@@ -1416,7 +1416,7 @@ Public Class Form1
 
             IntegerInputForm.ShowDialog(Me)
 
-            If IntegerInputForm.boolSuccess Then
+            If IntegerInputForm.DialogResult = DialogResult.OK Then
                 If IntegerInputForm.intResult < 1 Or IntegerInputForm.intResult > 300 Then
                     MsgBox("The time in seconds must be in the range of 1 - 300.", MsgBoxStyle.Critical, Text)
                 Else
@@ -1531,7 +1531,7 @@ Public Class Form1
 
             IntegerInputForm.ShowDialog(Me)
 
-            If IntegerInputForm.boolSuccess Then
+            If IntegerInputForm.DialogResult = DialogResult.OK Then
                 If IntegerInputForm.intResult < 30 Or IntegerInputForm.intResult > 240 Then
                     MsgBox("The time in seconds must be in the range of 30 - 240.", MsgBoxStyle.Critical, Text)
                 Else

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -709,6 +709,8 @@ Public Class Form1
         If e.CloseReason = CloseReason.UserClosing AndAlso My.Settings.boolConfirmClose Then
             Using CloseFreeSysLog As New CloseFreeSysLogDialog()
                 CloseFreeSysLog.StartPosition = FormStartPosition.CenterParent
+                CloseFreeSysLog.MyParentForm = Me
+
                 Dim result As DialogResult = CloseFreeSysLog.ShowDialog(Me)
 
                 If result = DialogResult.No Then

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -706,9 +706,20 @@ Public Class Form1
     End Sub
 
     Private Sub Form1_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
-        If e.CloseReason = CloseReason.UserClosing AndAlso My.Settings.boolConfirmClose AndAlso MsgBox("Are you sure you want to close Free SysLog?", MsgBoxStyle.YesNo + MsgBoxStyle.Question + vbDefaultButton2, Text) = MsgBoxResult.No Then
-            e.Cancel = True
-            Exit Sub
+        If e.CloseReason = CloseReason.UserClosing AndAlso My.Settings.boolConfirmClose Then
+            Using CloseFreeSysLog As New CloseFreeSysLogDialog()
+                CloseFreeSysLog.StartPosition = FormStartPosition.CenterParent
+                Dim result As DialogResult = CloseFreeSysLog.ShowDialog(Me)
+
+                If result = DialogResult.No Then
+                    e.Cancel = True
+                    Exit Sub
+                ElseIf result = DialogResult.Cancel Then
+                    WindowState = FormWindowState.Minimized
+                    e.Cancel = True
+                    Exit Sub
+                End If
+            End Using
         End If
 
         If e.CloseReason = CloseReason.WindowsShutDown Then

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -415,8 +415,7 @@ Public Class Form1
                                                                            Invoke(Sub() RestoreWindow())
                                                                        ElseIf argsDictionary("action").ToString.Equals(strViewLog, StringComparison.OrdinalIgnoreCase) AndAlso argsDictionary.ContainsKey("datapacket") Then
                                                                            Try
-                                                                               Dim strDataPacket As String = argsDictionary("datapacket")
-                                                                               Dim NotificationDataPacket As NotificationDataPacket = Newtonsoft.Json.JsonConvert.DeserializeObject(Of NotificationDataPacket)(strDataPacket, JSONDecoderSettingsForSettingsFiles)
+                                                                               Dim NotificationDataPacket As NotificationDataPacket = Newtonsoft.Json.JsonConvert.DeserializeObject(Of NotificationDataPacket)(argsDictionary("datapacket").ToString, JSONDecoderSettingsForSettingsFiles)
 
                                                                                OpenLogViewerWindow(NotificationDataPacket.logtext, NotificationDataPacket.alerttext, NotificationDataPacket.logdate, NotificationDataPacket.sourceip, NotificationDataPacket.rawlogtext)
                                                                            Catch ex As Exception

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -199,9 +199,7 @@ Public Class IgnoredLogsAndSearchResults
             Logs.SuspendLayout()
 
             Task.Run(Sub()
-                         Dim intTotalEntries As Integer = LogsToBeDisplayed.Count
-
-                         For index As Integer = 0 To intTotalEntries - 1 Step intBatchSize
+                         For index As Integer = 0 To LogsToBeDisplayed.Count - 1 Step intBatchSize
                              Dim batch As MyDataGridViewRow() = LogsToBeDisplayed.Skip(index).Take(intBatchSize).ToArray()
                              Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                          Next
@@ -407,9 +405,7 @@ Public Class IgnoredLogsAndSearchResults
                                 Logs.Rows.Clear()
 
                                 Task.Run(Sub()
-                                             Dim intTotalEntries As Integer = listOfLogEntries.Count
-
-                                             For index As Integer = 0 To intTotalEntries - 1 Step intBatchSize
+                                             For index As Integer = 0 To listOfLogEntries.Count - 1 Step intBatchSize
                                                  Dim batch As MyDataGridViewRow() = listOfLogEntries.Skip(index).Take(intBatchSize).ToArray()
                                                  Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                                              Next

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -76,8 +76,10 @@ Public Class IgnoredLogsAndSearchResults
 
             Array.Sort(rows, Function(row1 As MyDataGridViewRow, row2 As MyDataGridViewRow) comparer.Compare(row1, row2))
 
+            Logs.SuspendLayout()
             Logs.Rows.Clear()
             Logs.Rows.AddRange(rows)
+            Logs.ResumeLayout()
 
             Logs.Enabled = True
             Logs.AllowUserToOrderColumns = True
@@ -189,8 +191,10 @@ Public Class IgnoredLogsAndSearchResults
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 
         If _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
+            Logs.SuspendLayout()
             Logs.Rows.AddRange(LogsToBeDisplayed.ToArray())
             SortLogsByDateObject(0, SortOrder.Ascending)
+            Logs.ResumeLayout()
 
             If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
                 LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
@@ -385,8 +389,10 @@ Public Class IgnoredLogsAndSearchResults
                 Next
 
                 Logs.Invoke(Sub()
+                                Logs.SuspendLayout()
                                 Logs.Rows.Clear()
                                 Logs.Rows.AddRange(listOfLogEntries.ToArray)
+                                Logs.ResumeLayout()
                                 LogsLoadedInLabel.Visible = True
                                 LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
                             End Sub)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -205,10 +205,12 @@ Public Class IgnoredLogsAndSearchResults
                              Dim batch As MyDataGridViewRow() = LogsToBeDisplayed.Skip(index).Take(intBatchSize).ToArray()
                              Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                          Next
-                     End Sub)
 
-            SortLogsByDateObject(0, SortOrder.Ascending)
-            Logs.ResumeLayout()
+                         Logs.Invoke(Sub()
+                                         SortLogsByDateObject(0, SortOrder.Ascending)
+                                         Logs.ResumeLayout()
+                                     End Sub)
+                     End Sub)
 
             If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
                 LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
@@ -411,10 +413,13 @@ Public Class IgnoredLogsAndSearchResults
                                                  Dim batch As MyDataGridViewRow() = listOfLogEntries.Skip(index).Take(intBatchSize).ToArray()
                                                  Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                                              Next
+
+                                             Logs.Invoke(Sub()
+                                                             SortLogsByDateObject(0, SortOrder.Ascending)
+                                                             Logs.ResumeLayout()
+                                                         End Sub)
                                          End Sub)
 
-                                SortLogsByDateObject(0, SortOrder.Ascending)
-                                Logs.ResumeLayout()
                                 LogsLoadedInLabel.Visible = True
                                 LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
                             End Sub)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -196,6 +196,8 @@ Public Class IgnoredLogsAndSearchResults
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 
         If _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
+            LogsToBeDisplayed.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
+
             Logs.SuspendLayout()
 
             Task.Run(Sub()
@@ -204,10 +206,7 @@ Public Class IgnoredLogsAndSearchResults
                              Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                          Next
 
-                         Logs.Invoke(Sub()
-                                         SortLogsByDateObject(0, SortOrder.Ascending)
-                                         Logs.ResumeLayout()
-                                     End Sub)
+                         Logs.Invoke(Sub() Logs.ResumeLayout())
                      End Sub)
 
             If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
@@ -401,6 +400,8 @@ Public Class IgnoredLogsAndSearchResults
                 Next
 
                 Logs.Invoke(Sub()
+                                listOfLogEntries.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
+
                                 Logs.SuspendLayout()
                                 Logs.Rows.Clear()
 
@@ -410,10 +411,7 @@ Public Class IgnoredLogsAndSearchResults
                                                  Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                                              Next
 
-                                             Logs.Invoke(Sub()
-                                                             SortLogsByDateObject(0, SortOrder.Ascending)
-                                                             Logs.ResumeLayout()
-                                                         End Sub)
+                                             Logs.Invoke(Sub() Logs.ResumeLayout())
                                          End Sub)
 
                                 LogsLoadedInLabel.Visible = True

--- a/Free SysLog/Windows/Integer Input Form.vb
+++ b/Free SysLog/Windows/Integer Input Form.vb
@@ -1,5 +1,4 @@
 ﻿Public Class IntegerInputForm
-    Public boolSuccess As Boolean = False
     Public intResult As Integer
     Private intMin, intMax As Integer
 
@@ -14,7 +13,7 @@
 
     Private Sub BtnSave_Click(sender As Object, e As EventArgs) Handles BtnSave.Click
         If Integer.TryParse(TxtSetting.Text, intResult) Then
-            boolSuccess = True
+            DialogResult = DialogResult.OK
             Close()
         Else
             MsgBox("Invalid user input!", MsgBoxStyle.Critical, Text)
@@ -42,10 +41,14 @@
     End Sub
 
     Private Sub BtnCancel_Click(sender As Object, e As EventArgs) Handles BtnCancel.Click
+        DialogResult = DialogResult.Cancel
         Close()
     End Sub
 
     Private Sub IntegerInputForm_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
-        If e.KeyData = Keys.Escape Then Close()
+        If e.KeyData = Keys.Escape Then
+            DialogResult = DialogResult.Cancel
+            Close()
+        End If
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -47,6 +47,8 @@ Partial Class ViewLogBackups
         Me.colEntryCount = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.HideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UnhideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ChkIgnoreSearchResultsLimits = New System.Windows.Forms.CheckBox()
         Me.lblNumberOfHiddenFiles = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblTotalNumberOfHiddenLogs = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
@@ -291,11 +293,24 @@ Partial Class ViewLogBackups
         Me.LblTotalDiskSpace.Size = New System.Drawing.Size(123, 17)
         Me.LblTotalDiskSpace.Text = "Total Disk Space Used:"
         '
+        'ChkIgnoreSearchResultsLimits
+        '
+        Me.ChkIgnoreSearchResultsLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkIgnoreSearchResultsLimits.AutoSize = True
+        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(556, 321)
+        Me.ChkIgnoreSearchResultsLimits.Name = "ChkIgnoreSearchResultsLimits"
+        Me.ChkIgnoreSearchResultsLimits.Size = New System.Drawing.Size(160, 17)
+        Me.ChkIgnoreSearchResultsLimits.TabIndex = 37
+        Me.ChkIgnoreSearchResultsLimits.Text = "Ignore Search Results Limits"
+        Me.ToolTip.SetToolTip(Me.ChkIgnoreSearchResultsLimits, "Warning: Enabling this could cause performance issues.")
+        Me.ChkIgnoreSearchResultsLimits.UseVisualStyleBackColor = True
+        '
         'ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(954, 364)
+        Me.Controls.Add(Me.ChkIgnoreSearchResultsLimits)
         Me.Controls.Add(Me.ChkShowHiddenAsGray)
         Me.Controls.Add(Me.ChkShowHidden)
         Me.Controls.Add(Me.ChkCaseInsensitiveSearch)
@@ -350,4 +365,6 @@ Partial Class ViewLogBackups
     Friend WithEvents lblTotalNumberOfHiddenLogs As ToolStripStatusLabel
     Friend WithEvents LblTotalDiskSpace As ToolStripStatusLabel
     Friend WithEvents colEntryCount As DataGridViewTextBoxColumn
+    Friend WithEvents ToolTip As ToolTip
+    Friend WithEvents ChkIgnoreSearchResultsLimits As CheckBox
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -72,7 +72,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(559, 272)
+        Me.FileList.Size = New System.Drawing.Size(929, 272)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -295,7 +295,7 @@ Partial Class ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(584, 364)
+        Me.ClientSize = New System.Drawing.Size(954, 364)
         Me.Controls.Add(Me.ChkShowHiddenAsGray)
         Me.Controls.Add(Me.ChkShowHidden)
         Me.Controls.Add(Me.ChkCaseInsensitiveSearch)
@@ -311,7 +311,7 @@ Partial Class ViewLogBackups
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(600, 403)
+        Me.MinimumSize = New System.Drawing.Size(970, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)

--- a/Free SysLog/Windows/ViewLogBackups.resx
+++ b/Free SysLog/Windows/ViewLogBackups.resx
@@ -135,4 +135,7 @@
   <metadata name="colHidden.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>290, 17</value>
+  </metadata>
 </root>

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -272,6 +272,7 @@ Public Class ViewLogBackups
             Exit Sub
         End If
 
+        Dim boolShowSearchResults As Boolean = True
         Dim listOfSearchResults As New HashSet(Of MyDataGridViewRow)()
         Dim listOfSearchResults2 As New List(Of MyDataGridViewRow)
         Dim regexCompiledObject As Regex = Nothing
@@ -336,6 +337,12 @@ Public Class ViewLogBackups
                                               End If
                                           Next
 
+                                          If listOfSearchResults.Count > 4000 Then
+                                              MsgBox($"Your search results contains more than four thousand results. It's highly recommended that you narrow your search terms.{vbCrLf}{vbCrLf}Search aborted.", MsgBoxStyle.Information, Text)
+                                              boolShowSearchResults = False
+                                              Exit Sub
+                                          End If
+
                                           listOfSearchResults2 = listOfSearchResults.Distinct().ToList().OrderBy(Function(row) row.Cells(ColumnIndex_LogText).Value.ToString()).ThenBy(Function(row) row.Cells(ColumnIndex_ComputedTime).Value.ToString()).ToList()
                                       Catch ex As ArgumentException
                                           MsgBox("Malformed RegEx pattern detected, search aborted.", MsgBoxStyle.Critical, Text)
@@ -343,13 +350,15 @@ Public Class ViewLogBackups
                                   End Sub
 
         AddHandler worker.RunWorkerCompleted, Sub()
-                                                  If listOfSearchResults2.Count > 0 Then
-                                                      searchResultsWindow.LogsToBeDisplayed = listOfSearchResults2
-                                                      searchResultsWindow.ColFileName.Visible = True
-                                                      searchResultsWindow.OpenLogFileForViewingToolStripMenuItem.Visible = True
-                                                      searchResultsWindow.ShowDialog(Me)
-                                                  Else
-                                                      MsgBox("Search terms not found.", MsgBoxStyle.Information, Text)
+                                                  If boolShowSearchResults Then
+                                                      If listOfSearchResults2.Count > 0 Then
+                                                          searchResultsWindow.LogsToBeDisplayed = listOfSearchResults2
+                                                          searchResultsWindow.ColFileName.Visible = True
+                                                          searchResultsWindow.OpenLogFileForViewingToolStripMenuItem.Visible = True
+                                                          searchResultsWindow.ShowDialog(Me)
+                                                      Else
+                                                          MsgBox("Search terms not found.", MsgBoxStyle.Information, Text)
+                                                      End If
                                                   End If
 
                                                   Invoke(Sub() BtnSearch.Enabled = True)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -344,10 +344,17 @@ Public Class ViewLogBackups
                                               End If
                                           Next
 
-                                          If Not My.Settings.IgnoreSearchResultLimits AndAlso listOfSearchResults.Count > 4000 Then
-                                              MsgBox($"Your search results contains more than four thousand results. It's highly recommended that you narrow your search terms.{vbCrLf}{vbCrLf}Search aborted.", MsgBoxStyle.Information, Text)
-                                              boolShowSearchResults = False
-                                              Exit Sub
+                                          If listOfSearchResults.Count > 4000 Then
+                                              If Not My.Settings.IgnoreSearchResultLimits Then
+                                                  MsgBox($"Your search results contains more than four thousand results. It's highly recommended that you narrow your search terms.{vbCrLf}{vbCrLf}Search aborted.", MsgBoxStyle.Information, Text)
+                                                  boolShowSearchResults = False
+                                                  Exit Sub
+                                              Else
+                                                  If MsgBox("There are more than 4000 search results, are you sure you want to display them?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.No Then
+                                                      boolShowSearchResults = False
+                                                      Exit Sub
+                                                  End If
+                                              End If
                                           End If
 
                                           listOfSearchResults2 = listOfSearchResults.Distinct().ToList().OrderBy(Function(row) row.Cells(ColumnIndex_LogText).Value.ToString()).ThenBy(Function(row) row.Cells(ColumnIndex_ComputedTime).Value.ToString()).ToList()

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -52,8 +52,11 @@ Public Class ViewLogBackups
 
         Array.Sort(rows, Function(row1 As MyDataGridViewFileRow, row2 As MyDataGridViewFileRow) comparer.Compare(row1, row2))
 
+        FileList.SuspendLayout()
         FileList.Rows.Clear()
         FileList.Rows.AddRange(rows)
+        FileList.ResumeLayout()
+
         FileList.Enabled = True
         FileList.AllowUserToOrderColumns = True
     End Sub
@@ -143,8 +146,11 @@ Public Class ViewLogBackups
                        FileList.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
                    End If
 
+                   FileList.SuspendLayout()
                    FileList.Rows.Clear()
                    FileList.Rows.AddRange(listOfDataGridViewRows.ToArray())
+                   FileList.ResumeLayout()
+
                    lblNumberOfFiles.Text = $"Number of Files: {intFileCount:N0}"
                    LblTotalDiskSpace.Text = $"Total Disk Space Used: {FileSizeToHumanSize(longUsedDiskSpace)}"
                    lblTotalNumberOfLogs.Text = $"Total Number of Logs: {longTotalLogCount:N0}"

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -314,7 +314,7 @@ Public Class ViewLogBackups
                                                                                              myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
                                                                                              myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
                                                                                              myDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
-                                                                                             If My.Settings.font IsNot Nothing Then myDataGridRow.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
+
                                                                                              SyncLock listOfSearchResults ' Ensure thread safety
                                                                                                  listOfSearchResults.Add(myDataGridRow)
                                                                                              End SyncLock
@@ -322,6 +322,10 @@ Public Class ViewLogBackups
                                                                                      Next
                                                                                  End Using
                                                                              End Sub)
+
+                                          For Each item As MyDataGridViewRow In listOfSearchResults
+                                              If My.Settings.font IsNot Nothing Then item.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
+                                          Next
 
                                           For Each item As SavedData In currentLogs
                                               If regexCompiledObject.IsMatch(item.log) Then

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -163,6 +163,7 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub ViewLogBackups_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        ChkIgnoreSearchResultsLimits.Checked = My.Settings.IgnoreSearchResultLimits
         Dim flags As Reflection.BindingFlags = Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance Or Reflection.BindingFlags.SetProperty
         Dim propInfo As Reflection.PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
         propInfo?.SetValue(FileList, True, Nothing)
@@ -343,7 +344,7 @@ Public Class ViewLogBackups
                                               End If
                                           Next
 
-                                          If listOfSearchResults.Count > 4000 Then
+                                          If Not My.Settings.IgnoreSearchResultLimits AndAlso listOfSearchResults.Count > 4000 Then
                                               MsgBox($"Your search results contains more than four thousand results. It's highly recommended that you narrow your search terms.{vbCrLf}{vbCrLf}Search aborted.", MsgBoxStyle.Information, Text)
                                               boolShowSearchResults = False
                                               Exit Sub
@@ -496,5 +497,9 @@ Public Class ViewLogBackups
         If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
             FileList.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
         End If
+    End Sub
+
+    Private Sub ChkIgnoreSearchResultsLimits_Click(sender As Object, e As EventArgs) Handles ChkIgnoreSearchResultsLimits.Click
+        My.Settings.IgnoreSearchResultLimits = ChkIgnoreSearchResultsLimits.Checked
     End Sub
 End Class

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -279,6 +279,9 @@
             <setting name="ConfirmDelete" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="IgnoreSearchResultLimits" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Fixed searching on the "View Log Backups" window.
- Implemented a search results limit.
- Added some calls to SuspendLayout() and ResumeLayout() to hopefully improve performance with many of the DataGrids.
- Included some more potential performance improvements to the "Ignored Logs and Search Results" window.
- Changed the minimum size of the "View Logs Backups" window.
- Drastically improved loading of large datasets into the Logs DataGrid when loading large log backup files by loading the data in batches.
- Added the ability to bypass the search results limits on the "View Log Backups" window.
- Moved the code that sorts the data in the DataGrid to inside the Asynchronous Task code on the "Ignored Logs and Search Results" window.
- Made it so that even if "Ignore Search Result Limits" is enabled, diplaying more than 4000 search results will still ask the user.
- Created a new form to create a dialog to give the user more than one choice when asking if they want to close Free Syslog. No, Yes, and Minimize.
- Improved data sorting performance on the "Ignored Logs and Search Results" window.