### PR TITLE
Version 4.0 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("3.9.6.93")>
+<Assembly: AssemblyFileVersion("4.0.1.94")>

--- a/Free SysLog/Support Code/HTTPHelper.vb
+++ b/Free SysLog/Support Code/HTTPHelper.vb
@@ -202,7 +202,7 @@ End Class
 
 ''' <summary>Allows you to easily POST and upload files to a remote HTTP server without you, the programmer, knowing anything about how it all works. This class does it all for you. It handles adding a User Agent String, additional HTTP Request Headers, string data to your HTTP POST data, and files to be uploaded in the HTTP POST data.</summary>
 Public Class HttpHelper
-    Private Const classVersion As String = "1.343"
+    Private Const classVersion As String = "1.345"
 
     Private strUserAgentString As String = Nothing
     Private boolUseProxy As Boolean = False
@@ -220,10 +220,10 @@ Public Class HttpHelper
     Private _intDownloadThreadSleepTime As Integer = 1000
     Private intDownloadBufferSize As Integer = 8191 ' The default is 8192 bytes or 8 KBs.
 
-    Private ReadOnly additionalHTTPHeaders As New Dictionary(Of String, String)
-    Private ReadOnly httpCookies As New Dictionary(Of String, CookieDetails)
-    Private ReadOnly postData As New Dictionary(Of String, Object)
-    Private ReadOnly getData As New Dictionary(Of String, String)
+    Private ReadOnly additionalHTTPHeaders As New Dictionary(Of String, String)(StringComparison.OrdinalIgnoreCase)
+    Private ReadOnly httpCookies As New Dictionary(Of String, CookieDetails)(StringComparison.OrdinalIgnoreCase)
+    Private ReadOnly postData As New Dictionary(Of String, Object)(StringComparison.OrdinalIgnoreCase)
+    Private ReadOnly getData As New Dictionary(Of String, String)(StringComparison.OrdinalIgnoreCase)
     Private downloadStatusDetails As DownloadStatusDetails
     Private credentials As Credentials
 
@@ -566,7 +566,7 @@ Public Class HttpHelper
             Throw lastException
         End If
 
-        If postData.MyContainsKey(strName) And throwExceptionIfDataAlreadyExists Then
+        If postData.ContainsKey(strName) And throwExceptionIfDataAlreadyExists Then
             lastException = New DataAlreadyExistsException($"The POST data key named ""{strName}"" already exists in the POST data.")
             Throw lastException
         Else
@@ -585,7 +585,7 @@ Public Class HttpHelper
             Throw lastException
         End If
 
-        If getData.MyContainsKey(strName) And throwExceptionIfDataAlreadyExists Then
+        If getData.ContainsKey(strName) And throwExceptionIfDataAlreadyExists Then
             lastException = New DataAlreadyExistsException($"The GET data key named ""{strName}"" already exists in the GET data.")
             Throw lastException
         Else
@@ -654,28 +654,28 @@ Public Class HttpHelper
     ''' <param name="strName">The name of the GET data variable you are checking the existance of.</param>
     ''' <returns></returns>
     Public Function DoesGETDataExist(strName As String) As Boolean
-        Return getData.MyContainsKey(strName)
+        Return getData.ContainsKey(strName)
     End Function
 
     ''' <summary>Checks to see if the POST data key exists in this POST data.</summary>
     ''' <param name="strName">The name of the POST data variable you are checking the existance of.</param>
     ''' <returns></returns>
     Public Function DoesPOSTDataExist(strName As String) As Boolean
-        Return postData.MyContainsKey(strName)
+        Return postData.ContainsKey(strName)
     End Function
 
     ''' <summary>Checks to see if an additional HTTP Request Header has been added to the Class.</summary>
     ''' <param name="strHeaderName">The name of the HTTP Request Header to check the existance of.</param>
     ''' <returns>Boolean value; True if found, False if not found.</returns>
     Public Function DoesAdditionalHeaderExist(strHeaderName As String) As Boolean
-        Return additionalHTTPHeaders.MyContainsKey(strHeaderName.ToLower)
+        Return additionalHTTPHeaders.ContainsKey(strHeaderName.ToLower)
     End Function
 
     ''' <summary>Checks to see if a cookie has been added to the Class.</summary>
     ''' <param name="strCookieName">The name of the cookie to check the existance of.</param>
     ''' <returns>Boolean value; True if found, False if not found.</returns>
     Public Function DoesCookieExist(strCookieName As String) As Boolean
-        Return httpCookies.MyContainsKey(strCookieName.ToLower)
+        Return httpCookies.ContainsKey(strCookieName.ToLower)
     End Function
 
     ''' <summary>This adds a file to be uploaded to your POST data.</summary>
@@ -695,7 +695,7 @@ Public Class HttpHelper
         If Not fileInfo.Exists Then
             lastException = New FileNotFoundException("Local file not found.", strLocalFilePath)
             Throw lastException
-        ElseIf postData.MyContainsKey(strFormName) Then
+        ElseIf postData.ContainsKey(strFormName) Then
             If throwExceptionIfItemAlreadyExists Then
                 lastException = New DataAlreadyExistsException($"The POST data key named ""{strFormName}"" already exists in the POST data.")
                 Throw lastException
@@ -858,7 +858,7 @@ beginAgain:
 
             Return False
         Catch ex As Threading.ThreadAbortException
-            If httpWebRequest IsNot Nothing Then httpWebRequest.Abort()
+            httpWebRequest?.Abort()
             Return False
         Catch ex As Exception
             lastException = ex
@@ -956,7 +956,7 @@ beginAgain:
             Return True
         Catch ex As Threading.ThreadAbortException
             AbortDownloadStatusUpdaterThread()
-            If httpWebRequest IsNot Nothing Then httpWebRequest.Abort()
+            httpWebRequest?.Abort()
             Return False
         Catch ex As Exception
             AbortDownloadStatusUpdaterThread()
@@ -1146,7 +1146,7 @@ beginAgain:
             End Using
         Catch ex As Exception
             If ex.GetType.Equals(GetType(Threading.ThreadAbortException)) Then
-                If httpWebRequest IsNot Nothing Then httpWebRequest.Abort()
+                httpWebRequest?.Abort()
                 Return False
             End If
 
@@ -1222,7 +1222,7 @@ beginAgain:
             End Using
         Catch ex As Exception
             If ex.GetType.Equals(GetType(Threading.ThreadAbortException)) Then
-                If httpWebRequest IsNot Nothing Then httpWebRequest.Abort()
+                httpWebRequest?.Abort()
                 Return False
             End If
 
@@ -1348,7 +1348,7 @@ beginAgain:
             End Using
         Catch ex As Exception
             If ex.GetType.Equals(GetType(Threading.ThreadAbortException)) Then
-                If httpWebRequest IsNot Nothing Then httpWebRequest.Abort()
+                httpWebRequest?.Abort()
             End If
 
             lastException = ex
@@ -1525,53 +1525,3 @@ beginAgain:
         Return result
     End Function
 End Class
-
-Module DictionaryExtensions
-    ''' <summary>This function operates a lot like ContainsKey() but is case-InSeNsItIvE.</summary>
-    ''' <param name="haystack">The dictionary that's being searched.</param>
-    ''' <param name="needle">The key that you're looking for.</param>
-    ''' <return>Returns a String value.</return>
-    <Extension()>
-    Function MyContainsKey(haystack As Dictionary(Of String, String), needle As String) As Boolean
-        If String.IsNullOrEmpty(needle) Then
-            Throw New ArgumentException($"'{NameOf(needle)}' cannot be null or empty.", NameOf(needle))
-        End If
-        If haystack Is Nothing Then
-            Throw New ArgumentNullException(NameOf(haystack))
-        End If
-
-        Return haystack.Keys.Any(Function(key As String) key.Trim.Equals(needle, StringComparison.OrdinalIgnoreCase))
-    End Function
-
-    ''' <summary>This function operates a lot like ContainsKey() but is case-InSeNsItIvE.</summary>
-    ''' <param name="haystack">The dictionary that's being searched.</param>
-    ''' <param name="needle">The key that you're looking for.</param>
-    ''' <return>Returns a String value.</return>
-    <Extension()>
-    Function MyContainsKey(haystack As Dictionary(Of String, Object), needle As String) As Boolean
-        If String.IsNullOrEmpty(needle) Then
-            Throw New ArgumentException($"'{NameOf(needle)}' cannot be null or empty.", NameOf(needle))
-        End If
-        If haystack Is Nothing Then
-            Throw New ArgumentNullException(NameOf(haystack))
-        End If
-
-        Return haystack.Keys.Any(Function(key As String) key.Trim.Equals(needle, StringComparison.OrdinalIgnoreCase))
-    End Function
-
-    ''' <summary>This function operates a lot like ContainsKey() but is case-InSeNsItIvE.</summary>
-    ''' <param name="haystack">The dictionary that's being searched.</param>
-    ''' <param name="needle">The key that you're looking for.</param>
-    ''' <return>Returns a String value.</return>
-    <Extension()>
-    Function MyContainsKey(haystack As Dictionary(Of String, CookieDetails), needle As String) As Boolean
-        If String.IsNullOrEmpty(needle) Then
-            Throw New ArgumentException($"'{NameOf(needle)}' cannot be null or empty.", NameOf(needle))
-        End If
-        If haystack Is Nothing Then
-            Throw New ArgumentNullException(NameOf(haystack))
-        End If
-
-        Return haystack.Keys.Any(Function(key As String) key.Trim.Equals(needle, StringComparison.OrdinalIgnoreCase))
-    End Function
-End Module

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -244,7 +244,7 @@ Namespace SupportCode
                     Dim data As Byte() = Encoding.UTF8.GetBytes(strMessage)
                     udpClient.Send(data, data.Length)
                 End Using
-            Catch ex As SocketException
+            Catch ex As Exception
             End Try
         End Sub
 
@@ -258,7 +258,7 @@ Namespace SupportCode
                         networkStream.Write(data, 0, data.Length)
                     End Using
                 End Using
-            Catch ex As SocketException
+            Catch ex As Exception
             End Try
         End Sub
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -222,12 +222,14 @@ Namespace SupportCode
         Private Function GetLocalIPAddress() As IPAddress
             Dim networkInterfaces As NetworkInterface() = NetworkInterface.GetAllNetworkInterfaces()
 
-            If networkInterfaces.Any() Then
+            If networkInterfaces IsNot Nothing AndAlso networkInterfaces.Any() Then
                 For Each ni As NetworkInterface In networkInterfaces
                     If ni IsNot Nothing AndAlso ni.OperationalStatus = OperationalStatus.Up AndAlso ni.NetworkInterfaceType <> NetworkInterfaceType.Loopback AndAlso ni.NetworkInterfaceType <> NetworkInterfaceType.Tunnel Then
-                        For Each ip As UnicastIPAddressInformation In ni.GetIPProperties().UnicastAddresses
-                            If ip.Address.AddressFamily = AddressFamily.InterNetwork Then Return ip.Address
-                        Next
+                        If ni.GetIPProperties().UnicastAddresses.Any() Then
+                            For Each ip As UnicastIPAddressInformation In ni.GetIPProperties().UnicastAddresses
+                                If ip.Address.AddressFamily = AddressFamily.InterNetwork Then Return ip.Address
+                            Next
+                        End If
                     End If
                 Next
             End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -82,7 +82,7 @@ Namespace SyslogParser
             End Using
         End Function
 
-        Public Sub AddToLogList(strTimeStampFromServer As String, strSourceIP As String, strLogText As String)
+        Public Sub AddToLogList(strTimeStampFromServer As String, strLogText As String)
             If strLogText.CaseInsensitiveContains(strNewLine) Then strLogText = strLogText.Replace(strNewLine, vbCrLf).Trim
 
             Dim currentDate As Date = Now.ToLocalTime
@@ -95,7 +95,7 @@ Namespace SyslogParser
                     serverDate = ParseTimestamp(strTimeStampFromServer)
                 Catch ex As FormatException
                     serverDate = currentDate
-                    AddToLogList(Nothing, "local", $"Unable to parse timestamp {strQuote}{strTimeStampFromServer.Trim}{strQuote}.")
+                    AddToLogList(Nothing, $"Unable to parse timestamp {strQuote}{strTimeStampFromServer.Trim}{strQuote}.")
                 End Try
             End If
 
@@ -269,7 +269,7 @@ Namespace SyslogParser
                     Next
                 Else
                     ' Nope, log it as unable to be parsed.
-                    AddToLogList(Nothing, "local", $"Unable to parse log {strQuote}{strRawLogText}{strQuote}.")
+                    AddToLogList(Nothing, $"Unable to parse log {strQuote}{strRawLogText}{strQuote}.")
                 End If
             End If
         End Sub
@@ -324,7 +324,7 @@ Namespace SyslogParser
                     AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType)
                 End If
             Catch ex As Exception
-                AddToLogList(Nothing, "local", $"{ex.Message} -- {ex.StackTrace}{vbCrLf}Data from Server: {strRawLogText}")
+                AddToLogList(Nothing, $"{ex.Message} -- {ex.StackTrace}{vbCrLf}Data from Server: {strRawLogText}")
             End Try
         End Sub
 
@@ -356,7 +356,7 @@ Namespace SyslogParser
                     serverDate = ParseTimestamp(strTimeStampFromServer)
                 Catch ex As FormatException
                     serverDate = currentDate
-                    AddToLogList(Nothing, "local", $"Unable to parse timestamp {strQuote}{strTimeStampFromServer.Trim}{strQuote}.")
+                    AddToLogList(Nothing, $"Unable to parse timestamp {strQuote}{strTimeStampFromServer.Trim}{strQuote}.")
                 End Try
             End If
 

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -178,7 +178,6 @@ Partial Class Form1
         '
         'AlertsHistory
         '
-        Me.AlertsHistory.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.BtnClearAllLogs, Me.LogsOlderThanToolStripMenuItem})
         Me.AlertsHistory.Enabled = True
         Me.AlertsHistory.Name = "AlertsHistory"
         Me.AlertsHistory.Size = New System.Drawing.Size(239, 22)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1644,6 +1644,12 @@ Public Class Form1
         My.Settings.ConfirmDelete = ConfirmDelete.Checked
     End Sub
 
+    Private Sub LogFunctionsToolStripMenuItem_DropDownOpening(sender As Object, e As EventArgs) Handles LogFunctionsToolStripMenuItem.DropDownOpening
+        SyncLock dataGridLockObject
+            AlertsHistory.Enabled = Logs.Rows.Cast(Of MyDataGridViewRow).Any(Function(row As MyDataGridViewRow) Not String.IsNullOrWhiteSpace(row.AlertText))
+        End SyncLock
+    End Sub
+
 #Region "-- SysLog Server Code --"
     Sub SysLogThread()
         Try

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -595,7 +595,8 @@ Public Class Form1
     End Sub
 
     Private Sub Logs_DoubleClick(sender As Object, e As EventArgs) Handles Logs.DoubleClick
-        OpenLogViewerWindow()
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(Logs.PointToClient(MousePosition).X, Logs.PointToClient(MousePosition).Y)
+        If hitTest.Type = DataGridViewHitTestType.Cell And hitTest.RowIndex <> -1 Then OpenLogViewerWindow()
     End Sub
 
     Private Sub Logs_KeyUp(sender As Object, e As KeyEventArgs) Handles Logs.KeyUp

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1098,6 +1098,13 @@ Public Class Form1
     End Sub
 
     Private Sub LogsMenu_Opening(sender As Object, e As CancelEventArgs) Handles LogsMenu.Opening
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(Logs.PointToClient(MousePosition).X, Logs.PointToClient(MousePosition).Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            e.Cancel = True
+            Exit Sub
+        End If
+
         If Logs.SelectedRows.Count = 0 Then
             DeleteLogsToolStripMenuItem.Visible = False
             ExportsLogsToolStripMenuItem.Visible = False

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -350,6 +350,13 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub LogsContextMenu_Opening(sender As Object, e As CancelEventArgs) Handles LogsContextMenu.Opening
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(Logs.PointToClient(MousePosition).X, Logs.PointToClient(MousePosition).Y)
+
+        If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
+            e.Cancel = True
+            Exit Sub
+        End If
+
         If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then
             ExportSelectedLogsToolStripMenuItem.Visible = True
             CopyLogTextToolStripMenuItem.Visible = False

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -92,7 +92,8 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub Logs_DoubleClick(sender As Object, e As EventArgs) Handles Logs.DoubleClick
-        OpenLogViewerWindow()
+        Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(Logs.PointToClient(MousePosition).X, Logs.PointToClient(MousePosition).Y)
+        If hitTest.Type = DataGridViewHitTestType.Cell And hitTest.RowIndex <> -1 Then OpenLogViewerWindow()
     End Sub
 
     Private Sub Ignored_Logs_and_Search_Results_ResizeBegin(sender As Object, e As EventArgs) Handles Me.ResizeBegin

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -419,10 +419,10 @@ Public Class IgnoredLogsAndSearchResults
                             End Sub)
             End If
         Catch ex As Newtonsoft.Json.JsonSerializationException
-            SyslogParser.AddToLogList(Nothing, Net.IPAddress.Loopback.ToString, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
+            SyslogParser.AddToLogList(Nothing, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
             MsgBox("There was an error decoding JSON data.", MsgBoxStyle.Critical, Text)
         Catch ex As Newtonsoft.Json.JsonReaderException
-            SyslogParser.AddToLogList(Nothing, Net.IPAddress.Loopback.ToString, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
+            SyslogParser.AddToLogList(Nothing, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
             MsgBox("There was an error decoding JSON data.", MsgBoxStyle.Critical, Text)
         End Try
     End Sub

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -26,7 +26,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.BtnAdd = New System.Windows.Forms.Button()
         Me.BtnDelete = New System.Windows.Forms.Button()
         Me.IgnoredListView = New System.Windows.Forms.ListView()
-        Me.Replace = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.Ignored = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.Regex = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.CaseSensitive = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ColEnabled = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
@@ -76,7 +76,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Replace, Me.Regex, Me.CaseSensitive, Me.ColEnabled})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -87,10 +87,10 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.UseCompatibleStateImageBehavior = False
         Me.IgnoredListView.View = System.Windows.Forms.View.Details
         '
-        'Replace
+        'Ignored
         '
-        Me.Replace.Text = "Replace"
-        Me.Replace.Width = 345
+        Me.Ignored.Text = "Ignored Word and/or Phrase"
+        Me.Ignored.Width = 345
         '
         'Regex
         '
@@ -310,7 +310,7 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents BtnAdd As Button
     Friend WithEvents BtnDelete As Button
     Friend WithEvents IgnoredListView As ListView
-    Friend WithEvents Replace As ColumnHeader
+    Friend WithEvents Ignored As ColumnHeader
     Friend WithEvents Regex As ColumnHeader
     Friend WithEvents CaseSensitive As ColumnHeader
     Friend WithEvents BtnEdit As Button

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -23,6 +23,9 @@ Public Class IgnoredWordsAndPhrases
 
                 With selectedItemObject
                     .SubItems(0).Text = TxtIgnored.Text
+                    .SubItems(1).Text = If(ChkRegex.Checked, "Yes", "No")
+                    .SubItems(2).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
+                    .SubItems(3).Text = If(ChkEnabled.Checked, "Yes", "No")
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolRegex = ChkRegex.Checked
@@ -87,7 +90,7 @@ Public Class IgnoredWordsAndPhrases
 
         IgnoredListView.Items.AddRange(MyIgnoredListViewItem.ToArray())
 
-        Replace.Width = My.Settings.colIgnoredReplace
+        Ignored.Width = My.Settings.colIgnoredReplace
         Regex.Width = My.Settings.colIgnoredRegex
         CaseSensitive.Width = My.Settings.colIgnoredCaseSensitive
         ColEnabled.Width = My.Settings.colIgnoredEnabled
@@ -208,7 +211,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredListView_ColumnWidthChanged(sender As Object, e As ColumnWidthChangedEventArgs) Handles IgnoredListView.ColumnWidthChanged
         If boolDoneLoading Then
-            My.Settings.colIgnoredReplace = Replace.Width
+            My.Settings.colIgnoredReplace = Ignored.Width
             My.Settings.colIgnoredRegex = Regex.Width
             My.Settings.colIgnoredCaseSensitive = CaseSensitive.Width
             My.Settings.colIgnoredEnabled = ColEnabled.Width

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -227,7 +227,7 @@ Public Class ViewLogBackups
                 If MsgBox($"Are you sure you want to delete the file named ""{FileList.SelectedRows(0).Cells(0).Value}""?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then
                     File.Delete(fileName)
 
-                    If ChkLogFileDeletions.Checked Then SyslogParser.AddToLogList(Nothing, Net.IPAddress.Loopback.ToString, $"The user deleted ""{FileList.SelectedRows(0).Cells(0).Value}"" from the log backups folder.")
+                    If ChkLogFileDeletions.Checked Then SyslogParser.AddToLogList(Nothing, $"The user deleted ""{FileList.SelectedRows(0).Cells(0).Value}"" from the log backups folder.")
 
                     ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
                 End If
@@ -252,7 +252,7 @@ Public Class ViewLogBackups
 
                     strDeletedFilesLog &= vbCrLf & listOfFilesThatAreToBeDeletedInHumanReadableFormat
 
-                    If ChkLogFileDeletions.Checked Then SyslogParser.AddToLogList(Nothing, Net.IPAddress.Loopback.ToString, strDeletedFilesLog.ToString)
+                    If ChkLogFileDeletions.Checked Then SyslogParser.AddToLogList(Nothing, strDeletedFilesLog.ToString)
 
                     ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
                 End If


### PR DESCRIPTION
- Put some additional guardrails into the GetLocalIPAddress() function to prevent possible Null Reference Exceptions.
- Broadened the scope of the exception handler in both the SendMessageToSysLogServer() and SendMessageToTCPSysLogServer() functions to handle more than just Socket exceptions.
- Updated the HTTPHelper Class to version 1.345.
- Fixed some GUI element issues on the main form.
- Added code to enable and disable the "Alerts History" menu item when opening the "Log Functions" menu.
- Fixed auto-resizing of the columns in the DataGridView.
- Fixed a bug on the "Ignored Words and Phrases" window when editing an item.
- Fixed a bug on the "Ignored Words and Phrases" window where it incorrectly said "Replace" in the column header text.
- Made it so that the context menu for the datagrids don't open when right-clicking on the column headers.