### PR TITLE
Version 4.1 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.1.1.95")>
+<Assembly: AssemblyFileVersion("4.1.2.96")>

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -26,6 +26,10 @@ Namespace SupportCode
     End Class
 
     Module SupportCode
+        Public AlertsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+
         Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)

--- a/Free SysLog/Windows/Confirm Delete.vb
+++ b/Free SysLog/Windows/Confirm Delete.vb
@@ -1,6 +1,6 @@
 ﻿Public Class Confirm_Delete
     Private intNumberOfLogsToBeDeleted As Integer
-    Public choice As UserChoice
+    Public choice As UserChoice = UserChoice.NoDelete
 
     Public Enum UserChoice As Integer
         YesDeleteNoBackup

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -902,6 +902,7 @@ Partial Class Form1
         '
         'boxLimiter
         '
+        Me.boxLimiter.Enabled = False
         Me.boxLimiter.FormattingEnabled = True
         Me.boxLimiter.Location = New System.Drawing.Point(595, 29)
         Me.boxLimiter.Name = "boxLimiter"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -329,6 +329,7 @@ Public Class Form1
         boxLimiter.Text = Nothing
         boxLimiter.Items.Clear()
         boxLimiter.Text = "(Not Specified)"
+        boxLimiter.Enabled = True
 
         Dim sortedList As List(Of String)
 
@@ -354,6 +355,7 @@ Public Class Form1
             boxLimiter.Items.AddRange(sortedList.ToArray)
         Else
             boxLimiter.Text = "(Not Specified)"
+            boxLimiter.Enabled = False
         End If
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -15,7 +15,6 @@ Public Class Form1
     Private boolDoneLoading As Boolean = False
     Public longNumberOfIgnoredLogs As Long = 0
     Public IgnoredLogs As New List(Of MyDataGridViewRow)
-    Public regexCache As New Dictionary(Of String, Regex)
     Public intSortColumnIndex As Integer = 0 ' Define intColumnNumber at class level
     Public sortOrder As SortOrder = SortOrder.Ascending ' Define soSortOrder at class level
     Public ReadOnly dataGridLockObject As New Object
@@ -947,7 +946,12 @@ Public Class Form1
     Private Sub IgnoredWordsAndPhrasesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Click
         Using IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
             IgnoredWordsAndPhrasesOrAlertsInstance.ShowDialog(Me)
-            If IgnoredWordsAndPhrasesOrAlertsInstance.boolChanged Then regexCache.Clear()
+
+            If IgnoredWordsAndPhrasesOrAlertsInstance.boolChanged Then
+                SyncLock IgnoredRegexCache
+                    IgnoredRegexCache.Clear()
+                End SyncLock
+            End If
         End Using
     End Sub
 
@@ -1053,7 +1057,12 @@ Public Class Form1
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click
         Using ReplacementsInstance As New Replacements With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
             ReplacementsInstance.ShowDialog(Me)
-            If ReplacementsInstance.boolChanged Then regexCache.Clear()
+
+            SyncLock ReplacementsRegexCache
+                If ReplacementsInstance.boolChanged Then
+                    ReplacementsRegexCache.Clear()
+                End If
+            End SyncLock
         End Using
     End Sub
 
@@ -1327,7 +1336,12 @@ Public Class Form1
     Private Sub ConfigureAlertsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureAlertsToolStripMenuItem.Click
         Using Alerts As New Alerts With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
             Alerts.ShowDialog(Me)
-            If Alerts.boolChanged Then regexCache.Clear()
+
+            If Alerts.boolChanged Then
+                SyncLock AlertsRegexCache
+                    AlertsRegexCache.Clear()
+                End SyncLock
+            End If
         End Using
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -697,11 +697,20 @@ Public Class Form1
                     End If
                 End If
 
+                ' Create a list to store rows that need to be removed
+                Dim rowsToDelete As New List(Of MyDataGridViewRow)
+
+                ' Loop through the rows in reverse order to avoid index shifting
                 For i As Integer = Logs.SelectedRows.Count - 1 To 0 Step -1
-                    Logs.Rows.Remove(Logs.SelectedRows(i))
+                    rowsToDelete.Add(Logs.SelectedRows(i))
                 Next
 
-                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {intNumberOfLogsDeleted:N0} log {If(intNumberOfLogsDeleted = 1, "entry", "entries")}.", Logs))
+                ' Remove the rows outside the loop
+                For Each row As MyDataGridViewRow In rowsToDelete
+                    Logs.Rows.Remove(row)
+                Next
+
+                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {rowsToDelete.Count:N0} log {If(rowsToDelete.Count = 1, "entry", "entries")}.", Logs))
 
                 SelectLatestLogEntry()
             End SyncLock
@@ -1282,11 +1291,20 @@ Public Class Form1
                 MakeLogBackup()
             End If
 
+            ' Create a list to store rows that need to be removed
+            Dim rowsToDelete As New List(Of MyDataGridViewRow)
+
+            ' Loop through the rows in reverse order to avoid index shifting
             For i As Integer = Logs.SelectedRows.Count - 1 To 0 Step -1
-                Logs.Rows.Remove(Logs.SelectedRows(i))
+                rowsToDelete.Add(Logs.SelectedRows(i))
             Next
 
-            Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {intNumberOfLogsDeleted:N0} log {If(intNumberOfLogsDeleted = 1, "entry", "entries")}.", Logs))
+            ' Remove the rows outside the loop
+            For Each row As MyDataGridViewRow In rowsToDelete
+                Logs.Rows.Remove(row)
+            Next
+
+            Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {rowsToDelete.Count:N0} log {If(rowsToDelete.Count = 1, "entry", "entries")}.", Logs))
 
             SelectLatestLogEntry()
         End SyncLock

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -332,8 +332,6 @@ Public Class Form1
 
         Dim sortedList As List(Of String)
 
-        ', "Hostnames", "IP Address"
-
         If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
             sortedList = uniqueObjects.logTypes.ToList()
             sortedList.Sort()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1786,6 +1786,8 @@ Public Class Form1
                 For Each row As MyDataGridViewRow In rowsToDelete
                     Logs.Rows.Remove(row)
                 Next
+
+                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The program deleted {rowsToDelete.Count:N0} similar log {If(rowsToDelete.Count = 1, "entry", "entries")}.", Logs))
             End SyncLock
 
             ' Update log count and save changes to disk

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -343,6 +343,7 @@ Partial Class ViewLogBackups
         '
         'boxLimiter
         '
+        Me.boxLimiter.Enabled = False
         Me.boxLimiter.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.boxLimiter.FormattingEnabled = True
         Me.boxLimiter.Location = New System.Drawing.Point(182, 290)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -543,6 +543,7 @@ Public Class ViewLogBackups
         boxLimiter.Text = Nothing
         boxLimiter.Items.Clear()
         boxLimiter.Text = "(Not Specified)"
+        boxLimiter.Enabled = True
 
         Dim sortedList As List(Of String)
 
@@ -568,6 +569,7 @@ Public Class ViewLogBackups
             boxLimiter.Items.AddRange(sortedList.ToArray)
         Else
             boxLimiter.Text = "(Not Specified)"
+            boxLimiter.Enabled = False
         End If
     End Sub
 End Class


### PR DESCRIPTION
- Reworked the internal compiled RegEx cache system by splitting off the three different types (alerts, replacements, and ignore) into their own separate caches so that the program doesn't have to rebuild all of the caches when a user changes something in alerts (or anything else for that matter).
- Added code to log how many logs were deleted by the program's "Similar Log Deletion" tool.
- Tweaked the selected log deletion code to better handle index shifting.
- Added code to enable and disable the boxLimiter GUI element on the main window and the "View Log Backups" window.
- Fixed a bug where if you exit out of the "Confirm Deletion of Logs?" window by clicking the X button, the program would delete the logs anyways. This was not the intended function, the program shouldn't have deleted the logs and assumed the user meant to not delete the logs.