### PR TITLE
Version 4.3 Build 1

### DIFF
--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -336,7 +336,7 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="TaskScheduler">
-      <Version>2.12.1</Version>
+      <Version>2.12.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.2.2.99")>
+<Assembly: AssemblyFileVersion("4.3.1.100")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -1194,6 +1194,18 @@ Namespace My
             End Get
             Set
                 Me("ProcessReplacementsInSyslogDataFirst") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("1000")>  _
+        Public Property LimitNumberOfIgnoredLogs() As Integer
+            Get
+                Return CType(Me("LimitNumberOfIgnoredLogs"),Integer)
+            End Get
+            Set
+                Me("LimitNumberOfIgnoredLogs") = value
             End Set
         End Property
     End Class

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -290,5 +290,8 @@
     <Setting Name="ProcessReplacementsInSyslogDataFirst" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LimitNumberOfIgnoredLogs" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1000</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/MyDataGridViewRow.vb
+++ b/Free SysLog/Support Code/MyDataGridViewRow.vb
@@ -7,6 +7,7 @@
     Public Property RawLogData As String
     Public Property AlertText As String
     Public Property alertType As AlertType
+    Public Property IgnoredPattern As String
 
     Public Overrides Function Clone()
         Dim newDataGridRow As New MyDataGridViewRow()
@@ -16,6 +17,7 @@
         newDataGridRow.AlertText = Me.AlertText
         newDataGridRow.RawLogData = Me.RawLogData
         newDataGridRow.alertType = Me.alertType
+        newDataGridRow.IgnoredPattern = Me.IgnoredPattern
 
         For index As Short = 0 To Me.Cells.Count - 1
             With newDataGridRow

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -68,8 +68,10 @@ Namespace checkForUpdates
                 xmlDocument.Load(New StringReader(xmlData)) ' Now we try and parse the XML data.
                 Dim xmlNode As XmlNode = xmlDocument.SelectSingleNode("/xmlroot")
 
-                remoteVersion = xmlNode.SelectSingleNode("version").InnerText.Trim
-                remoteBuild = xmlNode.SelectSingleNode("build").InnerText.Trim
+                If xmlNode Is Nothing Then Return ProcessUpdateXMLResponse.parseError ' Something went wrong, so we return a parseError value.
+
+                remoteVersion = xmlNode.SelectSingleNode("version")?.InnerText?.Trim()
+                remoteBuild = xmlNode.SelectSingleNode("build")?.InnerText?.Trim()
 
                 Dim longInternalVersionFromXML As Long = 0
                 If xmlNode.SelectSingleNode("internalversion") IsNot Nothing Then

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -98,23 +98,13 @@ Namespace checkForUpdates
             Return ProcessUpdateXMLResponse.noUpdateNeeded
         End Function
 
-        Private Shared Function CheckFolderPermissionsByACLs(folderPath As String) As Boolean
+        Private Function CanWriteToFolder(folderPath As String) As Boolean
             Try
-                Dim directoryACLs As DirectorySecurity = Directory.GetAccessControl(folderPath)
-                Dim directoryAccessRights As FileSystemAccessRule
-
-                For Each rule As AuthorizationRule In directoryACLs.GetAccessRules(True, True, GetType(SecurityIdentifier))
-                    If rule.IdentityReference.Value.Equals(WindowsIdentity.GetCurrent.User.Value, StringComparison.OrdinalIgnoreCase) Then
-                        directoryAccessRights = DirectCast(rule, FileSystemAccessRule)
-
-                        If directoryAccessRights.AccessControlType = AccessControlType.Allow AndAlso directoryAccessRights.FileSystemRights = (FileSystemRights.Read Or FileSystemRights.Modify Or FileSystemRights.Write Or FileSystemRights.FullControl) Then
-                            Return True
-                        End If
-                    End If
-                Next
-
-                Return False
-            Catch ex As Exception
+                Dim testFile = IO.Path.Combine(folderPath, Guid.NewGuid().ToString() & ".tmp")
+                File.WriteAllText(testFile, "test")
+                File.Delete(testFile)
+                Return True
+            Catch
                 Return False
             End Try
         End Function
@@ -241,7 +231,7 @@ Namespace checkForUpdates
                     .FileName = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, strUpdaterEXE),
                     .Arguments = $"--programcode={programCode}"
                 }
-                If Not CheckFolderPermissionsByACLs(AppDomain.CurrentDomain.BaseDirectory) Then startInfo.Verb = "runas"
+                If Not CanWriteToFolder(AppDomain.CurrentDomain.BaseDirectory) Then startInfo.Verb = "runas"
                 Process.Start(startInfo)
 
                 Process.GetCurrentProcess.Kill()

--- a/Free SysLog/Support Code/Namespace Code/Data Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Data Handling.vb
@@ -4,14 +4,6 @@ Imports Free_SysLog.SupportCode
 
 Namespace DataHandling
     Public Module DataHandling
-        Private ParentForm As Form1
-
-        Public WriteOnly Property SetParentForm As Form1
-            Set(value As Form1)
-                ParentForm = value
-            End Set
-        End Property
-
         Public Sub ExportSelectedLogs(selectedRows As DataGridViewSelectedRowCollection)
             SyncLock ParentForm.dataGridLockObject
                 Dim saveFileDialog As New SaveFileDialog With {.Title = "Export Data...", .Filter = "CSV (Comma Separated Value)|*.csv|JSON File|*.json|XML File|*.xml"}

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -21,7 +21,7 @@
                     Dim timeSinceLastNotification As TimeSpan = currentTime - lastTime
 
                     ' If the message was shown within the time limit, do not show it again
-                    If timeSinceLastNotification.TotalSeconds < My.Settings.TimeBetweenSameNotifications Then Return
+                    If timeSinceLastNotification.TotalSeconds < My.Settings.TimeBetweenSameNotifications Then Exit Sub
                 End If
 
                 ' Update the last shown time for this message

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -1,9 +1,7 @@
 ﻿Namespace NotificationLimiter
-    Public Module NotificationLimiterModule
+    Public Module NotificationLimiter
         Public lastNotificationTime As New Dictionary(Of String, Date)(StringComparison.OrdinalIgnoreCase)
-    End Module
 
-    Public Class NotificationLimiter
         ' Time after which an unused entry is considered stale (in minutes)
         Private Const CleanupThresholdInMinutes As Integer = 10
 
@@ -39,5 +37,5 @@
                 lastNotificationTime.Remove(key)
             Next
         End Sub
-    End Class
+    End Module
 End Namespace

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -42,6 +42,8 @@ Namespace SupportCode
     End Class
 
     Module SupportCode
+        Public ParentForm As Form1
+
         Public AlertsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
         Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
         Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -84,6 +84,7 @@ Namespace SupportCode
 
         Public allUniqueObjects As uniqueObjectsClass
         Public recentUniqueObjects As uniqueObjectsClass
+        Public ReadOnly recentUniqueObjectsLock As New Object()
 
 #If DEBUG Then
         Public Const boolDebugBuild As Boolean = True

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -88,6 +88,7 @@ Namespace SupportCode
         Public allUniqueObjects As uniqueObjectsClass
         Public recentUniqueObjects As uniqueObjectsClass
         Public ReadOnly recentUniqueObjectsLock As New Object()
+        Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()
 
 #If DEBUG Then
         Public Const boolDebugBuild As Boolean = True

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -30,6 +30,15 @@ Namespace SupportCode
             hostNames.Clear()
             ipAddresses.Clear()
         End Sub
+
+        Public Sub Merge(other As uniqueObjectsClass)
+            If other Is Nothing Then Exit Sub
+
+            logTypes.UnionWith(other.logTypes)
+            processes.UnionWith(other.processes)
+            hostNames.UnionWith(other.hostNames)
+            ipAddresses.UnionWith(other.ipAddresses)
+        End Sub
     End Class
 
     Module SupportCode

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -23,6 +23,13 @@ Namespace SupportCode
             hostNames = New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
             ipAddresses = New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
         End Sub
+
+        Public Sub Clear()
+            logTypes.Clear()
+            processes.Clear()
+            hostNames.Clear()
+            ipAddresses.Clear()
+        End Sub
     End Class
 
     Module SupportCode

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -433,7 +433,13 @@ Namespace SyslogParser
                                                                               dataGrid:=ParentForm.Logs
                                                                              )
                     NewIgnoredItem.IgnoredPattern = strIgnoredPattern
-                    ParentForm.IgnoredLogs.Add(NewIgnoredItem)
+
+                    If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                        ParentForm.IgnoredLogs.Add(NewIgnoredItem)
+                    Else
+                        ParentForm.IgnoredLogs.RemoveAt(0)
+                        ParentForm.IgnoredLogs.Add(NewIgnoredItem)
+                    End If
 
                     SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
                         If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem, ParentForm.ChkEnableAutoScroll.Checked)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -365,7 +365,12 @@ Namespace SyslogParser
                                               If Not ParentForm.ChkEnableRecordingOfIgnoredLogs.Checked Then
                                                   ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
                                               End If
-                                              ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.longNumberOfIgnoredLogs:N0}"
+
+                                              If My.Settings.recordIgnoredLogs Then
+                                                  ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.IgnoredLogs.Count:N0}"
+                                              Else
+                                                  ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.longNumberOfIgnoredLogs:N0}"
+                                              End If
                                           End Sub)
                         Return True
                     End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -5,7 +5,6 @@ Imports System.ComponentModel
 
 Namespace SyslogParser
     Public Module SyslogParser
-        Private ParentForm As Form1
         Private ReadOnly rfc5424Regex As New Regex("<(?<priority>[0-9]+)>(?:\d ){0,1}(?<timestamp>[0-9]{4}[-.](?:1[0-2]|0[1-9])[-.](?:3[01]|[12][0-9]|0[1-9])T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]\.[0-9]+Z)(?: -){0,1} (?<hostname>(?:\\.|[^\n\r ])+) (?:\d+ ){0,1}(?<appname>(?:\\.|[^\n\r:]+?)(?: \d*){0,1}):{0,1} (?:- - %% ){0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
         Private ReadOnly rfc5424TransformRegex As New Regex("<(?<priority>[0-9]+)>(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} (?<appname>(?:\\.|[^\n\r:]+)): (?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
 
@@ -16,13 +15,6 @@ Namespace SyslogParser
         Private Const strNewLine As String = "{newline}"
 
         Private NotificationLimiter As NotificationLimiter.NotificationLimiter
-
-        Public WriteOnly Property SetParentForm As Form1
-            Set(value As Form1)
-                ParentForm = value
-                NotificationLimiter = New NotificationLimiter.NotificationLimiter()
-            End Set
-        End Property
 
         Public Function MakeLocalDataGridRowEntry(strLogText As String, ByRef dataGrid As DataGridView, Optional strLogType As String = "Informational, Local") As MyDataGridViewRow
             Dim MyDataGridViewRow As MyDataGridViewRow = MakeDataGridRow(serverTimeStamp:=Now,

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -442,7 +442,10 @@ Namespace SyslogParser
                     If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
                         ParentForm.IgnoredLogs.Add(NewIgnoredItem)
                     Else
-                        ParentForm.IgnoredLogs.RemoveAt(0)
+                        While ParentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                            ParentForm.IgnoredLogs.RemoveAt(0)
+                        End While
+
                         ParentForm.IgnoredLogs.Add(NewIgnoredItem)
                     End If
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -439,15 +439,17 @@ Namespace SyslogParser
                                                                              )
                     NewIgnoredItem.IgnoredPattern = strIgnoredPattern
 
-                    If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
-                        ParentForm.IgnoredLogs.Add(NewIgnoredItem)
-                    Else
-                        While ParentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
-                            ParentForm.IgnoredLogs.RemoveAt(0)
-                        End While
+                    SyncLock ParentForm.IgnoredLogsLockingObject
+                        If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                            ParentForm.IgnoredLogs.Add(NewIgnoredItem)
+                        Else
+                            While ParentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                                ParentForm.IgnoredLogs.RemoveAt(0)
+                            End While
 
-                        ParentForm.IgnoredLogs.Add(NewIgnoredItem)
-                    End If
+                            ParentForm.IgnoredLogs.Add(NewIgnoredItem)
+                        End If
+                    End SyncLock
 
                     SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
                         If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem, ParentForm.ChkEnableAutoScroll.Checked)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -327,11 +327,25 @@ Namespace SyslogParser
 
                     If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType)
 
+                    Dim strLimitBy As String = ParentForm.boxLimitBy.Text
+                    Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
+
                     With recentUniqueObjects
-                        .logTypes.Add($"{priorityObject.Severity}, {priorityObject.Facility}")
-                        .processes.Add(appName)
-                        .hostNames.Add(hostname)
-                        .ipAddresses.Add(strSourceIP)
+                        If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                            ParentForm.boxLimiter.Items.Add(logType)
+                        End If
+
+                        If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                            ParentForm.boxLimiter.Items.Add(appName)
+                        End If
+
+                        If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                            ParentForm.boxLimiter.Items.Add(hostname)
+                        End If
+
+                        If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+                            ParentForm.boxLimiter.Items.Add(strSourceIP)
+                        End If
                     End With
 
                     ' Step 4: Add to log list, separating header and message

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -331,7 +331,7 @@ Namespace SyslogParser
                         Dim strLimitBy As String = ParentForm.boxLimitBy.Text
                         Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
 
-                        SyncLock recentUniqueObjects
+                        SyncLock recentUniqueObjectsLock
                             With recentUniqueObjects
                                 If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
                                     ParentForm.boxLimiter.Items.Add(logType)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -2,6 +2,7 @@
 Imports System.Text.RegularExpressions
 Imports Free_SysLog.SupportCode
 Imports System.ComponentModel
+Imports System.Threading
 
 Namespace SyslogParser
     Public Module SyslogParser
@@ -355,7 +356,7 @@ Namespace SyslogParser
                 For Each ignoredClassInstance As IgnoredClass In ignoredList
                     If GetCachedRegex(IgnoredRegexCache, If(ignoredClassInstance.BoolRegex, ignoredClassInstance.StrIgnore, $".*{Regex.Escape(ignoredClassInstance.StrIgnore)}.*"), ignoredClassInstance.BoolCaseSensitive).IsMatch(message) Then
                         ParentForm.Invoke(Sub()
-                                              ParentForm.longNumberOfIgnoredLogs += 1
+                                              Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs)
                                               If Not ParentForm.ChkEnableRecordingOfIgnoredLogs.Checked Then
                                                   ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
                                               End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -452,7 +452,7 @@ Namespace SyslogParser
                     End SyncLock
 
                     SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
-                        If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem, ParentForm.ChkEnableAutoScroll.Checked)
+                        If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem)
                     End SyncLock
 
                     ParentForm.Invoke(Sub() ParentForm.ClearIgnoredLogsToolStripMenuItem.Enabled = True)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -434,7 +434,11 @@ Namespace SyslogParser
                                                                              )
                     NewIgnoredItem.IgnoredPattern = strIgnoredPattern
                     ParentForm.IgnoredLogs.Add(NewIgnoredItem)
-                    If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem, ParentForm.ChkEnableAutoScroll.Checked)
+
+                    SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
+                        If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem, ParentForm.ChkEnableAutoScroll.Checked)
+                    End SyncLock
+
                     ParentForm.Invoke(Sub() ParentForm.ClearIgnoredLogsToolStripMenuItem.Enabled = True)
                 End SyncLock
             End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -14,8 +14,6 @@ Namespace SyslogParser
 
         Private Const strNewLine As String = "{newline}"
 
-        Private NotificationLimiter As NotificationLimiter.NotificationLimiter
-
         Public Function MakeLocalDataGridRowEntry(strLogText As String, ByRef dataGrid As DataGridView, Optional strLogType As String = "Informational, Local") As MyDataGridViewRow
             Dim MyDataGridViewRow As MyDataGridViewRow = MakeDataGridRow(serverTimeStamp:=Now,
                                    dateObject:=Now,

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -327,28 +327,30 @@ Namespace SyslogParser
 
                     If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType)
 
-                    Dim strLimitBy As String = ParentForm.boxLimitBy.Text
-                    Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
+                    If Not boolIgnored Then
+                        Dim strLimitBy As String = ParentForm.boxLimitBy.Text
+                        Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
 
-                    SyncLock recentUniqueObjects
-                        With recentUniqueObjects
-                            If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(logType)
-                            End If
+                        SyncLock recentUniqueObjects
+                            With recentUniqueObjects
+                                If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                                    ParentForm.boxLimiter.Items.Add(logType)
+                                End If
 
-                            If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(appName)
-                            End If
+                                If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                                    ParentForm.boxLimiter.Items.Add(appName)
+                                End If
 
-                            If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(hostname)
-                            End If
+                                If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                                    ParentForm.boxLimiter.Items.Add(hostname)
+                                End If
 
-                            If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(strSourceIP)
-                            End If
-                        End With
-                    End SyncLock
+                                If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+                                    ParentForm.boxLimiter.Items.Add(strSourceIP)
+                                End If
+                            End With
+                        End SyncLock
+                    End If
 
                     ' Step 4: Add to log list, separating header and message
                     AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -330,23 +330,25 @@ Namespace SyslogParser
                     Dim strLimitBy As String = ParentForm.boxLimitBy.Text
                     Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
 
-                    With recentUniqueObjects
-                        If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                            ParentForm.boxLimiter.Items.Add(logType)
-                        End If
+                    SyncLock recentUniqueObjects
+                        With recentUniqueObjects
+                            If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(logType)
+                            End If
 
-                        If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                            ParentForm.boxLimiter.Items.Add(appName)
-                        End If
+                            If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(appName)
+                            End If
 
-                        If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-                            ParentForm.boxLimiter.Items.Add(hostname)
-                        End If
+                            If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(hostname)
+                            End If
 
-                        If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-                            ParentForm.boxLimiter.Items.Add(strSourceIP)
-                        End If
-                    End With
+                            If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(strSourceIP)
+                            End If
+                        End With
+                    End SyncLock
 
                     ' Step 4: Add to log list, separating header and message
                     AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -320,7 +320,10 @@ Namespace SyslogParser
                     If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType)
 
                     If Not boolIgnored Then
-                        Dim strLimitBy As String = ParentForm.boxLimitBy.Text
+                        Dim strLimitBy As String = Nothing
+
+                        ParentForm.boxLimitBy.Invoke(Sub() strLimitBy = ParentForm.boxLimitBy.Text)
+
                         Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
 
                         SyncLock recentUniqueObjectsLock

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -360,18 +360,7 @@ Namespace SyslogParser
                 For Each ignoredClassInstance As IgnoredClass In ignoredList
                     If GetCachedRegex(IgnoredRegexCache, If(ignoredClassInstance.BoolRegex, ignoredClassInstance.StrIgnore, $".*{Regex.Escape(ignoredClassInstance.StrIgnore)}.*"), ignoredClassInstance.BoolCaseSensitive).IsMatch(message) Then
                         strIgnoredPattern = ignoredClassInstance.StrIgnore
-                        ParentForm.Invoke(Sub()
-                                              Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs)
-                                              If Not ParentForm.ChkEnableRecordingOfIgnoredLogs.Checked Then
-                                                  ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
-                                              End If
-
-                                              If My.Settings.recordIgnoredLogs Then
-                                                  ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.IgnoredLogs.Count:N0}"
-                                              Else
-                                                  ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.longNumberOfIgnoredLogs:N0}"
-                                              End If
-                                          End Sub)
+                        ParentForm.Invoke(Sub() Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs))
                         Return True
                     End If
                 Next
@@ -448,6 +437,13 @@ Namespace SyslogParser
                             End While
 
                             ParentForm.IgnoredLogs.Add(NewIgnoredItem)
+                        End If
+
+                        If My.Settings.recordIgnoredLogs Then
+                            ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.IgnoredLogs.Count:N0}"
+                        Else
+                            ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
+                            ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.longNumberOfIgnoredLogs:N0}"
                         End If
                     End SyncLock
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -1,6 +1,7 @@
 ﻿Imports System.Net
 Imports System.Net.Sockets
 Imports System.Text
+Imports System.Text.RegularExpressions
 Imports System.Threading.Tasks
 Imports Free_SysLog.SupportCode
 
@@ -35,7 +36,14 @@ Namespace SyslogTcpServer
                     Await HandleClientAsync(tcpClient)
                 End While
             Catch ex As Exception
-                _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)
+                Dim process As Process = GetProcessUsingPort(My.Settings.sysLogPort, ProtocolType.Tcp)
+
+                If process Is Nothing Then
+                    _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)
+                Else
+                    Dim strLogText As String = $"Unable to start syslog server. A process with a PID of {process.Id} already has the port open."
+                    _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}{vbCrLf}{vbCrLf}{strLogText}", IPAddress.Loopback.ToString)
+                End If
             End Try
         End Function
 

--- a/Free SysLog/Support Code/Namespace Code/Task Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Task Handling.vb
@@ -5,14 +5,6 @@ Imports Free_SysLog.SupportCode
 
 Namespace TaskHandling
     Module TaskHandling
-        Private ParentForm As Form1
-
-        Public WriteOnly Property SetParentForm As Form1
-            Set(value As Form1)
-                ParentForm = value
-            End Set
-        End Property
-
         Public Function GetTaskObject(ByRef taskServiceObject As TaskService, nameOfTask As String, ByRef taskObject As Task) As Boolean
             Try
                 taskObject = taskServiceObject.GetTask($"\{nameOfTask}")

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -322,7 +322,7 @@ Public Class Alerts
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
 
-            MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
+            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -180,7 +180,7 @@ Public Class ConfigureSysLogMirrorClients
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfSysLogProxyServer, Newtonsoft.Json.Formatting.Indented))
 
-            MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
+            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -10,6 +10,7 @@ Public Class ConfigureSysLogMirrorClients
     Private Sub ConfigureSysLogMirrorServers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         BtnCancel.Visible = False
         Location = SupportCode.VerifyWindowLocation(My.Settings.syslogProxyLocation, Me)
+        Location = VerifyWindowLocation(My.Settings.syslogProxyLocation, Me)
         If My.Settings.ServersToSendTo IsNot Nothing AndAlso My.Settings.ServersToSendTo.Count > 0 Then
             Dim SysLogProxyServer As SysLogProxyServer
 

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -176,6 +176,7 @@ Partial Class Form1
         Me.LimitNumberOfIgnoredLogs.Name = "LimitNumberOfIgnoredLogs"
         Me.LimitNumberOfIgnoredLogs.Size = New System.Drawing.Size(239, 22)
         Me.LimitNumberOfIgnoredLogs.Text = "Limit Number of Ignored Logs"
+        Me.LimitNumberOfIgnoredLogs.ToolTipText = "Limits the number of ignored logs that stored in system RAM by the program."
         '
         'BtnOpenLogLocation
         '

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -874,9 +874,9 @@ Partial Class Form1
         '
         Me.LoadingProgressBar.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.LoadingProgressBar.Location = New System.Drawing.Point(977, 28)
+        Me.LoadingProgressBar.Location = New System.Drawing.Point(954, 28)
         Me.LoadingProgressBar.Name = "LoadingProgressBar"
-        Me.LoadingProgressBar.Size = New System.Drawing.Size(186, 23)
+        Me.LoadingProgressBar.Size = New System.Drawing.Size(209, 23)
         Me.LoadingProgressBar.TabIndex = 19
         Me.LoadingProgressBar.Visible = False
         '
@@ -905,7 +905,7 @@ Partial Class Form1
         '
         Me.btnShowLimit.Location = New System.Drawing.Point(909, 27)
         Me.btnShowLimit.Name = "btnShowLimit"
-        Me.btnShowLimit.Size = New System.Drawing.Size(62, 23)
+        Me.btnShowLimit.Size = New System.Drawing.Size(39, 23)
         Me.btnShowLimit.TabIndex = 45
         Me.btnShowLimit.Text = "Limit"
         Me.btnShowLimit.UseVisualStyleBackColor = True

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -918,7 +918,7 @@ Partial Class Form1
         Me.boxLimiter.Location = New System.Drawing.Point(595, 29)
         Me.boxLimiter.Name = "boxLimiter"
         Me.boxLimiter.Size = New System.Drawing.Size(250, 21)
-        Me.boxLimiter.Text = "(Not Specified)"
+        Me.boxLimiter.Sorted = True
         Me.boxLimiter.TabIndex = 44
         '
         'boxLimitBy

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -903,6 +903,7 @@ Partial Class Form1
         '
         'btnShowLimit
         '
+        Me.btnShowLimit.Enabled = False
         Me.btnShowLimit.Location = New System.Drawing.Point(909, 27)
         Me.btnShowLimit.Name = "btnShowLimit"
         Me.btnShowLimit.Size = New System.Drawing.Size(39, 23)

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -26,6 +26,7 @@ Partial Class Form1
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Me.BtnOpenLogLocation = New System.Windows.Forms.ToolStripMenuItem()
+        Me.LimitNumberOfIgnoredLogs = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnOpenLogForViewing = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnClearLog = New System.Windows.Forms.ToolStripMenuItem()
         Me.AlertsHistory = New System.Windows.Forms.ToolStripMenuItem()
@@ -169,6 +170,12 @@ Partial Class Form1
         Me.CreateAlertToolStripMenuItem.Name = "CreateAlertToolStripMenuItem"
         Me.CreateAlertToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
         Me.CreateAlertToolStripMenuItem.Text = "Create Alert"
+        '
+        'LimitNumberOfIgnoredLogs
+        '
+        Me.LimitNumberOfIgnoredLogs.Name = "LimitNumberOfIgnoredLogs"
+        Me.LimitNumberOfIgnoredLogs.Size = New System.Drawing.Size(239, 22)
+        Me.LimitNumberOfIgnoredLogs.Text = "Limit Number of Ignored Logs"
         '
         'BtnOpenLogLocation
         '
@@ -405,7 +412,7 @@ Partial Class Form1
         '
         'LogFunctionsToolStripMenuItem
         '
-        Me.LogFunctionsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AlertsHistory, Me.BtnClearLog, Me.ClearNotificationLimits, Me.ExportAllLogsToolStripMenuItem, Me.IgnoredLogsToolStripMenuItem, Me.BtnOpenLogLocation, Me.BtnOpenLogForViewing, Me.BtnSaveLogsToDisk, Me.ViewLogBackups, Me.ZerooutIgnoredLogsCounterToolStripMenuItem})
+        Me.LogFunctionsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AlertsHistory, Me.BtnClearLog, Me.ClearNotificationLimits, Me.ExportAllLogsToolStripMenuItem, Me.IgnoredLogsToolStripMenuItem, Me.LimitNumberOfIgnoredLogs, Me.BtnOpenLogLocation, Me.BtnOpenLogForViewing, Me.BtnSaveLogsToDisk, Me.ViewLogBackups, Me.ZerooutIgnoredLogsCounterToolStripMenuItem})
         Me.LogFunctionsToolStripMenuItem.Name = "LogFunctionsToolStripMenuItem"
         Me.LogFunctionsToolStripMenuItem.Size = New System.Drawing.Size(94, 20)
         Me.LogFunctionsToolStripMenuItem.Text = "Log Functions"
@@ -967,6 +974,7 @@ Partial Class Form1
 
     End Sub
     Friend WithEvents BtnOpenLogLocation As ToolStripMenuItem
+    Friend WithEvents LimitNumberOfIgnoredLogs As ToolStripMenuItem
     Friend WithEvents BtnOpenLogForViewing As ToolStripMenuItem
     Friend WithEvents SaveFileDialog As SaveFileDialog
     Friend WithEvents StatusStrip As StatusStrip

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1119,7 +1119,7 @@ Public Class Form1
 
     Private Sub ExportToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ExportToolStripMenuItem.Click
         Using SaveFileDialog As New SaveFileDialog()
-            SaveFileDialog.Title = "Safe Program Settings..."
+            SaveFileDialog.Title = "Save Program Settings..."
             SaveFileDialog.Filter = "JSON File|*.json"
 
             If SaveFileDialog.ShowDialog() = DialogResult.OK Then

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1018,7 +1018,12 @@ Public Class Form1
 
                 longNumberOfIgnoredLogs = 0
                 ClearIgnoredLogsToolStripMenuItem.Enabled = False
-                LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
+
+                If My.Settings.recordIgnoredLogs Then
+                    LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {IgnoredLogs.Count:N0}"
+                Else
+                    LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
+                End If
             End SyncLock
         End If
     End Sub

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -70,6 +70,7 @@ Public Class Form1
             UpdateLogCount()
             SelectLatestLogEntry()
             BtnSaveLogsToDisk.Enabled = True
+            recentUniqueObjects.Clear()
 
             NumberOfLogs.Text = $"Number of Log Entries: {Logs.Rows.Count:N0}"
         End SyncLock

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -999,16 +999,22 @@ Public Class Form1
     End Sub
 
     Private Sub ClearIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ClearIgnoredLogsToolStripMenuItem.Click
-        If MsgBox("Are you sure you want to clear the ignored logs stored in system memory?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then ClearIgnoredLogs()
-    End Sub
+        If MsgBox("Are you sure you want to clear the ignored logs stored in system memory?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then
+            SyncLock IgnoredLogsLockObject
+                For Each item As MyDataGridViewRow In IgnoredLogs
+                    item.Dispose()
+                Next
 
-    Public Sub ClearIgnoredLogs()
-        SyncLock IgnoredLogsLockObject
-            IgnoredLogs.Clear()
-            longNumberOfIgnoredLogs = 0
-            ClearIgnoredLogsToolStripMenuItem.Enabled = False
-            LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
-        End SyncLock
+                IgnoredLogs.Clear()
+
+                GC.Collect()
+                GC.WaitForPendingFinalizers()
+
+                longNumberOfIgnoredLogs = 0
+                ClearIgnoredLogsToolStripMenuItem.Enabled = False
+                LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
+            End SyncLock
+        End If
     End Sub
 
     Protected Overrides Sub WndProc(ByRef m As Message)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -330,6 +330,10 @@ Public Class Form1
         End If
     End Sub
 
+    Private Sub boxLimiter_SelectedValueChanged(sender As Object, e As EventArgs) Handles boxLimiter.SelectedValueChanged
+        btnShowLimit.Enabled = Not String.IsNullOrWhiteSpace(boxLimiter.Text)
+    End Sub
+
     Private Sub BoxLimitBy_SelectedValueChanged(sender As Object, e As EventArgs) Handles boxLimitBy.SelectedValueChanged
         boxLimiter.Text = Nothing
         boxLimiter.Items.Clear()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -497,10 +497,10 @@ Public Class Form1
     End Sub
 
     Private Sub RunWorkerCompleted(sender As Object, e As RunWorkerCompletedEventArgs)
-        If My.Settings.boolCheckForUpdates Then Threading.ThreadPool.QueueUserWorkItem(Sub()
-                                                                                           Dim checkForUpdatesClassObject As New checkForUpdates.CheckForUpdatesClass(Me)
-                                                                                           checkForUpdatesClassObject.CheckForUpdates(False)
-                                                                                       End Sub)
+        If Not boolDebugBuild AndAlso My.Settings.boolCheckForUpdates Then Threading.ThreadPool.QueueUserWorkItem(Sub()
+                                                                                                                      Dim checkForUpdatesClassObject As New checkForUpdates.CheckForUpdatesClass(Me)
+                                                                                                                      checkForUpdatesClassObject.CheckForUpdates(False)
+                                                                                                                  End Sub)
 
         If boolDoWeOwnTheMutex Then
             serverThread = New Threading.Thread(AddressOf SysLogThread) With {.Name = "UDP Server Thread", .Priority = Threading.ThreadPriority.Normal}

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -846,7 +846,7 @@ Public Class Form1
         End If
 
         Try
-            Mutex.ReleaseMutex()
+            mutex.ReleaseMutex()
         Catch ex As ApplicationException
         End Try
 
@@ -1147,7 +1147,7 @@ Public Class Form1
                 Process.Start(strEXEPath)
 
                 Try
-                    Mutex.ReleaseMutex()
+                    mutex.ReleaseMutex()
                 Catch ex As ApplicationException
                 End Try
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -184,7 +184,10 @@ Public Class Form1
                 My.Settings.boolMaximized = WindowState = FormWindowState.Maximized
             End If
 
-            If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.BtnViewMainWindow.Enabled = WindowState = FormWindowState.Minimized
+            SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
+                If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.BtnViewMainWindow.Enabled = WindowState = FormWindowState.Minimized
+            End SyncLock
+
             If MinimizeToClockTray.Checked Then ShowInTaskbar = WindowState <> FormWindowState.Minimized
 
             Logs.Invalidate()
@@ -988,14 +991,16 @@ Public Class Form1
     End Sub
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
-        If IgnoredLogsAndSearchResultsInstance Is Nothing Then
-            IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = IgnoredLogs, .Text = "Ignored Logs"}
-            IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
-            IgnoredLogsAndSearchResultsInstance.Show()
-        Else
-            IgnoredLogsAndSearchResultsInstance.WindowState = FormWindowState.Normal
-            IgnoredLogsAndSearchResultsInstance.BringToFront()
-        End If
+        SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
+            If IgnoredLogsAndSearchResultsInstance Is Nothing Then
+                IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = IgnoredLogs, .Text = "Ignored Logs"}
+                IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
+                IgnoredLogsAndSearchResultsInstance.Show()
+            Else
+                IgnoredLogsAndSearchResultsInstance.WindowState = FormWindowState.Normal
+                IgnoredLogsAndSearchResultsInstance.BringToFront()
+            End If
+        End SyncLock
     End Sub
 
     Private Sub ClearIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ClearIgnoredLogsToolStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -70,7 +70,10 @@ Public Class Form1
             UpdateLogCount()
             SelectLatestLogEntry()
             BtnSaveLogsToDisk.Enabled = True
-            recentUniqueObjects.Clear()
+
+            SyncLock recentUniqueObjects
+                recentUniqueObjects.Clear()
+            End SyncLock
 
             NumberOfLogs.Text = $"Number of Log Entries: {Logs.Rows.Count:N0}"
         End SyncLock
@@ -335,30 +338,32 @@ Public Class Form1
 
         Dim sortedList As List(Of String)
 
-        If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = recentUniqueObjects.logTypes.ToList()
-            sortedList.Sort()
+        SyncLock recentUniqueObjects
+            If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                sortedList = recentUniqueObjects.logTypes.ToList()
+                sortedList.Sort()
 
-            boxLimiter.Items.AddRange(sortedList.ToArray)
-        ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = recentUniqueObjects.processes.ToList()
-            sortedList.Sort()
+                boxLimiter.Items.AddRange(sortedList.ToArray)
+            ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                sortedList = recentUniqueObjects.processes.ToList()
+                sortedList.Sort()
 
-            boxLimiter.Items.AddRange(sortedList.ToArray)
-        ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = recentUniqueObjects.hostNames.ToList()
-            sortedList.Sort()
+                boxLimiter.Items.AddRange(sortedList.ToArray)
+            ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                sortedList = recentUniqueObjects.hostNames.ToList()
+                sortedList.Sort()
 
-            boxLimiter.Items.AddRange(sortedList.ToArray)
-        ElseIf boxLimitBy.Text.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = recentUniqueObjects.ipAddresses.ToList()
-            sortedList.Sort()
+                boxLimiter.Items.AddRange(sortedList.ToArray)
+            ElseIf boxLimitBy.Text.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+                sortedList = recentUniqueObjects.ipAddresses.ToList()
+                sortedList.Sort()
 
-            boxLimiter.Items.AddRange(sortedList.ToArray)
-        Else
-            boxLimiter.Text = "(Not Specified)"
-            boxLimiter.Enabled = False
-        End If
+                boxLimiter.Items.AddRange(sortedList.ToArray)
+            Else
+                boxLimiter.Text = "(Not Specified)"
+                boxLimiter.Enabled = False
+            End If
+        End SyncLock
     End Sub
 
     Private Function FormatSecondsToReadableTime(input As Integer) As String

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -16,6 +16,7 @@ Public Class Form1
     Private boolDoneLoading As Boolean = False
     Public longNumberOfIgnoredLogs As Long = 0
     Public IgnoredLogs As New List(Of MyDataGridViewRow)
+    Public IgnoredLogsLockingObject As New Object
     Public intSortColumnIndex As Integer = 0 ' Define intColumnNumber at class level
     Public sortOrder As SortOrder = SortOrder.Ascending ' Define soSortOrder at class level
     Public ReadOnly dataGridLockObject As New Object
@@ -1012,7 +1013,9 @@ Public Class Form1
                     item.Dispose()
                 Next
 
-                IgnoredLogs.Clear()
+                SyncLock IgnoredLogsLockingObject
+                    IgnoredLogs.Clear()
+                End SyncLock
 
                 GC.Collect()
                 GC.WaitForPendingFinalizers()
@@ -1048,7 +1051,10 @@ Public Class Form1
         longNumberOfIgnoredLogs = 0
 
         If Not ChkEnableRecordingOfIgnoredLogs.Checked Then
-            IgnoredLogs.Clear()
+            SyncLock IgnoredLogsLockingObject
+                IgnoredLogs.Clear()
+            End SyncLock
+
             LblNumberOfIgnoredIncomingLogs.Text = "Number of ignored incoming logs: 0"
         End If
     End Sub

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -241,6 +241,7 @@ Public Class Form1
         AutomaticallyCheckForUpdates.Checked = My.Settings.boolCheckForUpdates
         ChkDeselectItemAfterMinimizingWindow.Checked = My.Settings.boolDeselectItemsWhenMinimizing
         ChkEnableRecordingOfIgnoredLogs.Checked = My.Settings.recordIgnoredLogs
+        LimitNumberOfIgnoredLogs.Visible = My.Settings.recordIgnoredLogs
         IgnoredLogsToolStripMenuItem.Visible = ChkEnableRecordingOfIgnoredLogs.Checked
         ZerooutIgnoredLogsCounterToolStripMenuItem.Visible = Not ChkEnableRecordingOfIgnoredLogs.Checked
         ChkEnableAutoScroll.Checked = My.Settings.autoScroll
@@ -1041,6 +1042,7 @@ Public Class Form1
 
     Private Sub ChkRecordIgnoredLogs_Click(sender As Object, e As EventArgs) Handles ChkEnableRecordingOfIgnoredLogs.Click
         My.Settings.recordIgnoredLogs = ChkEnableRecordingOfIgnoredLogs.Checked
+        LimitNumberOfIgnoredLogs.Visible = My.Settings.recordIgnoredLogs
         IgnoredLogsToolStripMenuItem.Visible = ChkEnableRecordingOfIgnoredLogs.Checked
         ZerooutIgnoredLogsCounterToolStripMenuItem.Visible = Not ChkEnableRecordingOfIgnoredLogs.Checked
         longNumberOfIgnoredLogs = 0

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -71,7 +71,7 @@ Public Class Form1
             SelectLatestLogEntry()
             BtnSaveLogsToDisk.Enabled = True
 
-            SyncLock recentUniqueObjects
+            SyncLock recentUniqueObjectsLock
                 recentUniqueObjects.Clear()
             End SyncLock
 
@@ -338,7 +338,7 @@ Public Class Form1
 
         Dim sortedList As List(Of String)
 
-        SyncLock recentUniqueObjects
+        SyncLock recentUniqueObjectsLock
             If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
                 sortedList = recentUniqueObjects.logTypes.ToList()
                 sortedList.Sort()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1026,6 +1026,7 @@ Public Class Form1
         My.Settings.recordIgnoredLogs = ChkEnableRecordingOfIgnoredLogs.Checked
         IgnoredLogsToolStripMenuItem.Visible = ChkEnableRecordingOfIgnoredLogs.Checked
         ZerooutIgnoredLogsCounterToolStripMenuItem.Visible = Not ChkEnableRecordingOfIgnoredLogs.Checked
+        longNumberOfIgnoredLogs = 0
 
         If Not ChkEnableRecordingOfIgnoredLogs.Checked Then
             IgnoredLogs.Clear()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -402,6 +402,7 @@ Public Class Form1
         ChangeLogAutosaveIntervalToolStripMenuItem.Text = $"        Change Log Autosave Interval ({My.Settings.autoSaveMinutes} Minutes)"
         ChangeSyslogServerPortToolStripMenuItem.Text = $"Change Syslog Server Port (Port Number {My.Settings.sysLogPort})"
         ConfigureTimeBetweenSameNotifications.Text = $"Configure Time Between Same Notifications ({My.Settings.TimeBetweenSameNotifications} Seconds or {FormatSecondsToReadableTime(My.Settings.TimeBetweenSameNotifications)})"
+        LimitNumberOfIgnoredLogs.Text = $"Limit Number of Ignored Logs ({My.Settings.LimitNumberOfIgnoredLogs:N0})"
 
         ColTime.HeaderCell.Style.Padding = New Padding(0, 0, 1, 0)
         ColIPAddress.HeaderCell.Style.Padding = New Padding(0, 0, 2, 0)
@@ -1895,6 +1896,22 @@ Public Class Form1
                                               End Sub
 
         worker.RunWorkerAsync()
+    End Sub
+
+    Private Sub LimitNumberOfIgnoredLogs_Click(sender As Object, e As EventArgs) Handles LimitNumberOfIgnoredLogs.Click
+        Using IntegerInputForm As New IntegerInputForm(1, 2000) With {.Icon = Icon, .Text = "Limit Number of Ignored Logs", .StartPosition = FormStartPosition.CenterParent}
+            IntegerInputForm.lblSetting.Text = "Limit Number of Ignored Logs"
+            IntegerInputForm.TxtSetting.Text = My.Settings.LimitNumberOfIgnoredLogs
+
+            IntegerInputForm.ShowDialog(Me)
+
+            If IntegerInputForm.DialogResult = DialogResult.OK Then
+                My.Settings.LimitNumberOfIgnoredLogs = IntegerInputForm.intResult
+                LimitNumberOfIgnoredLogs.Text = $"Limit Number of Ignored Logs ({My.Settings.LimitNumberOfIgnoredLogs:N0})"
+
+                MsgBox("Done.", MsgBoxStyle.Information, Text)
+            End If
+        End Using
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -386,9 +386,7 @@ Public Class Form1
     End Function
 
     Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        SyslogParser.SetParentForm = Me
-        DataHandling.SetParentForm = Me
-        TaskHandling.SetParentForm = Me
+        SupportCode.ParentForm = Me
 
         TaskHandling.ConvertRegistryRunCommandToTask()
 

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -142,7 +142,7 @@ Public Class Hostnames
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
 
-            MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
+            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SupportCode.SelectFileInWindowsExplorer(saveFileDialog.FileName)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -61,6 +61,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ColHostname = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
         Me.ViewIgnoredLogPatternToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkAutoScroll = New System.Windows.Forms.CheckBox()
         Me.OpenLogFileForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpenLogForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsLoadedInLabel = New System.Windows.Forms.ToolStripStatusLabel()
@@ -341,11 +342,23 @@ Partial Class IgnoredLogsAndSearchResults
         Me.OpenLogForViewingToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
         Me.OpenLogForViewingToolStripMenuItem.Text = "Open Log for Viewing"
         '
+        'ChkAutoScroll
+        '
+        Me.ChkAutoScroll.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.ChkAutoScroll.AutoSize = True
+        Me.ChkAutoScroll.Location = New System.Drawing.Point(1251, 381)
+        Me.ChkAutoScroll.Name = "ChkAutoScroll"
+        Me.ChkAutoScroll.Size = New System.Drawing.Size(77, 17)
+        Me.ChkAutoScroll.TabIndex = 31
+        Me.ChkAutoScroll.Text = "Auto Scroll"
+        Me.ChkAutoScroll.UseVisualStyleBackColor = True
+        '
         'IgnoredLogsAndSearchResults
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1563, 425)
+        Me.Controls.Add(Me.ChkAutoScroll)
         Me.Controls.Add(Me.LoadingProgressBar)
         Me.Controls.Add(Me.ChkColLogsAutoFill)
         Me.Controls.Add(Me.BtnViewMainWindow)
@@ -401,4 +414,5 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents LoadingProgressBar As ProgressBar
     Friend WithEvents ViewIgnoredLogPatternToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OpenLogForViewingToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ChkAutoScroll As CheckBox
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -62,6 +62,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
         Me.ViewIgnoredLogPatternToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpenLogFileForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OpenLogForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsLoadedInLabel = New System.Windows.Forms.ToolStripStatusLabel()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.LogsContextMenu.SuspendLayout()
@@ -201,9 +202,9 @@ Partial Class IgnoredLogsAndSearchResults
         '
         'LogsContextMenu
         '
-        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
+        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.OpenLogForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
         Me.LogsContextMenu.Name = "LogsContextMenu"
-        Me.LogsContextMenu.Size = New System.Drawing.Size(211, 136)
+        Me.LogsContextMenu.Size = New System.Drawing.Size(211, 158)
         '
         'CopyLogTextToolStripMenuItem
         '
@@ -334,6 +335,12 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ViewIgnoredLogPatternToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
         Me.ViewIgnoredLogPatternToolStripMenuItem.Text = "View Ignored Log Pattern"
         '
+        'OpenLogForViewingToolStripMenuItem
+        '
+        Me.OpenLogForViewingToolStripMenuItem.Name = "OpenLogForViewingToolStripMenuItem"
+        Me.OpenLogForViewingToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.OpenLogForViewingToolStripMenuItem.Text = "Open Log for Viewing"
+        '
         'IgnoredLogsAndSearchResults
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -393,4 +400,5 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents ChkColLogsAutoFill As CheckBox
     Friend WithEvents LoadingProgressBar As ProgressBar
     Friend WithEvents ViewIgnoredLogPatternToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents OpenLogForViewingToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -62,6 +62,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
         Me.ViewIgnoredLogPatternToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkAutoScroll = New System.Windows.Forms.CheckBox()
+        Me.ChkKeepIgnoredLogsPastUserLimit = New System.Windows.Forms.CheckBox()
         Me.OpenLogFileForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpenLogForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsLoadedInLabel = New System.Windows.Forms.ToolStripStatusLabel()
@@ -353,11 +354,23 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ChkAutoScroll.Text = "Auto Scroll"
         Me.ChkAutoScroll.UseVisualStyleBackColor = True
         '
+        'ChkKeepIgnoredLogsPastUserLimit
+        '
+        Me.ChkKeepIgnoredLogsPastUserLimit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.ChkKeepIgnoredLogsPastUserLimit.AutoSize = True
+        Me.ChkKeepIgnoredLogsPastUserLimit.Location = New System.Drawing.Point(1037, 381)
+        Me.ChkKeepIgnoredLogsPastUserLimit.Name = "ChkKeepIgnoredLogsPastUserLimit"
+        Me.ChkKeepIgnoredLogsPastUserLimit.Size = New System.Drawing.Size(208, 17)
+        Me.ChkKeepIgnoredLogsPastUserLimit.TabIndex = 32
+        Me.ChkKeepIgnoredLogsPastUserLimit.Text = "Keep Ignored Logs Past User-Set Limit"
+        Me.ChkKeepIgnoredLogsPastUserLimit.UseVisualStyleBackColor = True
+        '
         'IgnoredLogsAndSearchResults
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1563, 425)
+        Me.Controls.Add(Me.ChkKeepIgnoredLogsPastUserLimit)
         Me.Controls.Add(Me.ChkAutoScroll)
         Me.Controls.Add(Me.LoadingProgressBar)
         Me.Controls.Add(Me.ChkColLogsAutoFill)
@@ -415,4 +428,5 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents ViewIgnoredLogPatternToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OpenLogForViewingToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ChkAutoScroll As CheckBox
+    Friend WithEvents ChkKeepIgnoredLogsPastUserLimit As CheckBox
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -60,6 +60,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.colLogType = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColHostname = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
+        Me.ViewIgnoredLogPatternToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpenLogFileForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsLoadedInLabel = New System.Windows.Forms.ToolStripStatusLabel()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -200,9 +201,9 @@ Partial Class IgnoredLogsAndSearchResults
         '
         'LogsContextMenu
         '
-        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem})
+        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
         Me.LogsContextMenu.Name = "LogsContextMenu"
-        Me.LogsContextMenu.Size = New System.Drawing.Size(211, 92)
+        Me.LogsContextMenu.Size = New System.Drawing.Size(211, 136)
         '
         'CopyLogTextToolStripMenuItem
         '
@@ -327,6 +328,12 @@ Partial Class IgnoredLogsAndSearchResults
         Me.LoadingProgressBar.TabIndex = 30
         Me.LoadingProgressBar.Visible = False
         '
+        'ViewIgnoredLogPatternToolStripMenuItem
+        '
+        Me.ViewIgnoredLogPatternToolStripMenuItem.Name = "ViewIgnoredLogPatternToolStripMenuItem"
+        Me.ViewIgnoredLogPatternToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.ViewIgnoredLogPatternToolStripMenuItem.Text = "View Ignored Log Pattern"
+        '
         'IgnoredLogsAndSearchResults
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -385,4 +392,5 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents LogsLoadedInLabel As ToolStripStatusLabel
     Friend WithEvents ChkColLogsAutoFill As CheckBox
     Friend WithEvents LoadingProgressBar As ProgressBar
+    Friend WithEvents ViewIgnoredLogPatternToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -134,6 +134,7 @@ Public Class IgnoredLogsAndSearchResults
         If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
             BtnClearIgnoredLogs.Visible = True
             BtnViewMainWindow.Visible = True
+            ChkColLogsAutoFill.Location = New Point(135, 382)
         ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer Then
             BtnExport.Visible = False
             BtnViewMainWindow.Visible = True

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -186,6 +186,7 @@ Public Class IgnoredLogsAndSearchResults
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 
         ChkAutoScroll.Visible = _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored
+        ChkKeepIgnoredLogsPastUserLimit.Visible = _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored
 
         If _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
             Logs.SuspendLayout()
@@ -220,19 +221,23 @@ Public Class IgnoredLogsAndSearchResults
         Invoke(Sub()
                    Try
                        SyncLock logsLockObject
-                           If Logs.Rows.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                           If ChkKeepIgnoredLogsPastUserLimit.Checked Then
                                Logs.Rows.Add(ItemToAdd)
                            Else
-                               While Logs.Rows.Count >= My.Settings.LimitNumberOfIgnoredLogs
-                                   Logs.Rows.RemoveAt(0)
-                               End While
+                               If Logs.Rows.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                                   Logs.Rows.Add(ItemToAdd)
+                               Else
+                                   While Logs.Rows.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                                       Logs.Rows.RemoveAt(0)
+                                   End While
 
-                               Logs.Rows.Add(ItemToAdd)
+                                   Logs.Rows.Add(ItemToAdd)
+                               End If
                            End If
                        End SyncLock
 
                        If ChkAutoScroll.Checked Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
-                       LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
+                       LblCount.Text = $"Number of ignored logs: {Logs.Rows.Count:N0}"
                    Catch ex As Exception
                    End Try
                End Sub)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -12,6 +12,7 @@ Public Class IgnoredLogsAndSearchResults
     Private m_SortingColumn1, m_SortingColumn2 As ColumnHeader
     Private boolDoneLoading As Boolean = False
     Public MainProgramForm As Form1
+    Private logsLockObject As New Object
 
     Public boolLoadExternalData As Boolean = False
     Public strFileToLoad As String
@@ -215,15 +216,17 @@ Public Class IgnoredLogsAndSearchResults
     Public Sub AddIgnoredDatagrid(ItemToAdd As MyDataGridViewRow, BoolAutoScroll As Boolean)
         Invoke(Sub()
                    Try
-                       If parentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
-                           Logs.Rows.Add(ItemToAdd)
-                       Else
-                           While parentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
-                               Logs.Rows.RemoveAt(0)
-                           End While
+                       SyncLock logsLockObject
+                           If parentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                               Logs.Rows.Add(ItemToAdd)
+                           Else
+                               While parentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                                   Logs.Rows.RemoveAt(0)
+                               End While
 
-                           Logs.Rows.Add(ItemToAdd)
-                       End If
+                               Logs.Rows.Add(ItemToAdd)
+                           End If
+                       End SyncLock
 
                        If BoolAutoScroll Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
                        LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -347,7 +347,7 @@ Public Class IgnoredLogsAndSearchResults
             ExportSelectedLogsToolStripMenuItem.Visible = False
             CopyLogTextToolStripMenuItem.Visible = True
             CreateAlertToolStripMenuItem.Visible = True
-            OpenLogFileForViewingToolStripMenuItem.Visible = True
+            OpenLogFileForViewingToolStripMenuItem.Visible = _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.ignored
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -218,7 +218,10 @@ Public Class IgnoredLogsAndSearchResults
                        If parentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
                            Logs.Rows.Add(ItemToAdd)
                        Else
-                           Logs.Rows.RemoveAt(0)
+                           While parentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                               Logs.Rows.RemoveAt(0)
+                           End While
+
                            Logs.Rows.Add(ItemToAdd)
                        End If
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -185,6 +185,8 @@ Public Class IgnoredLogsAndSearchResults
         Logs.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 
+        ChkAutoScroll.Visible = _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored
+
         If _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
             Logs.SuspendLayout()
 
@@ -213,7 +215,7 @@ Public Class IgnoredLogsAndSearchResults
         boolDoneLoading = True
     End Sub
 
-    Public Sub AddIgnoredDatagrid(ItemToAdd As MyDataGridViewRow, BoolAutoScroll As Boolean)
+    Public Sub AddIgnoredDatagrid(ItemToAdd As MyDataGridViewRow)
         Invoke(Sub()
                    Try
                        SyncLock logsLockObject
@@ -228,7 +230,7 @@ Public Class IgnoredLogsAndSearchResults
                            End If
                        End SyncLock
 
-                       If BoolAutoScroll Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
+                       If ChkAutoScroll.Checked Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
                        LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
                    Catch ex As Exception
                    End Try

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -603,4 +603,14 @@ Public Class IgnoredLogsAndSearchResults
             MainProgramForm.ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
         End If
     End Sub
+
+    Private Sub ChkKeepIgnoredLogsPastUserLimit_Click(sender As Object, e As EventArgs) Handles ChkKeepIgnoredLogsPastUserLimit.Click
+        If Not ChkKeepIgnoredLogsPastUserLimit.Checked AndAlso Logs.Rows.Count > My.Settings.LimitNumberOfIgnoredLogs Then
+            SyncLock logsLockObject
+                While Logs.Rows.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                    Logs.Rows.RemoveAt(0)
+                End While
+            End SyncLock
+        End If
+    End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -187,6 +187,12 @@ Public Class IgnoredLogsAndSearchResults
         If _WindowDisplayMode <> IgnoreOrSearchWindowDisplayMode.viewer Then
             Logs.SuspendLayout()
 
+            If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+                LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
+            Else
+                LblCount.Text = $"Number of search results: {LogsToBeDisplayed.Count:N0}"
+            End If
+
             Threading.ThreadPool.QueueUserWorkItem(Sub()
                                                        SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
                                                            LogsToBeDisplayed.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
@@ -196,15 +202,7 @@ Public Class IgnoredLogsAndSearchResults
                                                                Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
                                                            Next
 
-                                                           Invoke(Sub()
-                                                                      Logs.ResumeLayout()
-
-                                                                      If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
-                                                                          LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
-                                                                      Else
-                                                                          LblCount.Text = $"Number of search results: {LogsToBeDisplayed.Count:N0}"
-                                                                      End If
-                                                                  End Sub)
+                                                           Invoke(Sub() Logs.ResumeLayout())
                                                        End SyncLock
                                                    End Sub)
         ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -219,10 +219,10 @@ Public Class IgnoredLogsAndSearchResults
         Invoke(Sub()
                    Try
                        SyncLock logsLockObject
-                           If parentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                           If Logs.Rows.Count < My.Settings.LimitNumberOfIgnoredLogs Then
                                Logs.Rows.Add(ItemToAdd)
                            Else
-                               While parentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
+                               While Logs.Rows.Count >= My.Settings.LimitNumberOfIgnoredLogs
                                    Logs.Rows.RemoveAt(0)
                                End While
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -191,6 +191,7 @@ Public Class IgnoredLogsAndSearchResults
             Logs.SuspendLayout()
 
             If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
+                ColAlerts.Visible = False
                 LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
             Else
                 LblCount.Text = $"Number of search results: {LogsToBeDisplayed.Count:N0}"

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -564,6 +564,10 @@ Public Class IgnoredLogsAndSearchResults
         End If
     End Sub
 
+    Private Sub OpenLogForViewingToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles OpenLogForViewingToolStripMenuItem.Click
+        OpenLogViewerWindow()
+    End Sub
+
     Private Sub ChkColLogsAutoFill_Click(sender As Object, e As EventArgs) Handles ChkColLogsAutoFill.Click
         My.Settings.colLogAutoFill = ChkColLogsAutoFill.Checked
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -215,7 +215,13 @@ Public Class IgnoredLogsAndSearchResults
     Public Sub AddIgnoredDatagrid(ItemToAdd As MyDataGridViewRow, BoolAutoScroll As Boolean)
         Invoke(Sub()
                    Try
-                       Logs.Rows.Add(ItemToAdd)
+                       If parentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                           Logs.Rows.Add(ItemToAdd)
+                       Else
+                           Logs.Rows.RemoveAt(0)
+                           Logs.Rows.Add(ItemToAdd)
+                       End If
+
                        If BoolAutoScroll Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
                        LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
                    Catch ex As Exception

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -216,9 +216,12 @@ Public Class IgnoredLogsAndSearchResults
 
     Public Sub AddIgnoredDatagrid(ItemToAdd As MyDataGridViewRow, BoolAutoScroll As Boolean)
         Invoke(Sub()
-                   Logs.Rows.Add(ItemToAdd)
-                   If BoolAutoScroll Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
-                   LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
+                   Try
+                       Logs.Rows.Add(ItemToAdd)
+                       If BoolAutoScroll Then Logs.FirstDisplayedScrollingRowIndex = Logs.Rows.Count - 1
+                       LblCount.Text = $"Number of ignored logs: {LogsToBeDisplayed.Count:N0}"
+                   Catch ex As Exception
+                   End Try
                End Sub)
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -47,6 +47,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.TxtIgnored = New System.Windows.Forms.TextBox()
         Me.Label1 = New System.Windows.Forms.Label()
         Me.BtnCancel = New System.Windows.Forms.Button()
+        Me.btnDeleteDuringEditing = New System.Windows.Forms.Button()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -275,11 +276,21 @@ Partial Class IgnoredWordsAndPhrases
         Me.BtnCancel.Text = "Cancel"
         Me.BtnCancel.UseVisualStyleBackColor = True
         '
+        'btnDeleteDuringEditing
+        '
+        Me.btnDeleteDuringEditing.Location = New System.Drawing.Point(164, 348)
+        Me.btnDeleteDuringEditing.Name = "btnDeleteDuringEditing"
+        Me.btnDeleteDuringEditing.Size = New System.Drawing.Size(75, 23)
+        Me.btnDeleteDuringEditing.TabIndex = 46
+        Me.btnDeleteDuringEditing.Text = "Delete"
+        Me.btnDeleteDuringEditing.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(799, 378)
+        Me.Controls.Add(Me.btnDeleteDuringEditing)
         Me.Controls.Add(Me.BtnCancel)
         Me.Controls.Add(Me.ChkEnabled)
         Me.Controls.Add(Me.ChkCaseSensitive)
@@ -331,4 +342,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents TxtIgnored As TextBox
     Friend WithEvents Label1 As Label
     Friend WithEvents BtnCancel As Button
+    Friend WithEvents btnDeleteDuringEditing As Button
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -4,6 +4,7 @@ Public Class IgnoredWordsAndPhrases
     Private boolDoneLoading As Boolean = False
     Public boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
+    Public strIgnoredPattern As String = Nothing
 
     Private Function CheckForExistingItem(strIgnored As String) As Boolean
         Return IgnoredListView.Items.Cast(Of MyIgnoredListViewItem).Any(Function(item As MyIgnoredListViewItem)
@@ -98,6 +99,17 @@ Public Class IgnoredWordsAndPhrases
         Size = My.Settings.ConfigureIgnoredSize
 
         boolDoneLoading = True
+
+        If Not String.IsNullOrWhiteSpace(strIgnoredPattern) AndAlso CheckForExistingItem(strIgnoredPattern) Then
+            For Each item As ListViewItem In IgnoredListView.Items
+                If item.SubItems(0).Text.Equals(strIgnoredPattern, StringComparison.OrdinalIgnoreCase) Then
+                    item.Selected = True
+                    'IgnoredListView_Click(Nothing, Nothing)
+                    EditItem()
+                    Exit For
+                End If
+            Next
+        End If
     End Sub
 
     Private Sub IgnoredListView_KeyUp(sender As Object, e As KeyEventArgs) Handles IgnoredListView.KeyUp

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -80,6 +80,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
         BtnCancel.Visible = False
+        btnDeleteDuringEditing.Visible = False
         Location = VerifyWindowLocation(My.Settings.ignoredWordsLocation, Me)
         Dim MyIgnoredListViewItem As New List(Of MyIgnoredListViewItem)
 
@@ -104,6 +105,7 @@ Public Class IgnoredWordsAndPhrases
             For Each item As ListViewItem In IgnoredListView.Items
                 If item.SubItems(0).Text.Equals(strIgnoredPattern, StringComparison.OrdinalIgnoreCase) Then
                     item.Selected = True
+                    btnDeleteDuringEditing.Visible = True
                     IgnoredListView.Refresh()
                     'IgnoredListView_Click(Nothing, Nothing)
                     EditItem()
@@ -341,5 +343,18 @@ Public Class IgnoredWordsAndPhrases
         ChkRegex.Checked = False
         ChkEnabled.Checked = True
         BtnCancel.Visible = False
+    End Sub
+
+    Private Sub btnDeleteDuringEditing_Click(sender As Object, e As EventArgs) Handles btnDeleteDuringEditing.Click
+        IgnoredListView.SelectedItems(0).Remove()
+        IgnoredListView.Enabled = True
+        BtnAdd.Text = "Add"
+        Label4.Text = "Add Ignored Words and Phrases"
+        boolEditMode = False
+        boolChanged = True
+        TxtIgnored.Text = Nothing
+        ChkCaseSensitive.Checked = False
+        ChkRegex.Checked = False
+        ChkEnabled.Checked = True
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -104,6 +104,7 @@ Public Class IgnoredWordsAndPhrases
             For Each item As ListViewItem In IgnoredListView.Items
                 If item.SubItems(0).Text.Equals(strIgnoredPattern, StringComparison.OrdinalIgnoreCase) Then
                     item.Selected = True
+                    IgnoredListView.Refresh()
                     'IgnoredListView_Click(Nothing, Nothing)
                     EditItem()
                     Exit For

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -238,7 +238,7 @@ Public Class IgnoredWordsAndPhrases
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
 
-            MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
+            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -254,7 +254,7 @@ Public Class Replacements
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
 
-            MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
+            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
         End If
     End Sub
 

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -335,7 +335,7 @@ Partial Class ViewLogBackups
         Me.boxLimitBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.boxLimitBy.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.boxLimitBy.FormattingEnabled = True
-        Me.boxLimitBy.Items.AddRange(New Object() {"Not Specified", "Log Type", "Remote Process", "Source Hostname", "Source IP Address"})
+        Me.boxLimitBy.Items.AddRange(New Object() {"(Not Specified)", "Log Type", "Remote Process", "Source Hostname", "Source IP Address"})
         Me.boxLimitBy.Location = New System.Drawing.Point(55, 290)
         Me.boxLimitBy.Name = "boxLimitBy"
         Me.boxLimitBy.Size = New System.Drawing.Size(121, 21)

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -91,7 +91,7 @@ Partial Class ViewLogBackups
         '
         'ColFileDate
         '
-        Me.ColFileDate.HeaderText = "Creation Date"
+        Me.ColFileDate.HeaderText = "Modified Date"
         Me.ColFileDate.Name = "ColFileDate"
         Me.ColFileDate.ReadOnly = True
         Me.ColFileDate.Width = 240

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -56,6 +56,7 @@ Partial Class ViewLogBackups
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
+        Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.StatusStrip1.SuspendLayout()
         CType(Me.FileList, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -354,11 +355,22 @@ Partial Class ViewLogBackups
         Me.boxLimiter.Text = "(Not Specified)"
         Me.boxLimiter.TabIndex = 41
         '
+        'btnViewLogsWithLimits
+        '
+        Me.btnViewLogsWithLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnViewLogsWithLimits.Location = New System.Drawing.Point(438, 288)
+        Me.btnViewLogsWithLimits.Name = "btnViewLogsWithLimits"
+        Me.btnViewLogsWithLimits.Size = New System.Drawing.Size(110, 23)
+        Me.btnViewLogsWithLimits.TabIndex = 42
+        Me.btnViewLogsWithLimits.Text = "View All with Limits"
+        Me.btnViewLogsWithLimits.UseVisualStyleBackColor = True
+        '
         'ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(954, 364)
+        Me.Controls.Add(Me.btnViewLogsWithLimits)
         Me.Controls.Add(Me.boxLimiter)
         Me.Controls.Add(Me.boxLimitBy)
         Me.Controls.Add(Me.lblLimitBy)
@@ -424,4 +436,5 @@ Partial Class ViewLogBackups
     Friend WithEvents lblLimitBy As Label
     Friend WithEvents boxLimitBy As ComboBox
     Friend WithEvents boxLimiter As ComboBox
+    Friend WithEvents btnViewLogsWithLimits As Button
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -546,24 +546,28 @@ Public Class ViewLogBackups
         boxLimiter.Enabled = True
 
         Dim sortedList As List(Of String)
+        Dim combinedUniqueObjects As New uniqueObjectsClass
+
+        combinedUniqueObjects.Merge(allUniqueObjects)
+        combinedUniqueObjects.Merge(recentUniqueObjects)
 
         If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = allUniqueObjects.logTypes.ToList()
+            sortedList = combinedUniqueObjects.logTypes.ToList()
             sortedList.Sort()
 
             boxLimiter.Items.AddRange(sortedList.ToArray)
         ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = allUniqueObjects.processes.ToList()
+            sortedList = combinedUniqueObjects.processes.ToList()
             sortedList.Sort()
 
             boxLimiter.Items.AddRange(sortedList.ToArray)
         ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = allUniqueObjects.hostNames.ToList()
+            sortedList = combinedUniqueObjects.hostNames.ToList()
             sortedList.Sort()
 
             boxLimiter.Items.AddRange(sortedList.ToArray)
         ElseIf boxLimitBy.Text.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-            sortedList = allUniqueObjects.ipAddresses.ToList()
+            sortedList = combinedUniqueObjects.ipAddresses.ToList()
             sortedList.Sort()
 
             boxLimiter.Items.AddRange(sortedList.ToArray)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -109,7 +109,7 @@ Public Class ViewLogBackups
                                                        .Cells(0).Value = file.Name
                                                        .Cells(0).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
-                                                       .Cells(1).Value = $"{file.CreationTime.ToLongDateString} {file.CreationTime.ToLongTimeString}"
+                                                       .Cells(1).Value = $"{file.LastWriteTime.ToLongDateString} {file.LastWriteTime.ToLongTimeString}"
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        .Cells(2).Value = FileSizeToHumanSize(file.Length)

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -288,6 +288,9 @@
             <setting name="ProcessReplacementsInSyslogDataFirst" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="LimitNumberOfIgnoredLogs" serializeAs="String">
+                <value>1000</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
This is probably the biggest release of Free SysLog ever, it's chock full of new features and bug fixes.

- Added a clear operation to the uniqueObjectsClass to clear unique objects at Midnight.
- Added code to the syslog parsing code to add new data limiters as new logs come in.
- Added additional null checks before we go into the parsing of the XML data in the check for update code.
- Replaced the CheckFolderPermissionsByACLs() function with a simple CanWriteToFolder() function. All it does it checks to see if we can create a file instead of complex series of ACL checks.
- The program will now tell you if a process already has a port open and what PID it is.
- Fixed a possible NullReferenceException with the Notification Limiter code by changing the class to a plain module.
- Brought the new limiter code to the "View Log Backups" window.
- Added code to ask if the user wants to open Windows Explorer to the exported file.
- Fixed a bug where if the user enables the recording of ignored logs the ignored log counter isn't reset to zero.
- Fixed a bug on the "Ignored Logs and Search Results" when it's in ignored mode in which the "Open Log File for Viewing" menu item was visible when it shouldn't have been.
- Added the ability to view the pattern that resulted in an ignored log on the "Ignored Logs and Search Results" window when the window is in ignored mode.
- Added an "Open Log Viewer" menu item to the logs context menu on the "Ignored Logs and Search Results" window.
- Fixed a bug in which the item in the ignored list didn't appear to be selected when it should have been.
- Fixed a bug in which the "Logs Column AutoFill" checkbox was in the wrong place on the "Ignored Logs and Search Results" window when it was in ignored mode.
- Added a Delete button on the bottom of the "Ignored Words and Phrases" window.
- Updated the TaskScheduler NuGet package.
- Put some synclocks around the code that deals with the IgnoredLogsAndSearchResultsInstance to prevent a TOCTOU bug.
- But in a Try-Catch block to handle a possible duplicate entry cleanly.
- Moved the code to update the log count label to the beginning on the data load routine on the "Ignored Logs and Search Results" window.
- Added code to limit the number of log entries that are saved by the program in system RAM.
- Fixed a bug where the ignored log count was incorrect when recording ignored logs to system RAM.
- Changed code to reference the LastWriteTime instead of CreationTime on the "View Log Backups" window.
- Made it so that the Alerts column isn't shown on the "Ignored Logs and Search Results" window when the window is showing ignored logs.
- And a whole lot more changes under the hood with over fifty individual commits brought in from the dev branch.