### PR TITLE
Version 4.4 Build 1

### DIFF
--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -221,6 +221,12 @@
     </Compile>
     <Compile Include="Support Code\MyDataGridViewRow.vb" />
     <Compile Include="Support Code\Namespace Code\NativeMethod.vb" />
+    <Compile Include="Windows\OpenExplorer.Designer.vb">
+      <DependentUpon>OpenExplorer.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\OpenExplorer.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Windows\Replacements.Designer.vb">
       <DependentUpon>Replacements.vb</DependentUpon>
     </Compile>
@@ -288,6 +294,9 @@
       <LastGenOutput>Resources.Designer.vb</LastGenOutput>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Windows\OpenExplorer.resx">
+      <DependentUpon>OpenExplorer.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\Replacements.resx">
       <DependentUpon>Replacements.vb</DependentUpon>

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.3.1.100")>
+<Assembly: AssemblyFileVersion("4.4.1.101")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1208,6 +1208,18 @@ Namespace My
                 Me("LimitNumberOfIgnoredLogs") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property AskOpenExplorer() As Boolean
+            Get
+                Return CType(Me("AskOpenExplorer"),Boolean)
+            End Get
+            Set
+                Me("AskOpenExplorer") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1220,6 +1220,30 @@ Namespace My
                 Me("AskOpenExplorer") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("0")>  _
+        Public Property ignoredLogCount() As Long
+            Get
+                Return CType(Me("ignoredLogCount"),Long)
+            End Get
+            Set
+                Me("ignoredLogCount") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property saveIgnoredLogCount() As Boolean
+            Get
+                Return CType(Me("saveIgnoredLogCount"),Boolean)
+            End Get
+            Set
+                Me("saveIgnoredLogCount") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -293,5 +293,8 @@
     <Setting Name="LimitNumberOfIgnoredLogs" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1000</Value>
     </Setting>
+    <Setting Name="AskOpenExplorer" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -296,5 +296,11 @@
     <Setting Name="AskOpenExplorer" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ignoredLogCount" Type="System.Int64" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="saveIgnoredLogCount" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/My Custom ListViews.vb
+++ b/Free SysLog/Support Code/My Custom ListViews.vb
@@ -1,4 +1,9 @@
-﻿' This class extends the ListViewItem so that I can add more properties to it for my purposes.
+﻿Public Enum IgnoreType
+    MainLog = 0
+    RemoteApp = 1
+End Enum
+
+' This class extends the ListViewItem so that I can add more properties to it for my purposes.
 Public Class MyReplacementsListViewItem
     Inherits ListViewItem
     Implements ICloneable
@@ -18,6 +23,7 @@ Public Class MyIgnoredListViewItem
     Public Property BoolRegex As Boolean
     Public Property BoolCaseSensitive As Boolean
     Public Property BoolEnabled As Boolean
+    Public Property IgnoreType As IgnoreType
 
     Public Sub New(strInput As String)
         Me.Text = strInput

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -122,14 +122,14 @@ Public Class IgnoredClass
     Public IgnoreType As IgnoreType = IgnoreType.MainLog
 
     Public Function ToListViewItem() As MyIgnoredListViewItem
-        Dim intIgnoreType As Integer
-        If Not IgnoredHits.TryGetValue(StrIgnore, intIgnoreType) Then intIgnoreType = 0
+        Dim intHits As Integer
+        If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
 
         Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
         listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolCaseSensitive, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolEnabled, "Yes", "No"))
-        listViewItem.SubItems.Add(intIgnoreType.ToString("N0"))
+        listViewItem.SubItems.Add(intHits.ToString("N0"))
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -118,6 +118,7 @@ Public Class IgnoredClass
     Public BoolCaseSensitive As Boolean
     Public StrIgnore As String
     Public BoolEnabled As Boolean = True
+    Public IgnoreType As IgnoreType = IgnoreType.MainLog
 
     Public Function ToListViewItem() As MyIgnoredListViewItem
         Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
@@ -127,6 +128,7 @@ Public Class IgnoredClass
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled
+        listViewItem.IgnoreType = IgnoreType
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
         Return listViewItem
     End Function

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -67,6 +67,7 @@ Public Class ReplacementsClass
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
+        listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
         Return listViewItem
     End Function
 End Class
@@ -130,6 +131,7 @@ Public Class IgnoredClass
         listViewItem.BoolEnabled = BoolEnabled
         listViewItem.IgnoreType = IgnoreType
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
+        listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
         Return listViewItem
     End Function
 End Class

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -130,6 +130,7 @@ Public Class IgnoredClass
         listViewItem.SubItems.Add(If(BoolCaseSensitive, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolEnabled, "Yes", "No"))
         listViewItem.SubItems.Add(intHits.ToString("N0"))
+        listViewItem.SubItems.Add(If(IgnoreType = IgnoreType.MainLog, "Main Log Text", "Remote App"))
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -122,10 +122,14 @@ Public Class IgnoredClass
     Public IgnoreType As IgnoreType = IgnoreType.MainLog
 
     Public Function ToListViewItem() As MyIgnoredListViewItem
+        Dim intIgnoreType As Integer
+        If Not IgnoredHits.TryGetValue(StrIgnore, intIgnoreType) Then intIgnoreType = 0
+
         Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
         listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolCaseSensitive, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolEnabled, "Yes", "No"))
+        listViewItem.SubItems.Add(intIgnoreType.ToString("N0"))
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -182,6 +182,7 @@ Public Class AlertsClass
         listViewItem.BoolEnabled = BoolEnabled
         listViewItem.BoolLimited = BoolLimited
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
+        listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
         Return listViewItem
     End Function
 End Class

--- a/Free SysLog/Support Code/MyDataGridViewFileRowComparer.vb
+++ b/Free SysLog/Support Code/MyDataGridViewFileRowComparer.vb
@@ -22,8 +22,8 @@
 
             Return If(soSortOrder = SortOrder.Ascending, size1.CompareTo(size2), size2.CompareTo(size1))
         ElseIf intColumnNumber = 3 Then
-            Dim entry1 As Long = row1.entryCount
-            Dim entry2 As Long = row2.entryCount
+            Dim entry1 As UInteger = row1.entryCount
+            Dim entry2 As UInteger = row2.entryCount
 
             Return If(soSortOrder = SortOrder.Ascending, entry1.CompareTo(entry2), entry2.CompareTo(entry1))
         Else

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -31,7 +31,7 @@ Namespace checkForUpdates
         Public windowObject As Form1
         Private ReadOnly shortBuild As Short = Short.Parse(versionInfo(VersionPieces.build).Trim)
         Private ReadOnly versionStringWithoutBuild As Double = Double.Parse($"{versionInfo(VersionPieces.major)}.{versionInfo(VersionPieces.minor)}")
-        Private ReadOnly longInternalVersion As Long = Long.Parse(versionInfo(VersionPieces.revision))
+        Private ReadOnly intInternalVersion As Integer = Integer.Parse(versionInfo(VersionPieces.revision))
 
         Public Sub New(inputWindowObject As Form1)
             windowObject = inputWindowObject
@@ -73,14 +73,14 @@ Namespace checkForUpdates
                 remoteVersion = xmlNode.SelectSingleNode("version")?.InnerText?.Trim()
                 remoteBuild = xmlNode.SelectSingleNode("build")?.InnerText?.Trim()
 
-                Dim longInternalVersionFromXML As Long = 0
+                Dim intInternalVersionFromXML As Integer = 0
                 If xmlNode.SelectSingleNode("internalversion") IsNot Nothing Then
-                    If Long.TryParse(xmlNode.SelectSingleNode("internalversion").InnerText.Trim, longInternalVersionFromXML) Then
-                        If longInternalVersionFromXML = longInternalVersion Then ' If the internal version from the XML file matches the internal version from the program itself, we return a noUpdateNeeded value.
+                    If Integer.TryParse(xmlNode.SelectSingleNode("internalversion").InnerText.Trim, intInternalVersionFromXML) Then
+                        If intInternalVersionFromXML = intInternalVersion Then ' If the internal version from the XML file matches the internal version from the program itself, we return a noUpdateNeeded value.
                             Return ProcessUpdateXMLResponse.noUpdateNeeded
-                        ElseIf longInternalVersionFromXML > longInternalVersion Then ' If the internal version from the XML file is greater than the internal version from the program itself, we return a newVersion value.
+                        ElseIf intInternalVersionFromXML > intInternalVersion Then ' If the internal version from the XML file is greater than the internal version from the program itself, we return a newVersion value.
                             Return ProcessUpdateXMLResponse.newVersion
-                        ElseIf longInternalVersionFromXML < longInternalVersion Then
+                        ElseIf intInternalVersionFromXML < intInternalVersion Then
                             Return ProcessUpdateXMLResponse.newerVersionThanWebSite ' If the internal version from the XML file is less than the internal version from the program itself, we return a newerVersionThanWebSite value.
                         End If
                     Else

--- a/Free SysLog/Support Code/Namespace Code/Data Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Data Handling.vb
@@ -65,8 +65,21 @@ Namespace DataHandling
                         End If
                     End Using
 
-                    If MsgBox($"Data exported to ""{saveFileDialog.FileName}"" successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, ParentForm.Text) = MsgBoxResult.Yes Then
-                        SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    If My.Settings.AskOpenExplorer Then
+                        Using OpenExplorer As New OpenExplorer()
+                            OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                            OpenExplorer.MyParentForm = ParentForm
+
+                            Dim result As DialogResult = OpenExplorer.ShowDialog(ParentForm)
+
+                            If result = DialogResult.No Then
+                                Exit Sub
+                            ElseIf result = DialogResult.Yes Then
+                                SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                            End If
+                        End Using
+                    Else
+                        MsgBox("Data exported successfully.", MsgBoxStyle.Information, ParentForm.Text)
                     End If
                 End If
             End SyncLock
@@ -133,8 +146,21 @@ Namespace DataHandling
                         End If
                     End Using
 
-                    If MsgBox($"Data exported to ""{saveFileDialog.FileName}"" successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, ParentForm.Text) = MsgBoxResult.Yes Then
-                        SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    If My.Settings.AskOpenExplorer Then
+                        Using OpenExplorer As New OpenExplorer()
+                            OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                            OpenExplorer.MyParentForm = ParentForm
+
+                            Dim result As DialogResult = OpenExplorer.ShowDialog(ParentForm)
+
+                            If result = DialogResult.No Then
+                                Exit Sub
+                            ElseIf result = DialogResult.Yes Then
+                                SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                            End If
+                        End Using
+                    Else
+                        MsgBox("Data exported successfully.", MsgBoxStyle.Information, ParentForm.Text)
                     End If
                 End If
             End SyncLock

--- a/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
+++ b/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
@@ -28,6 +28,10 @@ Namespace NativeMethod
         <DllImport("shell32.dll", ExactSpelling:=True)>
         Public Shared Sub ILFree(pidlList As IntPtr)
         End Sub
+
+        <DllImport("user32.dll")>
+        Public Shared Function SetForegroundWindow(hwnd As IntPtr) As Boolean
+        End Function
     End Class
 
     Module APIs

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -49,7 +49,6 @@ Namespace SupportCode
         Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
         Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
 
-        Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)
         Public ignoredList As New List(Of IgnoredClass)
@@ -89,6 +88,23 @@ Namespace SupportCode
         Public recentUniqueObjects As uniqueObjectsClass
         Public ReadOnly recentUniqueObjectsLock As New Object()
         Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()
+
+
+        Public _boolIsProgrammaticScroll As Boolean = False
+        Private boolIsProgrammaticScrollLockObj As New Object()
+
+        Public Property boolIsProgrammaticScroll As Boolean
+            Set(value As Boolean)
+                SyncLock boolIsProgrammaticScrollLockObj
+                    _boolIsProgrammaticScroll = value
+                End SyncLock
+            End Set
+            Get
+                SyncLock boolIsProgrammaticScrollLockObj
+                    Return _boolIsProgrammaticScroll
+                End SyncLock
+            End Get
+        End Property
 
         Public WriteOnly Property AskOpenExplorer As Boolean
             Set(value As Boolean)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -53,6 +53,7 @@ Namespace SupportCode
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)
         Public ignoredList As New List(Of IgnoredClass)
+        Public ignoredListLockingObject As New Object()
         Public alertsList As New List(Of AlertsClass)
         Public serversList As New List(Of SysLogProxyServer)
         Public hostnames As New Dictionary(Of String, String)(StringComparison.OrdinalIgnoreCase)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -90,6 +90,13 @@ Namespace SupportCode
         Public ReadOnly recentUniqueObjectsLock As New Object()
         Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()
 
+        Public WriteOnly Property AskOpenExplorer As Boolean
+            Set(value As Boolean)
+                My.Settings.AskOpenExplorer = value
+                If ParentForm IsNot Nothing Then ParentForm.AskToOpenExplorerWhenSavingData.Checked = value
+            End Set
+        End Property
+
 #If DEBUG Then
         Public Const boolDebugBuild As Boolean = True
 #Else

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -1,9 +1,10 @@
-﻿Imports System.Net
+﻿Imports System.Collections.Concurrent
+Imports System.Net
+Imports System.Net.NetworkInformation
 Imports System.Net.Sockets
 Imports System.Text
-Imports System.Net.NetworkInformation
-Imports Microsoft.Toolkit.Uwp.Notifications
 Imports System.Text.RegularExpressions
+Imports Microsoft.Toolkit.Uwp.Notifications
 
 Namespace SupportCode
     Public Enum IgnoreOrSearchWindowDisplayMode As Byte
@@ -48,6 +49,7 @@ Namespace SupportCode
         Public AlertsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
         Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
         Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
 
         Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -49,6 +49,7 @@ Namespace SupportCode
         Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
         Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
 
+        Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)
         Public ignoredList As New List(Of IgnoredClass)
@@ -88,23 +89,6 @@ Namespace SupportCode
         Public recentUniqueObjects As uniqueObjectsClass
         Public ReadOnly recentUniqueObjectsLock As New Object()
         Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()
-
-
-        Public _boolIsProgrammaticScroll As Boolean = False
-        Private boolIsProgrammaticScrollLockObj As New Object()
-
-        Public Property boolIsProgrammaticScroll As Boolean
-            Set(value As Boolean)
-                SyncLock boolIsProgrammaticScrollLockObj
-                    _boolIsProgrammaticScroll = value
-                End SyncLock
-            End Set
-            Get
-                SyncLock boolIsProgrammaticScrollLockObj
-                    Return _boolIsProgrammaticScroll
-                End SyncLock
-            End Get
-        End Property
 
         Public WriteOnly Property AskOpenExplorer As Boolean
             Set(value As Boolean)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -47,8 +47,11 @@ Namespace SupportCode
         Public ParentForm As Form1
 
         Public AlertsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public AlertsRegexCacheLockingObject As New Object
         Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public ReplacementsRegexCacheLockingObject As New Object
         Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public IgnoredRegexCacheLockingObject As New Object()
         Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
 
         Public boolIsProgrammaticScroll As Boolean = False

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -7,7 +7,7 @@ Imports System.Threading
 Namespace SyslogParser
     Public Module SyslogParser
         Private ReadOnly rfc5424Regex As New Regex("<(?<priority>[0-9]+)>(?:\d ){0,1}(?<timestamp>[0-9]{4}[-.](?:1[0-2]|0[1-9])[-.](?:3[01]|[12][0-9]|0[1-9])T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]\.[0-9]+Z)(?: -){0,1} (?<hostname>(?:\\.|[^\n\r ])+) (?:\d+ ){0,1}(?<appname>(?:\\.|[^\n\r:]+?)(?: \d*){0,1}):{0,1} (?:- - %% ){0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
-        Private ReadOnly rfc5424TransformRegex As New Regex("<(?<priority>[0-9]+)>(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} (?<appname>(?:\\.|[^\n\r:]+)): (?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
+        Private ReadOnly rfc5424TransformRegex As New Regex("<(?<priority>[0-9]+)>(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} \[{0,1}(?<appname>(?:\\.|[^\n\r:]+))\]:{0,1} (?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
 
         Private ReadOnly NumberRemovingRegex As New Regex("([A-Za-z-]*)\[[0-9]*\]", RegexOptions.Compiled)
         Private ReadOnly SyslogPreProcessor1 As New Regex("\d+ (<\d+>)", RegexOptions.Compiled)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -360,7 +360,6 @@ Namespace SyslogParser
             Dim strRegexPattern As String = Nothing
             Dim matchFound As Boolean = False
             Dim _strIgnoredPattern As String = Nothing
-            Dim stopWatch As Stopwatch = Stopwatch.StartNew()
             Dim parallelOptions As New ParallelOptions With {.MaxDegreeOfParallelism = Environment.ProcessorCount}
 
             Try
@@ -397,7 +396,6 @@ Namespace SyslogParser
                 End SyncLock
 
                 If matchFound Then strIgnoredPattern = _strIgnoredPattern
-                Debug.WriteLine($"ProcessIgnoredLogPreferences took {stopWatch.ElapsedMilliseconds} ms to complete for message: {message}")
                 Return matchFound
             Catch ex As Exception
                 AddToLogList(Nothing, $"{strQuote}{strRegexPattern}{strQuote} failed to be processed.")

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -439,28 +439,32 @@ Namespace SyslogParser
 
             If Not boolIgnored Then
                 SyncLock ParentForm.dataGridLockObject
-                    ParentForm.Logs.Rows.Add(MakeDataGridRow(serverTimeStamp:=serverDate,
-                                                             dateObject:=currentDate,
-                                                             strTime:=currentDate.ToString,
-                                                             strSourceAddress:=strSourceIP,
-                                                             strHostname:=strHostname,
-                                                             strRemoteProcess:=strRemoteProcess,
-                                                             strLog:=strLogText,
-                                                             strLogType:=$"{priority.Severity}, {priority.Facility}",
-                                                             boolAlerted:=boolAlerted,
-                                                             strRawLogText:=strRawLogText.Trim,
-                                                             strAlertText:=strAlertText,
-                                                             AlertType:=alertType,
-                                                             dataGrid:=ParentForm.Logs)
-                                                            )
+                    ParentForm.Logs.Invoke(Sub()
+                                               ParentForm.Logs.Rows.Add(MakeDataGridRow(serverTimeStamp:=serverDate,
+                                                                                        dateObject:=currentDate,
+                                                                                        strTime:=currentDate.ToString,
+                                                                                        strSourceAddress:=strSourceIP,
+                                                                                        strHostname:=strHostname,
+                                                                                        strRemoteProcess:=strRemoteProcess,
+                                                                                        strLog:=strLogText,
+                                                                                        strLogType:=$"{priority.Severity}, {priority.Facility}",
+                                                                                        boolAlerted:=boolAlerted,
+                                                                                        strRawLogText:=strRawLogText.Trim,
+                                                                                        strAlertText:=strAlertText,
+                                                                                        AlertType:=alertType,
+                                                                                        dataGrid:=ParentForm.Logs)
+                                                                                       )
+                                           End Sub)
                     If ParentForm.intSortColumnIndex = 0 And ParentForm.sortOrder = SortOrder.Descending Then ParentForm.SortLogsByDateObjectNoLocking(ParentForm.intSortColumnIndex, ListSortDirection.Descending)
                 End SyncLock
 
                 ParentForm.NotifyIcon.Text = $"Free SysLog{vbCrLf}Last log received at {currentDate}."
                 ParentForm.UpdateLogCount()
-                ParentForm.BtnSaveLogsToDisk.Enabled = True
 
-                ParentForm.SelectLatestLogEntry()
+                ParentForm.Invoke(Sub()
+                                      ParentForm.BtnSaveLogsToDisk.Enabled = True
+                                      ParentForm.SelectLatestLogEntry()
+                                  End Sub)
             ElseIf boolIgnored Then
                 If ParentForm.ChkEnableRecordingOfIgnoredLogs.Checked Then
                     SyncLock ParentForm.IgnoredLogsLockObject

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -109,7 +109,6 @@ Namespace SyslogParser
                                       boolIsProgrammaticScroll = True
                                       ParentForm.Logs.BeginInvoke(Sub()
                                                                       ParentForm.Logs.FirstDisplayedScrollingRowIndex = If(ParentForm.sortOrder = SortOrder.Ascending, ParentForm.Logs.Rows.Count - 1, 0)
-                                                                      boolIsProgrammaticScroll = False
                                                                   End Sub)
                                   End If
                               End Sub)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -414,6 +414,7 @@ Namespace SyslogParser
                                                                                    If Not matchFound Then
                                                                                        _strIgnoredPattern = strRegexPattern
                                                                                        matchFound = True
+                                                                                       IgnoredHits.AddOrUpdate(strRegexPattern, 1, Function(key, oldValue) oldValue + 1)
                                                                                        state.Stop()
                                                                                        If ParentForm IsNot Nothing Then ParentForm.Invoke(Sub() Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs))
                                                                                    End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -7,7 +7,7 @@ Imports System.Threading
 Namespace SyslogParser
     Public Module SyslogParser
         Private ReadOnly rfc5424Regex As New Regex("<(?<priority>[0-9]+)>(?:\d ){0,1}(?<timestamp>[0-9]{4}[-.](?:1[0-2]|0[1-9])[-.](?:3[01]|[12][0-9]|0[1-9])T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]\.[0-9]+Z)(?: -){0,1} (?<hostname>(?:\\.|[^\n\r ])+) (?:\d+ ){0,1}(?<appname>(?:\\.|[^\n\r:]+?)(?: \d*){0,1}):{0,1} (?:- - %% ){0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
-        Private ReadOnly rfc5424TransformRegex As New Regex("<(?<priority>[0-9]+)>(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} \[{0,1}(?<appname>(?:\\.|[^\n\r:]+))\]:{0,1} (?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
+        Private ReadOnly rfc5424TransformRegex As New Regex("<{0,1}(?<priority>[0-9]{0,})>{0,1}(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} \[{0,1}(?<appname>(?:\\.|[^\n\r:]+))\]{0,1}:{0,1} {0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
 
         Private ReadOnly NumberRemovingRegex As New Regex("([A-Za-z-]*)\[[0-9]*\]", RegexOptions.Compiled)
         Private ReadOnly SyslogPreProcessor1 As New Regex("\d+ (<\d+>)", RegexOptions.Compiled)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -446,31 +446,29 @@ Namespace SyslogParser
             End If
 
             If Not boolIgnored Then
-                ParentForm.Invoke(Sub()
-                                      SyncLock ParentForm.dataGridLockObject
-                                          ParentForm.Logs.Rows.Add(MakeDataGridRow(serverTimeStamp:=serverDate,
-                                                                                   dateObject:=currentDate,
-                                                                                   strTime:=currentDate.ToString,
-                                                                                   strSourceAddress:=strSourceIP,
-                                                                                   strHostname:=strHostname,
-                                                                                   strRemoteProcess:=strRemoteProcess,
-                                                                                   strLog:=strLogText,
-                                                                                   strLogType:=$"{priority.Severity}, {priority.Facility}",
-                                                                                   boolAlerted:=boolAlerted,
-                                                                                   strRawLogText:=strRawLogText.Trim,
-                                                                                   strAlertText:=strAlertText,
-                                                                                   AlertType:=alertType,
-                                                                                   dataGrid:=ParentForm.Logs)
-                                                                                  )
-                                          If ParentForm.intSortColumnIndex = 0 And ParentForm.sortOrder = SortOrder.Descending Then ParentForm.SortLogsByDateObjectNoLocking(ParentForm.intSortColumnIndex, ListSortDirection.Descending)
-                                      End SyncLock
+                SyncLock ParentForm.dataGridLockObject
+                    ParentForm.Logs.Rows.Add(MakeDataGridRow(serverTimeStamp:=serverDate,
+                                                             dateObject:=currentDate,
+                                                             strTime:=currentDate.ToString,
+                                                             strSourceAddress:=strSourceIP,
+                                                             strHostname:=strHostname,
+                                                             strRemoteProcess:=strRemoteProcess,
+                                                             strLog:=strLogText,
+                                                             strLogType:=$"{priority.Severity}, {priority.Facility}",
+                                                             boolAlerted:=boolAlerted,
+                                                             strRawLogText:=strRawLogText.Trim,
+                                                             strAlertText:=strAlertText,
+                                                             AlertType:=alertType,
+                                                             dataGrid:=ParentForm.Logs)
+                                                            )
+                    If ParentForm.intSortColumnIndex = 0 And ParentForm.sortOrder = SortOrder.Descending Then ParentForm.SortLogsByDateObjectNoLocking(ParentForm.intSortColumnIndex, ListSortDirection.Descending)
+                End SyncLock
 
-                                      ParentForm.NotifyIcon.Text = $"Free SysLog{vbCrLf}Last log received at {currentDate}."
-                                      ParentForm.UpdateLogCount()
-                                      ParentForm.BtnSaveLogsToDisk.Enabled = True
+                ParentForm.NotifyIcon.Text = $"Free SysLog{vbCrLf}Last log received at {currentDate}."
+                ParentForm.UpdateLogCount()
+                ParentForm.BtnSaveLogsToDisk.Enabled = True
 
-                                      ParentForm.SelectLatestLogEntry()
-                                  End Sub)
+                ParentForm.SelectLatestLogEntry()
             ElseIf boolIgnored Then
                 If ParentForm.ChkEnableRecordingOfIgnoredLogs.Checked Then
                     SyncLock ParentForm.IgnoredLogsLockObject

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -363,8 +363,8 @@ Namespace SyslogParser
                     For Each ignoredClassInstance As IgnoredClass In ignoredList
                         strRegexPattern = ignoredClassInstance.StrIgnore
 
-                        If GetCachedRegex(IgnoredRegexCache, If(ignoredClassInstance.BoolRegex, ignoredClassInstance.StrIgnore, $".*{Regex.Escape(ignoredClassInstance.StrIgnore)}.*"), ignoredClassInstance.BoolCaseSensitive).IsMatch(message) Then
-                            strIgnoredPattern = ignoredClassInstance.StrIgnore
+                        If GetCachedRegex(IgnoredRegexCache, If(ignoredClassInstance.BoolRegex, strRegexPattern, $".*{Regex.Escape(strRegexPattern)}.*"), ignoredClassInstance.BoolCaseSensitive).IsMatch(message) Then
+                            strIgnoredPattern = strRegexPattern
                             ParentForm.Invoke(Sub() Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs))
                             Return True
                         End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -311,9 +311,9 @@ Namespace SyslogParser
                     ' Step 3: Handle the ignored logs and alerts
                     If My.Settings.ProcessReplacementsInSyslogDataFirst Then
                         If replacementsList IsNot Nothing AndAlso replacementsList.Any() Then message = ProcessReplacements(message)
-                        If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then boolIgnored = ProcessIgnoredLogPreferences(message, strIgnoredPattern)
+                        If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, strIgnoredPattern)
                     Else
-                        If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then boolIgnored = ProcessIgnoredLogPreferences(message, strIgnoredPattern)
+                        If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, strIgnoredPattern)
                         If replacementsList IsNot Nothing AndAlso replacementsList.Any() Then message = ProcessReplacements(message)
                     End If
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -377,7 +377,7 @@ Namespace SyslogParser
                                                                                strRegexPattern = ignoredClassInstance.StrIgnore
 
                                                                                ' Build the correct regex pattern based on the BoolRegex flag
-                                                                               Dim regexPattern As String = If(ignoredClassInstance.BoolRegex, strRegexPattern, $".*{Regex.Escape(strRegexPattern).Replace("\ ", " ")}.*")
+                                                                               Dim regexPattern As String = If(ignoredClassInstance.BoolRegex, strRegexPattern, Regex.Escape(strRegexPattern).Replace("\ ", " "))
 
                                                                                ' Get the cached regex or create it as needed
                                                                                Dim myRegExPattern As Regex = GetCachedRegex(IgnoredRegexCache, regexPattern, ignoredClassInstance.BoolCaseSensitive)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -377,7 +377,7 @@ Namespace SyslogParser
                                                                                strRegexPattern = ignoredClassInstance.StrIgnore
 
                                                                                ' Build the correct regex pattern based on the BoolRegex flag
-                                                                               Dim regexPattern As String = If(ignoredClassInstance.BoolRegex, strRegexPattern, $".*{Regex.Escape(strRegexPattern)}.*")
+                                                                               Dim regexPattern As String = If(ignoredClassInstance.BoolRegex, strRegexPattern, $".*{Regex.Escape(strRegexPattern).Replace("\ ", " ")}.*")
 
                                                                                ' Get the cached regex or create it as needed
                                                                                Dim myRegExPattern As Regex = GetCachedRegex(IgnoredRegexCache, regexPattern, ignoredClassInstance.BoolCaseSensitive)
@@ -502,7 +502,7 @@ Namespace SyslogParser
             SyncLock ReplacementsRegexCache
                 For Each item As ReplacementsClass In replacementsList
                     Try
-                        input = GetCachedRegex(ReplacementsRegexCache, If(item.BoolRegex, item.StrReplace, Regex.Escape(item.StrReplace)), item.BoolCaseSensitive).Replace(input, item.StrReplaceWith)
+                        input = GetCachedRegex(ReplacementsRegexCache, If(item.BoolRegex, item.StrReplace, Regex.Escape(item.StrReplace).Replace("\ ", " ")), item.BoolCaseSensitive).Replace(input, item.StrReplaceWith)
                     Catch ex As Exception
                     End Try
                 Next
@@ -524,7 +524,7 @@ Namespace SyslogParser
 
             SyncLock AlertsRegexCache
                 For Each alert As AlertsClass In alertsList
-                    RegExObject = GetCachedRegex(AlertsRegexCache, If(alert.BoolRegex, alert.StrLogText, Regex.Escape(alert.StrLogText)), alert.BoolCaseSensitive)
+                    RegExObject = GetCachedRegex(AlertsRegexCache, If(alert.BoolRegex, alert.StrLogText, Regex.Escape(alert.StrLogText).Replace("\ ", " ")), alert.BoolCaseSensitive)
 
                     If RegExObject.IsMatch(strLogText) Then
                         If alert.alertType = AlertType.Warning Then

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -374,9 +374,9 @@ Namespace SyslogParser
                         ' Parallel loop to check each pattern concurrently
                         Parallel.ForEach(ignoredList, parallelOptions, Sub(ignoredClassInstance As IgnoredClass, state As ParallelLoopState)
                                                                            If Not matchFound Then ' Check this flag to prevent unnecessary checks after a match
-                                                                               If ignoredClassInstance.StrIgnore.StartsWith("RemoteProcess:", StringComparison.OrdinalIgnoreCase) Then
+                                                                               If ignoredClassInstance.IgnoreType = IgnoreType.RemoteApp Then
                                                                                    If Not String.IsNullOrWhiteSpace(remoteProcess) Then
-                                                                                       Dim strRemoteProcess As String = ignoredClassInstance.StrIgnore.Substring("RemoteProcess:".Length).Trim()
+                                                                                       Dim strRemoteProcess As String = ignoredClassInstance.StrIgnore
 
                                                                                        If remoteProcess.CaseInsensitiveContains(strRemoteProcess) Then
                                                                                            SyncLock lockObj

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -106,12 +106,11 @@ Namespace SyslogParser
                                   ParentForm.BtnSaveLogsToDisk.Enabled = True
 
                                   If ParentForm.ChkEnableAutoScroll.Checked And ParentForm.Logs.Rows.Count > 0 And ParentForm.intSortColumnIndex = 0 Then
-                                      Try
-                                          boolIsProgrammaticScroll = True
-                                          ParentForm.Logs.FirstDisplayedScrollingRowIndex = If(ParentForm.sortOrder = SortOrder.Ascending, ParentForm.Logs.Rows.Count - 1, 0)
-                                      Finally
-                                          boolIsProgrammaticScroll = False
-                                      End Try
+                                      boolIsProgrammaticScroll = True
+                                      ParentForm.Logs.BeginInvoke(Sub()
+                                                                      ParentForm.Logs.FirstDisplayedScrollingRowIndex = If(ParentForm.sortOrder = SortOrder.Ascending, ParentForm.Logs.Rows.Count - 1, 0)
+                                                                      boolIsProgrammaticScroll = False
+                                                                  End Sub)
                                   End If
                               End Sub)
         End Sub

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -3,7 +3,6 @@ Imports System.Text.RegularExpressions
 Imports Free_SysLog.SupportCode
 Imports System.ComponentModel
 Imports System.Threading
-Imports Windows.AI.MachineLearning
 
 Namespace SyslogParser
     Public Module SyslogParser

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -388,7 +388,7 @@ Namespace SyslogParser
 
             Try
                 ' Using a SyncLock to protect the shared IgnoredRegexCache and prevent race conditions.
-                SyncLock IgnoredRegexCache
+                SyncLock IgnoredRegexCacheLockingObject
                     ' Use a thread-safe flag to stop Parallel.ForEach as soon as a match is found.
                     ' This ensures that only the first match updates the result.
                     Dim lockObj As New Object()
@@ -527,7 +527,7 @@ Namespace SyslogParser
         End Sub
 
         Private Function ProcessReplacements(input As String) As String
-            SyncLock ReplacementsRegexCache
+            SyncLock ReplacementsRegexCacheLockingObject
                 For Each item As ReplacementsClass In replacementsList
                     Try
                         input = GetCachedRegex(ReplacementsRegexCache, If(item.BoolRegex, item.StrReplace, Regex.Escape(item.StrReplace).Replace("\ ", " ")), item.BoolCaseSensitive).Replace(input, item.StrReplaceWith)
@@ -550,7 +550,7 @@ Namespace SyslogParser
             Dim strAlertText As String
             Dim regExGroupCollection As GroupCollection
 
-            SyncLock AlertsRegexCache
+            SyncLock AlertsRegexCacheLockingObject
                 For Each alert As AlertsClass In alertsList
                     RegExObject = GetCachedRegex(AlertsRegexCache, If(alert.BoolRegex, alert.StrLogText, Regex.Escape(alert.StrLogText).Replace("\ ", " ")), alert.BoolCaseSensitive)
 

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -234,7 +234,7 @@ Partial Class Alerts
         Me.lblRegExBackReferences.AutoSize = True
         Me.lblRegExBackReferences.Location = New System.Drawing.Point(196, 360)
         Me.lblRegExBackReferences.Name = "lblRegExBackReferences"
-        Me.lblRegExBackReferences.Size = New System.Drawing.Size(602, 26)
+        Me.lblRegExBackReferences.Size = New System.Drawing.Size(595, 26)
         Me.lblRegExBackReferences.TabIndex = 37
         Me.lblRegExBackReferences.Text = resources.GetString("lblRegExBackReferences.Text")
         '

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -76,6 +76,7 @@ Partial Class Alerts
         '
         'AlertsListView
         '
+        Me.AlertsListView.AllowDrop = True
         Me.AlertsListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)

--- a/Free SysLog/Windows/Alerts.resx
+++ b/Free SysLog/Windows/Alerts.resx
@@ -121,7 +121,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="lblRegExBackReferences.Text" xml:space="preserve">
-    <value>You can use RegEx back-references in your alert text. For numerical back-referenences, simply use put a $ before the number.
+    <value>You can use RegEx back-references in your alert text. For numerical back-references, simply use put a $ before the number.
 For named back-references, put a $ and then put the name of the back-reference inside parentheses. For example... $(name)</value>
   </data>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -325,9 +325,9 @@ Public Class Alerts
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
-                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+                    OpenExplorer.MyParentForm = Me
 
-                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
 
                     If result = DialogResult.No Then
                         Exit Sub

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -314,10 +314,12 @@ Public Class Alerts
             selectedItem.BoolEnabled = False
             selectedItem.SubItems(5).Text = "No"
             BtnEnableDisable.Text = "Enable"
+            selectedItem.BackColor = Color.Pink
         Else
             selectedItem.BoolEnabled = True
             selectedItem.SubItems(5).Text = "Yes"
             BtnEnableDisable.Text = "Disable"
+            selectedItem.BackColor = Color.LightGreen
         End If
 
         boolChanged = True

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -322,7 +322,22 @@ Public Class Alerts
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
 
-            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
+            If My.Settings.AskOpenExplorer Then
+                Using OpenExplorer As New OpenExplorer()
+                    OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+
+                    If result = DialogResult.No Then
+                        Exit Sub
+                    ElseIf result = DialogResult.Yes Then
+                        SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    End If
+                End Using
+            Else
+                MsgBox("Data exported successfully.", MsgBoxStyle.Information, SupportCode.ParentForm.Text)
+            End If
         End If
     End Sub
 

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -4,6 +4,46 @@ Public Class Alerts
     Private boolDoneLoading As Boolean = False
     Public boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
+    Private draggedItem As ListViewItem
+
+    Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles AlertsListView.ItemDrag
+        draggedItem = CType(e.Item, ListViewItem)
+        DoDragDrop(e.Item, DragDropEffects.Move)
+    End Sub
+
+    Private Sub IgnoredListView_DragEnter(sender As Object, e As DragEventArgs) Handles AlertsListView.DragEnter
+        If e.Data.GetDataPresent(GetType(ListViewItem)) Then
+            e.Effect = DragDropEffects.Move
+        Else
+            e.Effect = DragDropEffects.None
+        End If
+    End Sub
+
+    Private Sub IgnoredListView_DragOver(sender As Object, e As DragEventArgs) Handles AlertsListView.DragOver
+        e.Effect = DragDropEffects.Move
+    End Sub
+
+    Private Sub IgnoredListView_DragDrop(sender As Object, e As DragEventArgs) Handles AlertsListView.DragDrop
+        If draggedItem Is Nothing Then Return
+
+        Dim cp As Point = AlertsListView.PointToClient(New Point(e.X, e.Y))
+        Dim targetItem As ListViewItem = AlertsListView.GetItemAt(cp.X, cp.Y)
+
+        If targetItem Is Nothing OrElse targetItem Is draggedItem Then Return
+
+        Dim targetIndex As Integer = targetItem.Index
+        Dim draggedIndex As Integer = draggedItem.Index
+
+        ' Remove and re-insert the dragged item
+        AlertsListView.Items.RemoveAt(draggedIndex)
+        AlertsListView.Items.Insert(targetIndex, draggedItem)
+
+        ' Re-select the moved item
+        draggedItem.Selected = True
+        draggedItem.Focused = True
+
+        boolChanged = True ' Mark changes
+    End Sub
 
     Private Sub AlertTypeComboBox_SelectedIndexChanged(sender As Object, e As EventArgs) Handles AlertTypeComboBox.SelectedIndexChanged
         If AlertTypeComboBox.SelectedIndex = 0 Then

--- a/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
@@ -42,7 +42,7 @@ Partial Class CloseFreeSysLogDialog
         Me.Panel1.Controls.Add(Me.PictureBox1)
         Me.Panel1.Location = New System.Drawing.Point(0, 0)
         Me.Panel1.Name = "Panel1"
-        Me.Panel1.Size = New System.Drawing.Size(293, 58)
+        Me.Panel1.Size = New System.Drawing.Size(358, 58)
         Me.Panel1.TabIndex = 2
         '
         'Label1
@@ -64,7 +64,7 @@ Partial Class CloseFreeSysLogDialog
         '
         'BtnNo
         '
-        Me.BtnNo.Location = New System.Drawing.Point(123, 64)
+        Me.BtnNo.Location = New System.Drawing.Point(189, 64)
         Me.BtnNo.Name = "BtnNo"
         Me.BtnNo.Size = New System.Drawing.Size(75, 23)
         Me.BtnNo.TabIndex = 0
@@ -74,7 +74,7 @@ Partial Class CloseFreeSysLogDialog
         '
         'BtnYes
         '
-        Me.BtnYes.Location = New System.Drawing.Point(42, 64)
+        Me.BtnYes.Location = New System.Drawing.Point(108, 64)
         Me.BtnYes.Name = "BtnYes"
         Me.BtnYes.Size = New System.Drawing.Size(75, 23)
         Me.BtnYes.TabIndex = 2
@@ -84,7 +84,7 @@ Partial Class CloseFreeSysLogDialog
         '
         'BtnMinimize
         '
-        Me.BtnMinimize.Location = New System.Drawing.Point(204, 64)
+        Me.BtnMinimize.Location = New System.Drawing.Point(271, 64)
         Me.BtnMinimize.Name = "BtnMinimize"
         Me.BtnMinimize.Size = New System.Drawing.Size(75, 23)
         Me.BtnMinimize.TabIndex = 1
@@ -95,18 +95,18 @@ Partial Class CloseFreeSysLogDialog
         'ChkConfirmClose
         '
         Me.ChkConfirmClose.AutoSize = True
-        Me.ChkConfirmClose.Location = New System.Drawing.Point(12, 93)
+        Me.ChkConfirmClose.Location = New System.Drawing.Point(12, 68)
         Me.ChkConfirmClose.Name = "ChkConfirmClose"
-        Me.ChkConfirmClose.Size = New System.Drawing.Size(90, 17)
+        Me.ChkConfirmClose.Size = New System.Drawing.Size(96, 17)
         Me.ChkConfirmClose.TabIndex = 3
-        Me.ChkConfirmClose.Text = "Confirm Close"
+        Me.ChkConfirmClose.Text = "Confirm Close?"
         Me.ChkConfirmClose.UseVisualStyleBackColor = True
         '
         'CloseFreeSysLogDialog
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(291, 116)
+        Me.ClientSize = New System.Drawing.Size(354, 93)
         Me.Controls.Add(Me.ChkConfirmClose)
         Me.Controls.Add(Me.BtnMinimize)
         Me.Controls.Add(Me.BtnYes)

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.Designer.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.Designer.vb
@@ -54,6 +54,7 @@ Partial Class ConfigureSysLogMirrorClients
         '
         'servers
         '
+        Me.servers.AllowDrop = True
         Me.servers.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -184,9 +184,9 @@ Public Class ConfigureSysLogMirrorClients
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
-                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+                    OpenExplorer.MyParentForm = Me
 
-                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
 
                     If result = DialogResult.No Then
                         Exit Sub

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -181,7 +181,22 @@ Public Class ConfigureSysLogMirrorClients
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfSysLogProxyServer, Newtonsoft.Json.Formatting.Indented))
 
-            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
+            If My.Settings.AskOpenExplorer Then
+                Using OpenExplorer As New OpenExplorer()
+                    OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+
+                    If result = DialogResult.No Then
+                        Exit Sub
+                    ElseIf result = DialogResult.Yes Then
+                        SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    End If
+                End Using
+            Else
+                MsgBox("Data exported successfully.", MsgBoxStyle.Information, SupportCode.ParentForm.Text)
+            End If
         End If
     End Sub
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -6,6 +6,44 @@ Public Class ConfigureSysLogMirrorClients
     Public boolSuccess As Boolean = False
     Private boolEditMode As Boolean = False
     Private boolDoneLoading As Boolean = False
+    Private draggedItem As ListViewItem
+
+    Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles servers.ItemDrag
+        draggedItem = CType(e.Item, ListViewItem)
+        DoDragDrop(e.Item, DragDropEffects.Move)
+    End Sub
+
+    Private Sub IgnoredListView_DragEnter(sender As Object, e As DragEventArgs) Handles servers.DragEnter
+        If e.Data.GetDataPresent(GetType(ListViewItem)) Then
+            e.Effect = DragDropEffects.Move
+        Else
+            e.Effect = DragDropEffects.None
+        End If
+    End Sub
+
+    Private Sub IgnoredListView_DragOver(sender As Object, e As DragEventArgs) Handles servers.DragOver
+        e.Effect = DragDropEffects.Move
+    End Sub
+
+    Private Sub IgnoredListView_DragDrop(sender As Object, e As DragEventArgs) Handles servers.DragDrop
+        If draggedItem Is Nothing Then Return
+
+        Dim cp As Point = servers.PointToClient(New Point(e.X, e.Y))
+        Dim targetItem As ListViewItem = servers.GetItemAt(cp.X, cp.Y)
+
+        If targetItem Is Nothing OrElse targetItem Is draggedItem Then Return
+
+        Dim targetIndex As Integer = targetItem.Index
+        Dim draggedIndex As Integer = draggedItem.Index
+
+        ' Remove and re-insert the dragged item
+        servers.Items.RemoveAt(draggedIndex)
+        servers.Items.Insert(targetIndex, draggedItem)
+
+        ' Re-select the moved item
+        draggedItem.Selected = True
+        draggedItem.Focused = True
+    End Sub
 
     Private Sub ConfigureSysLogMirrorServers_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         BtnCancel.Visible = False

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -91,6 +91,7 @@ Partial Class Form1
         Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CopyRawLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.AboutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.CloseMe = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripMenuSeparator = New System.Windows.Forms.ToolStripSeparator()
@@ -762,7 +763,7 @@ Partial Class Form1
         '
         'LogsMenu
         '
-        Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
+        Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
         Me.LogsMenu.Name = "LogsMenu"
         Me.LogsMenu.Size = New System.Drawing.Size(183, 180)
         '
@@ -771,6 +772,12 @@ Partial Class Form1
         Me.CopyLogTextToolStripMenuItem.Name = "CopyLogTextToolStripMenuItem"
         Me.CopyLogTextToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
         Me.CopyLogTextToolStripMenuItem.Text = "Copy Log Text"
+        '
+        'CopyRawLogTextToolStripMenuItem
+        '
+        Me.CopyRawLogTextToolStripMenuItem.Name = "CopyRawLogTextToolStripMenuItem"
+        Me.CopyRawLogTextToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.CopyRawLogTextToolStripMenuItem.Text = "Copy Raw Log Text"
         '
         'OpenLogViewerToolStripMenuItem
         '
@@ -1078,6 +1085,7 @@ Partial Class Form1
     Friend WithEvents ChkEnableConfirmCloseToolStripItem As ToolStripMenuItem
     Friend WithEvents LogsMenu As ContextMenuStrip
     Friend WithEvents CopyLogTextToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents CopyRawLogTextToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OpenLogViewerToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents DeleteLogsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents DeleteSimilarLogsToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -40,6 +40,7 @@ Partial Class Form1
         Me.LblItemsSelected = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblLogFileSize = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblNumberOfIgnoredIncomingLogs = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.LblAutoScrollStatus = New System.Windows.Forms.ToolStripStatusLabel()
         Me.ChkEnableAutoScroll = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkDisableAutoScrollUponScrolling = New System.Windows.Forms.ToolStripMenuItem()
         Me.AutomaticallyCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
@@ -229,7 +230,7 @@ Partial Class Form1
         '
         'StatusStrip
         '
-        Me.StatusStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.NumberOfLogs, Me.LblItemsSelected, Me.LblAutoSaved, Me.LblLogFileSize, Me.LblNumberOfIgnoredIncomingLogs})
+        Me.StatusStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.NumberOfLogs, Me.LblItemsSelected, Me.LblAutoSaved, Me.LblLogFileSize, Me.LblNumberOfIgnoredIncomingLogs, Me.LblAutoScrollStatus})
         Me.StatusStrip.Location = New System.Drawing.Point(0, 424)
         Me.StatusStrip.Name = "StatusStrip"
         Me.StatusStrip.Size = New System.Drawing.Size(1175, 22)
@@ -267,9 +268,16 @@ Partial Class Form1
         '
         'LblNumberOfIgnoredIncomingLogs
         '
+        Me.LblNumberOfIgnoredIncomingLogs.Margin = New System.Windows.Forms.Padding(0, 3, 25, 2)
         Me.LblNumberOfIgnoredIncomingLogs.Name = "LblNumberOfIgnoredIncomingLogs"
         Me.LblNumberOfIgnoredIncomingLogs.Size = New System.Drawing.Size(200, 17)
         Me.LblNumberOfIgnoredIncomingLogs.Text = "Number of ignored incoming logs: 0"
+        '
+        'LblAutoScrollStatus
+        '
+        Me.LblAutoScrollStatus.Name = "LblAutoScrollStatus"
+        Me.LblAutoScrollStatus.Size = New System.Drawing.Size(200, 17)
+        Me.LblAutoScrollStatus.Text = "Auto Scroll Status: Disabled"
         '
         'AskToOpenExplorerWhenSavingData
         '
@@ -1021,6 +1029,7 @@ Partial Class Form1
     Friend WithEvents BtnSearch As Button
     Friend WithEvents ConfigureIgnoredWordsAndPhrasesToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents LblNumberOfIgnoredIncomingLogs As ToolStripStatusLabel
+    Friend WithEvents LblAutoScrollStatus As ToolStripStatusLabel
     Friend WithEvents ViewIgnoredLogsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ClearIgnoredLogsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents IgnoredLogsToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -111,6 +111,7 @@ Partial Class Form1
         Me.ProcessReplacementsInSyslogDataFirst = New System.Windows.Forms.ToolStripMenuItem()
         Me.RemoveNumbersFromRemoteApp = New System.Windows.Forms.ToolStripMenuItem()
         Me.ShowRawLogOnLogViewer = New System.Windows.Forms.ToolStripMenuItem()
+        Me.SaveIgnoredLogCount = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkShowLogTypeColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkShowServerTimeColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkShowHostnameColumn = New System.Windows.Forms.ToolStripMenuItem()
@@ -461,7 +462,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -872,6 +873,13 @@ Partial Class Form1
         Me.ShowRawLogOnLogViewer.Size = New System.Drawing.Size(319, 22)
         Me.ShowRawLogOnLogViewer.Text = "Show Raw Log on Log Viewer Window"
         '
+        'SaveIgnoredLogCount
+        '
+        Me.SaveIgnoredLogCount.CheckOnClick = True
+        Me.SaveIgnoredLogCount.Name = "SaveIgnoredLogCount"
+        Me.SaveIgnoredLogCount.Size = New System.Drawing.Size(319, 22)
+        Me.SaveIgnoredLogCount.Text = "Save Ignored Log Count"
+        '
         'CreateIgnoredLogToolStripMenuItem
         '
         Me.CreateIgnoredLogToolStripMenuItem.Name = "CreateIgnoredLogToolStripMenuItem"
@@ -1078,6 +1086,7 @@ Partial Class Form1
     Friend WithEvents ProcessReplacementsInSyslogDataFirst As ToolStripMenuItem
     Friend WithEvents RemoveNumbersFromRemoteApp As ToolStripMenuItem
     Friend WithEvents ShowRawLogOnLogViewer As ToolStripMenuItem
+    Friend WithEvents SaveIgnoredLogCount As ToolStripMenuItem
     Friend WithEvents ChkShowLogTypeColumn As ToolStripMenuItem
     Friend WithEvents ChkShowServerTimeColumn As ToolStripMenuItem
     Friend WithEvents ChkShowHostnameColumn As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -887,6 +887,9 @@ Partial Class Form1
         Me.SaveIgnoredLogCount.Name = "SaveIgnoredLogCount"
         Me.SaveIgnoredLogCount.Size = New System.Drawing.Size(319, 22)
         Me.SaveIgnoredLogCount.Text = "Save Ignored Log Count"
+        Me.SaveIgnoredLogCount.ToolTipText = "In case you want to reach a very high number without having" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "to keep the program " &
+    "running for a very long time. This is" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "more for the funzies, if you know what I " &
+    "mean."
         '
         'CreateIgnoredLogToolStripMenuItem
         '

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -448,11 +448,9 @@ Partial Class Form1
         '
         'ZerooutIgnoredLogsCounterToolStripMenuItem
         '
-        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = False
         Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Name = "ZerooutIgnoredLogsCounterToolStripMenuItem"
         Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
         Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Text = "Zero-out Ignored Logs Counter"
-        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Visible = False
         '
         'ViewLogBackups
         '

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -43,6 +43,7 @@ Partial Class Form1
         Me.ChkEnableAutoScroll = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkDisableAutoScrollUponScrolling = New System.Windows.Forms.ToolStripMenuItem()
         Me.AutomaticallyCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
+        Me.AskToOpenExplorerWhenSavingData = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
         Me.SaveTimer = New System.Windows.Forms.Timer(Me.components)
         Me.ChkEnableAutoSave = New System.Windows.Forms.ToolStripMenuItem()
@@ -269,6 +270,13 @@ Partial Class Form1
         Me.LblNumberOfIgnoredIncomingLogs.Size = New System.Drawing.Size(200, 17)
         Me.LblNumberOfIgnoredIncomingLogs.Text = "Number of ignored incoming logs: 0"
         '
+        'AskToOpenExplorerWhenSavingData
+        '
+        Me.AskToOpenExplorerWhenSavingData.CheckOnClick = True
+        Me.AskToOpenExplorerWhenSavingData.Name = "AskToOpenExplorerWhenSavingData"
+        Me.AskToOpenExplorerWhenSavingData.Size = New System.Drawing.Size(319, 22)
+        Me.AskToOpenExplorerWhenSavingData.Text = "Ask to open Explorer after saving a file to disk"
+        '
         'AutomaticallyCheckForUpdates
         '
         Me.AutomaticallyCheckForUpdates.CheckOnClick = True
@@ -455,7 +463,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -983,6 +991,7 @@ Partial Class Form1
     Friend WithEvents ChkEnableAutoScroll As ToolStripMenuItem
     Friend WithEvents ChkDisableAutoScrollUponScrolling As ToolStripMenuItem
     Friend WithEvents AutomaticallyCheckForUpdates As ToolStripMenuItem
+    Friend WithEvents AskToOpenExplorerWhenSavingData As ToolStripMenuItem
     Friend WithEvents BtnClearLog As ToolStripMenuItem
     Friend WithEvents AlertsHistory As ToolStripMenuItem
     Friend WithEvents BtnSaveLogsToDisk As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -237,6 +237,7 @@ Public Class Form1
 
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
 
+        AskToOpenExplorerWhenSavingData.Checked = My.Settings.AskOpenExplorer
         ColLogsAutoFill.Checked = My.Settings.colLogAutoFill
         IncludeButtonsOnNotifications.Checked = My.Settings.IncludeButtonsOnNotifications
         AutomaticallyCheckForUpdates.Checked = My.Settings.boolCheckForUpdates
@@ -1153,7 +1154,10 @@ Public Class Form1
             If SaveFileDialog.ShowDialog() = DialogResult.OK Then
                 Try
                     SaveAppSettings.SaveApplicationSettingsToFile(SaveFileDialog.FileName)
-                    If MsgBox("Application settings have been saved to disk. Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(SaveFileDialog.FileName)
+
+                    If My.Settings.AskOpenExplorer Then
+                        If MsgBox("Application settings have been saved to disk. Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(SaveFileDialog.FileName)
+                    End If
                 Catch ex As Exception
                     MsgBox("There was an issue saving your exported settings to disk, export failed.", MsgBoxStyle.Critical, Text)
                 End Try
@@ -1933,6 +1937,10 @@ Public Class Form1
                 MsgBox("Done.", MsgBoxStyle.Information, Text)
             End If
         End Using
+    End Sub
+
+    Private Sub AskToOpenExplorerWhenSavingData_Click(sender As Object, e As EventArgs) Handles AskToOpenExplorerWhenSavingData.Click
+        My.Settings.AskOpenExplorer = AskToOpenExplorerWhenSavingData.Checked
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -320,7 +320,7 @@ Public Class Form1
             End If
         End If
 
-        SyncLock ignoredList
+        SyncLock ignoredListLockingObject
             If My.Settings.ignored2 IsNot Nothing AndAlso My.Settings.ignored2.Count > 0 Then
                 For Each strJSONString As String In My.Settings.ignored2
                     tempIgnoredClass = Newtonsoft.Json.JsonConvert.DeserializeObject(Of IgnoredClass)(strJSONString, JSONDecoderSettingsForSettingsFiles)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1112,7 +1112,6 @@ Public Class Form1
     Private Sub ZerooutIgnoredLogsCounterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ZerooutIgnoredLogsCounterToolStripMenuItem.Click
         longNumberOfIgnoredLogs = 0
         LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
-        ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = False
     End Sub
 
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -999,7 +999,7 @@ Public Class Form1
             IgnoredWordsAndPhrasesOrAlertsInstance.ShowDialog(Me)
 
             If IgnoredWordsAndPhrasesOrAlertsInstance.boolChanged Then
-                SyncLock IgnoredRegexCache
+                SyncLock IgnoredRegexCacheLockingObject
                     IgnoredRegexCache.Clear()
                 End SyncLock
             End If
@@ -1128,7 +1128,7 @@ Public Class Form1
         Using ReplacementsInstance As New Replacements With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
             ReplacementsInstance.ShowDialog(Me)
 
-            SyncLock ReplacementsRegexCache
+            SyncLock ReplacementsRegexCacheLockingObject
                 If ReplacementsInstance.boolChanged Then
                     ReplacementsRegexCache.Clear()
                 End If
@@ -1437,7 +1437,7 @@ Public Class Form1
             Alerts.ShowDialog(Me)
 
             If Alerts.boolChanged Then
-                SyncLock AlertsRegexCache
+                SyncLock AlertsRegexCacheLockingObject
                     AlertsRegexCache.Clear()
                 End SyncLock
             End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -237,6 +237,7 @@ Public Class Form1
 
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
 
+        SaveIgnoredLogCount.Checked = My.Settings.saveIgnoredLogCount
         AskToOpenExplorerWhenSavingData.Checked = My.Settings.AskOpenExplorer
         ColLogsAutoFill.Checked = My.Settings.colLogAutoFill
         IncludeButtonsOnNotifications.Checked = My.Settings.IncludeButtonsOnNotifications
@@ -449,6 +450,11 @@ Public Class Form1
         ColRemoteProcess.Width = My.Settings.RemoteProcessHeaderSize
         ColLog.Width = My.Settings.columnLogSize
         ColAlerts.Width = My.Settings.columnAlertedSize
+
+        If My.Settings.saveIgnoredLogCount Then
+            longNumberOfIgnoredLogs = My.Settings.ignoredLogCount
+            LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
+        End If
 
         If My.Settings.font IsNot Nothing Then
             Logs.DefaultCellStyle.Font = My.Settings.font
@@ -845,6 +851,7 @@ Public Class Form1
             End SyncLock
         End If
 
+        If My.Settings.saveIgnoredLogCount Then My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
         My.Settings.logsColumnOrder = SaveColumnOrders(Logs.Columns)
         My.Settings.Save()
         DataHandling.WriteLogsToDisk()
@@ -1953,6 +1960,10 @@ Public Class Form1
 
     Private Sub AskToOpenExplorerWhenSavingData_Click(sender As Object, e As EventArgs) Handles AskToOpenExplorerWhenSavingData.Click
         My.Settings.AskOpenExplorer = AskToOpenExplorerWhenSavingData.Checked
+    End Sub
+
+    Private Sub SaveIgnoredLogCount_Click(sender As Object, e As EventArgs) Handles SaveIgnoredLogCount.Click
+        My.Settings.saveIgnoredLogCount = SaveIgnoredLogCount.Checked
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1482,10 +1482,16 @@ Public Class Form1
     End Sub
 
     Private Sub CreateIgnoredLogToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateIgnoredLogToolStripMenuItem.Click
-        Using Ignored As New IgnoredWordsAndPhrases With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-            Ignored.TxtIgnored.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
-            Ignored.ShowDialog(Me)
-        End Using
+        If Logs.SelectedRows.Count > 0 Then
+            Using Ignored As New IgnoredWordsAndPhrases With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+                Dim myItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+
+                If myItem IsNot Nothing Then
+                    Ignored.TxtIgnored.Text = myItem.RawLogData
+                    Ignored.ShowDialog(Me)
+                End If
+            End Using
+        End If
     End Sub
 
     Private Sub CreateReplacementToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateReplacementToolStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1156,7 +1156,20 @@ Public Class Form1
                     SaveAppSettings.SaveApplicationSettingsToFile(SaveFileDialog.FileName)
 
                     If My.Settings.AskOpenExplorer Then
-                        If MsgBox("Application settings have been saved to disk. Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(SaveFileDialog.FileName)
+                        Using OpenExplorer As New OpenExplorer()
+                            OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                            OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                            Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
+
+                            If result = DialogResult.No Then
+                                Exit Sub
+                            ElseIf result = DialogResult.Yes Then
+                                SelectFileInWindowsExplorer(SaveFileDialog.FileName)
+                            End If
+                        End Using
+                    Else
+                        MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
                     End If
                 Catch ex As Exception
                     MsgBox("There was an issue saving your exported settings to disk, export failed.", MsgBoxStyle.Critical, Text)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -26,6 +26,7 @@ Public Class Form1
     Private SyslogTcpServer As SyslogTcpServer.SyslogTcpServer
     Private boolServerRunning As Boolean = False
     Private boolTCPServerRunning As Boolean = False
+    Private lastFirstDisplayedRowIndex As Integer = -1
 
 #Region "--== Midnight Timer Code ==--"
     ' This implementation is based on code found at https://www.codeproject.com/Articles/18201/Midnight-Timer-A-Way-to-Detect-When-it-is-Midnight.
@@ -153,7 +154,6 @@ Public Class Form1
             boolIsProgrammaticScroll = True
             Logs.BeginInvoke(Sub()
                                  Logs.FirstDisplayedScrollingRowIndex = If(sortOrder = SortOrder.Ascending, Logs.Rows.Count - 1, 0)
-                                 boolIsProgrammaticScroll = False
                              End Sub)
         End If
     End Sub
@@ -1828,6 +1828,13 @@ Public Class Form1
             My.Settings.autoScroll = False
             ChkEnableAutoScroll.Checked = False
             LblAutoScrollStatus.Text = "Auto Scroll Status: Disabled"
+        End If
+
+        If Logs.FirstDisplayedScrollingRowIndex <> lastFirstDisplayedRowIndex Then
+            ' The visible area has changed, handle the change
+            lastFirstDisplayedRowIndex = Logs.FirstDisplayedScrollingRowIndex
+            ' Your custom logic when the first displayed row changes
+            boolIsProgrammaticScroll = False
         End If
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -318,13 +318,15 @@ Public Class Form1
             End If
         End If
 
-        If My.Settings.ignored2 IsNot Nothing AndAlso My.Settings.ignored2.Count > 0 Then
-            For Each strJSONString As String In My.Settings.ignored2
-                tempIgnoredClass = Newtonsoft.Json.JsonConvert.DeserializeObject(Of IgnoredClass)(strJSONString, JSONDecoderSettingsForSettingsFiles)
-                If tempIgnoredClass.BoolEnabled Then ignoredList.Add(tempIgnoredClass)
-                tempIgnoredClass = Nothing
-            Next
-        End If
+        SyncLock ignoredList
+            If My.Settings.ignored2 IsNot Nothing AndAlso My.Settings.ignored2.Count > 0 Then
+                For Each strJSONString As String In My.Settings.ignored2
+                    tempIgnoredClass = Newtonsoft.Json.JsonConvert.DeserializeObject(Of IgnoredClass)(strJSONString, JSONDecoderSettingsForSettingsFiles)
+                    If tempIgnoredClass.BoolEnabled Then ignoredList.Add(tempIgnoredClass)
+                    tempIgnoredClass = Nothing
+                Next
+            End If
+        End SyncLock
 
         If My.Settings.alerts IsNot Nothing AndAlso My.Settings.alerts.Count > 0 Then
             For Each strJSONString As String In My.Settings.alerts

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1295,6 +1295,9 @@ Public Class Form1
             CreateReplacementToolStripMenuItem.Visible = True
             CreateIgnoredLogToolStripMenuItem.Visible = True
             DeleteSimilarLogsToolStripMenuItem.Visible = True
+
+            Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+            If selectedItem IsNot Nothing Then CopyRawLogTextToolStripMenuItem.Visible = Not String.IsNullOrEmpty(selectedItem.RawLogData)
         Else
             CopyLogTextToolStripMenuItem.Visible = False
             OpenLogViewerToolStripMenuItem.Visible = False
@@ -1302,6 +1305,7 @@ Public Class Form1
             CreateReplacementToolStripMenuItem.Visible = False
             CreateIgnoredLogToolStripMenuItem.Visible = False
             DeleteSimilarLogsToolStripMenuItem.Visible = False
+            CopyRawLogTextToolStripMenuItem.Visible = False
         End If
 
         DeleteLogsToolStripMenuItem.Text = If(Logs.SelectedRows.Count = 1, "Delete Selected Log", "Delete Selected Logs")
@@ -1975,6 +1979,13 @@ Public Class Form1
 
     Private Sub SaveIgnoredLogCount_Click(sender As Object, e As EventArgs) Handles SaveIgnoredLogCount.Click
         My.Settings.saveIgnoredLogCount = SaveIgnoredLogCount.Checked
+    End Sub
+
+    Private Sub CopyRawLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyRawLogTextToolStripMenuItem.Click
+        If Logs.SelectedRows().Count <> 0 Then
+            Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+            If selectedItem IsNot Nothing Then CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
+        End If
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -451,6 +451,8 @@ Public Class Form1
         ColLog.Width = My.Settings.columnLogSize
         ColAlerts.Width = My.Settings.columnAlertedSize
 
+        LblAutoScrollStatus.Text = $"Auto Scroll Status: {If(ChkEnableAutoScroll.Checked, "Enabled", "Disabled")}"
+
         If My.Settings.saveIgnoredLogCount Then
             longNumberOfIgnoredLogs = My.Settings.ignoredLogCount
             LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
@@ -774,6 +776,7 @@ Public Class Form1
     Private Sub ChkAutoScroll_Click(sender As Object, e As EventArgs) Handles ChkEnableAutoScroll.Click
         My.Settings.autoScroll = ChkEnableAutoScroll.Checked
         ChkDisableAutoScrollUponScrolling.Enabled = ChkEnableAutoScroll.Checked
+        LblAutoScrollStatus.Text = "Auto Scroll Status: Enabled"
     End Sub
 
     Private Sub Logs_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles Logs.ColumnWidthChanged
@@ -1824,6 +1827,7 @@ Public Class Form1
         If ChkDisableAutoScrollUponScrolling.Checked AndAlso Not boolIsProgrammaticScroll AndAlso ChkEnableAutoScroll.Checked AndAlso e.NewValue < e.OldValue Then
             My.Settings.autoScroll = False
             ChkEnableAutoScroll.Checked = False
+            LblAutoScrollStatus.Text = "Auto Scroll Status: Disabled"
         End If
     End Sub
 

--- a/Free SysLog/Windows/Hostnames.Designer.vb
+++ b/Free SysLog/Windows/Hostnames.Designer.vb
@@ -42,6 +42,7 @@ Partial Class Hostnames
         '
         'ListHostnames
         '
+        Me.ListHostnames.AllowDrop = True
         Me.ListHostnames.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -145,9 +145,9 @@ Public Class Hostnames
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
-                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+                    OpenExplorer.MyParentForm = Me
 
-                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
 
                     If result = DialogResult.No Then
                         Exit Sub

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -4,6 +4,44 @@ Public Class Hostnames
     Private selectedItem As ListViewItem
     Private boolEditMode As Boolean = False
     Private boolDoneLoading As Boolean = False
+    Private draggedItem As ListViewItem
+
+    Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles ListHostnames.ItemDrag
+        draggedItem = CType(e.Item, ListViewItem)
+        DoDragDrop(e.Item, DragDropEffects.Move)
+    End Sub
+
+    Private Sub IgnoredListView_DragEnter(sender As Object, e As DragEventArgs) Handles ListHostnames.DragEnter
+        If e.Data.GetDataPresent(GetType(ListViewItem)) Then
+            e.Effect = DragDropEffects.Move
+        Else
+            e.Effect = DragDropEffects.None
+        End If
+    End Sub
+
+    Private Sub IgnoredListView_DragOver(sender As Object, e As DragEventArgs) Handles ListHostnames.DragOver
+        e.Effect = DragDropEffects.Move
+    End Sub
+
+    Private Sub IgnoredListView_DragDrop(sender As Object, e As DragEventArgs) Handles ListHostnames.DragDrop
+        If draggedItem Is Nothing Then Return
+
+        Dim cp As Point = ListHostnames.PointToClient(New Point(e.X, e.Y))
+        Dim targetItem As ListViewItem = ListHostnames.GetItemAt(cp.X, cp.Y)
+
+        If targetItem Is Nothing OrElse targetItem Is draggedItem Then Return
+
+        Dim targetIndex As Integer = targetItem.Index
+        Dim draggedIndex As Integer = draggedItem.Index
+
+        ' Remove and re-insert the dragged item
+        ListHostnames.Items.RemoveAt(draggedIndex)
+        ListHostnames.Items.Insert(targetIndex, draggedItem)
+
+        ' Re-select the moved item
+        draggedItem.Selected = True
+        draggedItem.Focused = True
+    End Sub
 
     Private Sub BtnEdit_Click(sender As Object, e As EventArgs) Handles BtnEdit.Click
         If ListHostnames.SelectedItems.Count > 0 Then

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -142,7 +142,22 @@ Public Class Hostnames
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
 
-            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SupportCode.SelectFileInWindowsExplorer(saveFileDialog.FileName)
+            If My.Settings.AskOpenExplorer Then
+                Using OpenExplorer As New OpenExplorer()
+                    OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+
+                    If result = DialogResult.No Then
+                        Exit Sub
+                    ElseIf result = DialogResult.Yes Then
+                        SupportCode.SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    End If
+                End Using
+            Else
+                MsgBox("Data exported successfully.", MsgBoxStyle.Information, SupportCode.ParentForm.Text)
+            End If
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -50,6 +50,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsContextMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CopyRawLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkCaseInsensitiveSearch = New System.Windows.Forms.CheckBox()
         Me.ChkColLogsAutoFill = New System.Windows.Forms.CheckBox()
         Me.ChkRegExSearch = New System.Windows.Forms.CheckBox()
@@ -204,7 +205,7 @@ Partial Class IgnoredLogsAndSearchResults
         '
         'LogsContextMenu
         '
-        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.OpenLogForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
+        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.OpenLogForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
         Me.LogsContextMenu.Name = "LogsContextMenu"
         Me.LogsContextMenu.Size = New System.Drawing.Size(211, 158)
         '
@@ -213,6 +214,12 @@ Partial Class IgnoredLogsAndSearchResults
         Me.CopyLogTextToolStripMenuItem.Name = "CopyLogTextToolStripMenuItem"
         Me.CopyLogTextToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
         Me.CopyLogTextToolStripMenuItem.Text = "Copy Log Text"
+        '
+        'CopyRawLogTextToolStripMenuItem
+        '
+        Me.CopyRawLogTextToolStripMenuItem.Name = "CopyRawLogTextToolStripMenuItem"
+        Me.CopyRawLogTextToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.CopyRawLogTextToolStripMenuItem.Text = "Copy Raw Log Text"
         '
         'BtnViewMainWindow
         '
@@ -409,6 +416,7 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents BtnViewMainWindow As Button
     Friend WithEvents LogsContextMenu As ContextMenuStrip
     Friend WithEvents CopyLogTextToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents CopyRawLogTextToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CreateAlertToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ColAlerts As DataGridViewTextBoxColumn
     Friend WithEvents ColRemoteProcess As DataGridViewTextBoxColumn

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -630,7 +630,7 @@ Public Class IgnoredLogsAndSearchResults
                 IgnoredWordsAndPhrasesOrAlertsInstance.ShowDialog(Me)
 
                 If IgnoredWordsAndPhrasesOrAlertsInstance.boolChanged Then
-                    SyncLock IgnoredRegexCache
+                    SyncLock IgnoredRegexCacheLockingObject
                         IgnoredRegexCache.Clear()
                     End SyncLock
                 End If

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -219,8 +219,7 @@ Public Class IgnoredLogsAndSearchResults
                                                            Dim numBatches As Integer = Math.Ceiling(totalLogs / intBatchSize)
 
                                                            ' Create ParallelOptions to control the degree of parallelism
-                                                           Dim parallelOptions As New ParallelOptions()
-                                                           parallelOptions.MaxDegreeOfParallelism = 4 ' Max 4 concurrent threads (adjust as needed)
+                                                           Dim parallelOptions As New ParallelOptions() With {.MaxDegreeOfParallelism = Environment.ProcessorCount}
 
                                                            ' Parallel loop to process batches
                                                            Parallel.For(0, numBatches, parallelOptions, Sub(batchIndex As Integer)
@@ -449,8 +448,7 @@ Public Class IgnoredLogsAndSearchResults
                 Dim index As Integer = 0
 
                 ' Create ParallelOptions to control the degree of parallelism
-                Dim parallelOptions As New ParallelOptions()
-                parallelOptions.MaxDegreeOfParallelism = 4
+                Dim parallelOptions As New ParallelOptions() With {.MaxDegreeOfParallelism = Environment.ProcessorCount}
 
                 ' Dynamically calculate the batch size based on total logs
                 Dim totalLogs As Integer = collectionOfSavedData.Count

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -371,8 +371,21 @@ Public Class IgnoredLogsAndSearchResults
                 End If
             End Using
 
-            If MsgBox($"Data exported to ""{SaveFileDialog.FileName}"" successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then
-                SelectFileInWindowsExplorer(SaveFileDialog.FileName)
+            If My.Settings.AskOpenExplorer Then
+                Using OpenExplorer As New OpenExplorer()
+                    OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+
+                    If result = DialogResult.No Then
+                        Exit Sub
+                    ElseIf result = DialogResult.Yes Then
+                        SelectFileInWindowsExplorer(SaveFileDialog.FileName)
+                    End If
+                End Using
+            Else
+                MsgBox("Data exported successfully.", MsgBoxStyle.Information, SupportCode.ParentForm.Text)
             End If
         End If
     End Sub

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -374,9 +374,9 @@ Public Class IgnoredLogsAndSearchResults
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
-                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+                    OpenExplorer.MyParentForm = Me
 
-                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
 
                     If result = DialogResult.No Then
                         Exit Sub

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -410,10 +410,19 @@ Public Class IgnoredLogsAndSearchResults
             CreateAlertToolStripMenuItem.Visible = False
             OpenLogFileForViewingToolStripMenuItem.Visible = False
         Else
-            ExportSelectedLogsToolStripMenuItem.Visible = False
-            CopyLogTextToolStripMenuItem.Visible = True
-            CreateAlertToolStripMenuItem.Visible = True
-            OpenLogFileForViewingToolStripMenuItem.Visible = True
+            If Logs.SelectedRows().Count > 1 Then
+                Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+                If selectedItem IsNot Nothing Then CopyRawLogTextToolStripMenuItem.Visible = Not String.IsNullOrEmpty(selectedItem.RawLogData)
+
+                ExportSelectedLogsToolStripMenuItem.Visible = True
+                CopyLogTextToolStripMenuItem.Visible = False
+                CreateAlertToolStripMenuItem.Visible = False
+                OpenLogFileForViewingToolStripMenuItem.Visible = False
+            Else
+                CopyLogTextToolStripMenuItem.Visible = True
+                CreateAlertToolStripMenuItem.Visible = True
+                OpenLogFileForViewingToolStripMenuItem.Visible = True
+            End If
         End If
     End Sub
 
@@ -650,6 +659,13 @@ Public Class IgnoredLogsAndSearchResults
                     Logs.Rows.RemoveAt(0)
                 End While
             End SyncLock
+        End If
+    End Sub
+
+    Private Sub CopyRawLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyRawLogTextToolStripMenuItem.Click
+        If Logs.SelectedRows().Count <> 0 Then
+            Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+            If selectedItem IsNot Nothing Then CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
         End If
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -413,9 +413,9 @@ Public Class IgnoredLogsAndSearchResults
                     listOfLogEntries.Add(item.MakeDataGridRow(Logs))
                 Next
 
-                Logs.Invoke(Sub()
-                                listOfLogEntries.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
+                listOfLogEntries.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
 
+                Logs.Invoke(Sub()
                                 Logs.SuspendLayout()
                                 Logs.Rows.Clear()
 
@@ -424,23 +424,29 @@ Public Class IgnoredLogsAndSearchResults
                                     LoadingProgressBar.Value = 0 ' Start progress at 0
                                     LoadingProgressBar.Visible = True
                                 End If
+                            End Sub)
 
-                                If listOfLogEntries.Count > 1000 Then
-                                    Dim index, progress As Integer
+                If listOfLogEntries.Count > 1000 Then
+                    Dim index, progress As Integer
+                    Dim batch As MyDataGridViewRow()
 
-                                    For index = 0 To listOfLogEntries.Count - 1 Step intBatchSize
-                                        Dim batch As MyDataGridViewRow() = listOfLogEntries.Skip(index).Take(intBatchSize).ToArray()
+                    For index = 0 To listOfLogEntries.Count - 1 Step intBatchSize
+                        batch = listOfLogEntries.Skip(index).Take(intBatchSize).ToArray()
+
+                        Logs.Invoke(Sub()
                                         Logs.Rows.AddRange(batch)
 
                                         progress = (index + intBatchSize) / listOfLogEntries.Count * 100
 
                                         ' Update the progress bar value, ensuring it's within the valid range
                                         LoadingProgressBar.Value = Math.Min(progress, LoadingProgressBar.Maximum)
-                                    Next
-                                Else
-                                    Logs.Rows.AddRange(listOfLogEntries.ToArray)
-                                End If
+                                    End Sub)
+                    Next
+                Else
+                    Logs.Invoke(Sub() Logs.Rows.AddRange(listOfLogEntries.ToArray))
+                End If
 
+                Logs.Invoke(Sub()
                                 Logs.ResumeLayout()
                                 LblCount.Text = $"Number of logs: {Logs.Rows.Count:N0}"
                                 SortLogsByDateObject(0, SortOrder.Ascending)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -425,41 +425,29 @@ Public Class IgnoredLogsAndSearchResults
                                     LoadingProgressBar.Visible = True
                                 End If
 
-                                Dim BackgroundWorker As New BackgroundWorker()
+                                If listOfLogEntries.Count > 1000 Then
+                                    Dim index, progress As Integer
 
-                                AddHandler BackgroundWorker.RunWorkerCompleted, Sub()
-                                                                                    If listOfLogEntries.Count > 1000 Then
-                                                                                        Dim index, progress As Integer
+                                    For index = 0 To listOfLogEntries.Count - 1 Step intBatchSize
+                                        Dim batch As MyDataGridViewRow() = listOfLogEntries.Skip(index).Take(intBatchSize).ToArray()
+                                        Logs.Rows.AddRange(batch)
 
-                                                                                        For index = 0 To listOfLogEntries.Count - 1 Step intBatchSize
-                                                                                            Dim batch As MyDataGridViewRow() = listOfLogEntries.Skip(index).Take(intBatchSize).ToArray()
-                                                                                            Logs.Invoke(Sub() Logs.Rows.AddRange(batch)) ' Invoke needed for UI updates
+                                        progress = (index + intBatchSize) / listOfLogEntries.Count * 100
 
-                                                                                            LoadingProgressBar.Invoke(Sub()
-                                                                                                                          progress = (index + intBatchSize) / listOfLogEntries.Count * 100
-                                                                                                                          ' Update the progress bar value, ensuring it's within the valid range
-                                                                                                                          LoadingProgressBar.Value = Math.Min(progress, LoadingProgressBar.Maximum)
-                                                                                                                      End Sub)
-                                                                                        Next
-                                                                                    Else
-                                                                                        Logs.Invoke(Sub() Logs.Rows.AddRange(listOfLogEntries.ToArray)) ' Invoke needed for UI updates
-                                                                                    End If
-                                                                                End Sub
+                                        ' Update the progress bar value, ensuring it's within the valid range
+                                        LoadingProgressBar.Value = Math.Min(progress, LoadingProgressBar.Maximum)
+                                    Next
+                                Else
+                                    Logs.Rows.AddRange(listOfLogEntries.ToArray)
+                                End If
 
-                                AddHandler BackgroundWorker.RunWorkerCompleted, Sub()
-                                                                                    Logs.Invoke(Sub()
-                                                                                                    Logs.ResumeLayout()
-                                                                                                    LblCount.Text = $"Number of logs: {Logs.Rows.Count:N0}"
-                                                                                                    SortLogsByDateObject(0, SortOrder.Ascending)
-                                                                                                    LogsLoadedInLabel.Visible = True
-                                                                                                    LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
-                                                                                                    LoadingProgressBar.Visible = False
-                                                                                                    boolDoneLoading = True
-                                                                                                End Sub)
-                                                                                End Sub
-
-                                ' Start the background work
-                                BackgroundWorker.RunWorkerAsync()
+                                Logs.ResumeLayout()
+                                LblCount.Text = $"Number of logs: {Logs.Rows.Count:N0}"
+                                SortLogsByDateObject(0, SortOrder.Ascending)
+                                LogsLoadedInLabel.Visible = True
+                                LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
+                                LoadingProgressBar.Visible = False
+                                boolDoneLoading = True
                             End Sub)
             End If
         Catch ex As Newtonsoft.Json.JsonSerializationException

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -200,8 +200,6 @@ Public Class IgnoredLogsAndSearchResults
 
             Threading.ThreadPool.QueueUserWorkItem(Sub()
                                                        SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
-                                                           LogsToBeDisplayed.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
-
                                                            ' Dynamically calculate the batch size based on total logs
                                                            Dim totalLogs As Integer = LogsToBeDisplayed.Count
                                                            Dim intBatchSize As Integer

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -416,7 +416,6 @@ Public Class IgnoredLogsAndSearchResults
                 listOfLogEntries.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
 
                 Logs.Invoke(Sub()
-                                Logs.SuspendLayout()
                                 Logs.Rows.Clear()
 
                                 If listOfLogEntries.Count > 1000 Then
@@ -447,9 +446,7 @@ Public Class IgnoredLogsAndSearchResults
                 End If
 
                 Logs.Invoke(Sub()
-                                Logs.ResumeLayout()
                                 LblCount.Text = $"Number of logs: {Logs.Rows.Count:N0}"
-                                SortLogsByDateObject(0, SortOrder.Ascending)
                                 LogsLoadedInLabel.Visible = True
                                 LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
                                 LoadingProgressBar.Visible = False

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -294,7 +294,7 @@ Public Class IgnoredLogsAndSearchResults
         If TypeOf parentForm Is Form1 AndAlso MsgBox("Are you sure you want to clear the ignored logs stored in system memory?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then
             Logs.Rows.Clear()
             LblCount.Text = "Number of ignored logs: 0"
-            parentForm.ClearIgnoredLogs()
+            parentForm.IgnoredLogs.Clear()
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -48,6 +48,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.Label1 = New System.Windows.Forms.Label()
         Me.BtnCancel = New System.Windows.Forms.Button()
         Me.btnDeleteDuringEditing = New System.Windows.Forms.Button()
+        Me.ChkRemoteProcess = New System.Windows.Forms.CheckBox()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -286,11 +287,23 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnDeleteDuringEditing.Text = "Delete"
         Me.btnDeleteDuringEditing.UseVisualStyleBackColor = True
         '
+        'ChkRemoteProcess
+        '
+        Me.ChkRemoteProcess.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkRemoteProcess.AutoSize = True
+        Me.ChkRemoteProcess.Location = New System.Drawing.Point(684, 325)
+        Me.ChkRemoteProcess.Name = "ChkRemoteProcess"
+        Me.ChkRemoteProcess.Size = New System.Drawing.Size(110, 17)
+        Me.ChkRemoteProcess.TabIndex = 47
+        Me.ChkRemoteProcess.Text = "Remote Process?"
+        Me.ChkRemoteProcess.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(799, 378)
+        Me.Controls.Add(Me.ChkRemoteProcess)
         Me.Controls.Add(Me.btnDeleteDuringEditing)
         Me.Controls.Add(Me.BtnCancel)
         Me.Controls.Add(Me.ChkEnabled)
@@ -344,4 +357,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents Label1 As Label
     Friend WithEvents BtnCancel As Button
     Friend WithEvents btnDeleteDuringEditing As Button
+    Friend WithEvents ChkRemoteProcess As CheckBox
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -278,6 +278,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         'btnDeleteDuringEditing
         '
+        Me.btnDeleteDuringEditing.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.btnDeleteDuringEditing.Location = New System.Drawing.Point(164, 348)
         Me.btnDeleteDuringEditing.Name = "btnDeleteDuringEditing"
         Me.btnDeleteDuringEditing.Size = New System.Drawing.Size(75, 23)

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -49,6 +49,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.BtnCancel = New System.Windows.Forms.Button()
         Me.btnDeleteDuringEditing = New System.Windows.Forms.Button()
         Me.ChkRemoteProcess = New System.Windows.Forms.CheckBox()
+        Me.colHits = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -78,7 +79,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -298,6 +299,11 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkRemoteProcess.Text = "Remote Process?"
         Me.ChkRemoteProcess.UseVisualStyleBackColor = True
         '
+        'colHits
+        '
+        Me.colHits.Text = "Hits"
+        Me.colHits.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -358,4 +364,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents BtnCancel As Button
     Friend WithEvents btnDeleteDuringEditing As Button
     Friend WithEvents ChkRemoteProcess As CheckBox
+    Friend WithEvents colHits As ColumnHeader
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -50,6 +50,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnDeleteDuringEditing = New System.Windows.Forms.Button()
         Me.ChkRemoteProcess = New System.Windows.Forms.CheckBox()
         Me.colHits = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.colTarget = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -80,7 +81,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -305,6 +306,12 @@ Partial Class IgnoredWordsAndPhrases
         Me.colHits.Text = "Hits"
         Me.colHits.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
+        'colTarget
+        '
+        Me.colTarget.Text = "Target"
+        Me.colTarget.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
+        Me.colTarget.Width = 125
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -366,4 +373,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents btnDeleteDuringEditing As Button
     Friend WithEvents ChkRemoteProcess As CheckBox
     Friend WithEvents colHits As ColumnHeader
+    Friend WithEvents colTarget As ColumnHeader
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -76,6 +76,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         'IgnoredListView
         '
+        Me.IgnoredListView.AllowDrop = True
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -255,7 +255,22 @@ Public Class IgnoredWordsAndPhrases
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
 
-            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
+            If My.Settings.AskOpenExplorer Then
+                Using OpenExplorer As New OpenExplorer()
+                    OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+
+                    If result = DialogResult.No Then
+                        Exit Sub
+                    ElseIf result = DialogResult.Yes Then
+                        SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    End If
+                End Using
+            Else
+                MsgBox("Data exported successfully.", MsgBoxStyle.Information, SupportCode.ParentForm.Text)
+            End If
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -378,8 +378,4 @@ Public Class IgnoredWordsAndPhrases
         ChkRegex.Checked = False
         ChkEnabled.Checked = True
     End Sub
-
-    Private Sub ChkRemoteProcess_Click(sender As Object, e As EventArgs) Handles ChkRemoteProcess.Click
-        If ChkRemoteProcess.Checked Then ChkRegex.Checked = False
-    End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -23,7 +23,7 @@ Public Class IgnoredWordsAndPhrases
                 Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
                 With selectedItemObject
-                    .SubItems(0).Text = TxtIgnored.Text
+                    .SubItems(0).Text = If(chkRemoteProcess.Checked, $"RemoteProcess:{TxtIgnored.Text}", TxtIgnored.Text)
                     .SubItems(1).Text = If(ChkRegex.Checked, "Yes", "No")
                     .SubItems(2).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
                     .SubItems(3).Text = If(ChkEnabled.Checked, "Yes", "No")
@@ -36,7 +36,13 @@ Public Class IgnoredWordsAndPhrases
                 BtnAdd.Text = "Add"
                 Label4.Text = "Add Ignored Words and Phrases"
             Else
-                Dim IgnoredListViewItem As New MyIgnoredListViewItem(TxtIgnored.Text)
+                Dim IgnoredListViewItem As MyIgnoredListViewItem
+
+                If chkRemoteProcess.Checked Then
+                    IgnoredListViewItem = New MyIgnoredListViewItem($"RemoteProcess:{TxtIgnored.Text}")
+                Else
+                    IgnoredListViewItem = New MyIgnoredListViewItem(TxtIgnored.Text)
+                End If
 
                 With IgnoredListViewItem
                     .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
@@ -57,6 +63,7 @@ Public Class IgnoredWordsAndPhrases
             ChkCaseSensitive.Checked = False
             ChkRegex.Checked = False
             ChkEnabled.Checked = True
+            chkRemoteProcess.Checked = False
         End If
     End Sub
 
@@ -177,7 +184,8 @@ Public Class IgnoredWordsAndPhrases
 
             Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
-            TxtIgnored.Text = selectedItemObject.SubItems(0).Text
+            chkRemoteProcess.Checked = selectedItemObject.SubItems(0).Text.StartsWith("RemoteProcess:", StringComparison.OrdinalIgnoreCase)
+            TxtIgnored.Text = If(chkRemoteProcess.Checked, selectedItemObject.SubItems(0).Text.Substring("RemoteProcess:".Length).Trim, selectedItemObject.SubItems(0).Text)
             ChkRegex.Checked = selectedItemObject.BoolRegex
             ChkCaseSensitive.Checked = selectedItemObject.BoolCaseSensitive
             ChkEnabled.Checked = selectedItemObject.BoolEnabled
@@ -373,5 +381,9 @@ Public Class IgnoredWordsAndPhrases
         ChkCaseSensitive.Checked = False
         ChkRegex.Checked = False
         ChkEnabled.Checked = True
+    End Sub
+
+    Private Sub ChkRemoteProcess_Click(sender As Object, e As EventArgs) Handles ChkRemoteProcess.Click
+        If ChkRemoteProcess.Checked Then ChkRegex.Checked = False
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -62,19 +62,21 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         If boolChanged Then
-            ignoredList.Clear()
+            SyncLock ignoredList
+                ignoredList.Clear()
 
-            Dim ignoredClass As IgnoredClass
-            Dim tempIgnored As New Specialized.StringCollection()
+                Dim ignoredClass As IgnoredClass
+                Dim tempIgnored As New Specialized.StringCollection()
 
-            For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled}
-                If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
-                tempIgnored.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
-            Next
+                For Each item As MyIgnoredListViewItem In IgnoredListView.Items
+                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled}
+                    If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
+                    tempIgnored.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
+                Next
 
-            My.Settings.ignored2 = tempIgnored
-            My.Settings.Save()
+                My.Settings.ignored2 = tempIgnored
+                My.Settings.Save()
+            End SyncLock
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -262,9 +262,9 @@ Public Class IgnoredWordsAndPhrases
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
-                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+                    OpenExplorer.MyParentForm = Me
 
-                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
 
                     If result = DialogResult.No Then
                         Exit Sub

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -23,26 +23,21 @@ Public Class IgnoredWordsAndPhrases
                 Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
                 With selectedItemObject
-                    .SubItems(0).Text = If(chkRemoteProcess.Checked, $"RemoteProcess:{TxtIgnored.Text}", TxtIgnored.Text)
+                    .SubItems(0).Text = TxtIgnored.Text
                     .SubItems(1).Text = If(ChkRegex.Checked, "Yes", "No")
                     .SubItems(2).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
                     .SubItems(3).Text = If(ChkEnabled.Checked, "Yes", "No")
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolRegex = ChkRegex.Checked
+                    .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                 End With
 
                 IgnoredListView.Enabled = True
                 BtnAdd.Text = "Add"
                 Label4.Text = "Add Ignored Words and Phrases"
             Else
-                Dim IgnoredListViewItem As MyIgnoredListViewItem
-
-                If chkRemoteProcess.Checked Then
-                    IgnoredListViewItem = New MyIgnoredListViewItem($"RemoteProcess:{TxtIgnored.Text}")
-                Else
-                    IgnoredListViewItem = New MyIgnoredListViewItem(TxtIgnored.Text)
-                End If
+                Dim IgnoredListViewItem As New MyIgnoredListViewItem(TxtIgnored.Text)
 
                 With IgnoredListViewItem
                     .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
@@ -51,6 +46,7 @@ Public Class IgnoredWordsAndPhrases
                     .BoolRegex = ChkRegex.Checked
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
+                    .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
                 End With
 
@@ -76,7 +72,7 @@ Public Class IgnoredWordsAndPhrases
                 Dim tempIgnored As New Specialized.StringCollection()
 
                 For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled}
+                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType}
                     If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
                     tempIgnored.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
                 Next
@@ -184,8 +180,8 @@ Public Class IgnoredWordsAndPhrases
 
             Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
-            chkRemoteProcess.Checked = selectedItemObject.SubItems(0).Text.StartsWith("RemoteProcess:", StringComparison.OrdinalIgnoreCase)
-            TxtIgnored.Text = If(chkRemoteProcess.Checked, selectedItemObject.SubItems(0).Text.Substring("RemoteProcess:".Length).Trim, selectedItemObject.SubItems(0).Text)
+            ChkRemoteProcess.Checked = selectedItemObject.IgnoreType <> IgnoreType.MainLog
+            TxtIgnored.Text = selectedItemObject.SubItems(0).Text
             ChkRegex.Checked = selectedItemObject.BoolRegex
             ChkCaseSensitive.Checked = selectedItemObject.BoolCaseSensitive
             ChkEnabled.Checked = selectedItemObject.BoolEnabled
@@ -258,7 +254,7 @@ Public Class IgnoredWordsAndPhrases
 
         If saveFileDialog.ShowDialog() = DialogResult.OK Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled})
+                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType})
             Next
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -209,18 +209,32 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub DisableEnableItem()
-        Dim selectedItem As MyIgnoredListViewItem = IgnoredListView.SelectedItems(0)
+        If IgnoredListView.SelectedItems.Count = 1 Then
+            Dim selectedItem As MyIgnoredListViewItem = IgnoredListView.SelectedItems(0)
 
-        If selectedItem.BoolEnabled Then
-            selectedItem.BackColor = Color.LightGreen
-            selectedItem.BoolEnabled = False
-            selectedItem.SubItems(3).Text = "No"
-            BtnEnableDisable.Text = "Enable"
+            If selectedItem.BoolEnabled Then
+                selectedItem.BackColor = Color.Pink
+                selectedItem.BoolEnabled = False
+                selectedItem.SubItems(3).Text = "No"
+                BtnEnableDisable.Text = "Enable"
+            Else
+                selectedItem.BackColor = Color.LightGreen
+                selectedItem.BoolEnabled = True
+                selectedItem.SubItems(3).Text = "Yes"
+                BtnEnableDisable.Text = "Disable"
+            End If
         Else
-            selectedItem.BackColor = Color.Pink
-            selectedItem.BoolEnabled = True
-            selectedItem.SubItems(3).Text = "Yes"
-            BtnEnableDisable.Text = "Disable"
+            For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
+                If item.BoolEnabled Then
+                    item.BackColor = Color.Pink
+                    item.BoolEnabled = False
+                    item.SubItems(3).Text = "No"
+                Else
+                    item.BackColor = Color.LightGreen
+                    item.BoolEnabled = True
+                    item.SubItems(3).Text = "Yes"
+                End If
+            Next
         End If
 
         boolChanged = True

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -5,6 +5,46 @@ Public Class IgnoredWordsAndPhrases
     Public boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
     Public strIgnoredPattern As String = Nothing
+    Private draggedItem As ListViewItem
+
+    Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
+        draggedItem = CType(e.Item, ListViewItem)
+        DoDragDrop(e.Item, DragDropEffects.Move)
+    End Sub
+
+    Private Sub IgnoredListView_DragEnter(sender As Object, e As DragEventArgs) Handles IgnoredListView.DragEnter
+        If e.Data.GetDataPresent(GetType(ListViewItem)) Then
+            e.Effect = DragDropEffects.Move
+        Else
+            e.Effect = DragDropEffects.None
+        End If
+    End Sub
+
+    Private Sub IgnoredListView_DragOver(sender As Object, e As DragEventArgs) Handles IgnoredListView.DragOver
+        e.Effect = DragDropEffects.Move
+    End Sub
+
+    Private Sub IgnoredListView_DragDrop(sender As Object, e As DragEventArgs) Handles IgnoredListView.DragDrop
+        If draggedItem Is Nothing Then Return
+
+        Dim cp As Point = IgnoredListView.PointToClient(New Point(e.X, e.Y))
+        Dim targetItem As ListViewItem = IgnoredListView.GetItemAt(cp.X, cp.Y)
+
+        If targetItem Is Nothing OrElse targetItem Is draggedItem Then Return
+
+        Dim targetIndex As Integer = targetItem.Index
+        Dim draggedIndex As Integer = draggedItem.Index
+
+        ' Remove and re-insert the dragged item
+        IgnoredListView.Items.RemoveAt(draggedIndex)
+        IgnoredListView.Items.Insert(targetIndex, draggedItem)
+
+        ' Re-select the moved item
+        draggedItem.Selected = True
+        draggedItem.Focused = True
+
+        boolChanged = True ' Mark changes
+    End Sub
 
     Private Function CheckForExistingItem(strIgnored As String) As Boolean
         Return IgnoredListView.Items.Cast(Of MyIgnoredListViewItem).Any(Function(item As MyIgnoredListViewItem)

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -31,6 +31,7 @@ Public Class IgnoredWordsAndPhrases
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolRegex = ChkRegex.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
+                    .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                 End With
 
                 IgnoredListView.Enabled = True
@@ -48,6 +49,7 @@ Public Class IgnoredWordsAndPhrases
                     .BoolEnabled = ChkEnabled.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
+                    .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                 End With
 
                 IgnoredListView.Items.Add(IgnoredListViewItem)
@@ -210,10 +212,12 @@ Public Class IgnoredWordsAndPhrases
         Dim selectedItem As MyIgnoredListViewItem = IgnoredListView.SelectedItems(0)
 
         If selectedItem.BoolEnabled Then
+            selectedItem.BackColor = Color.LightGreen
             selectedItem.BoolEnabled = False
             selectedItem.SubItems(3).Text = "No"
             BtnEnableDisable.Text = "Enable"
         Else
+            selectedItem.BackColor = Color.Pink
             selectedItem.BoolEnabled = True
             selectedItem.SubItems(3).Text = "Yes"
             BtnEnableDisable.Text = "Disable"

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -71,15 +71,15 @@ Public Class IgnoredWordsAndPhrases
                 ignoredList.Clear()
 
                 Dim ignoredClass As IgnoredClass
-                Dim tempIgnored As New Specialized.StringCollection()
+                Dim listOfIgnoredRulesToBeSavedToSettings As New Specialized.StringCollection()
 
                 For Each item As MyIgnoredListViewItem In IgnoredListView.Items
                     ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType}
                     If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
-                    tempIgnored.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
+                    listOfIgnoredRulesToBeSavedToSettings.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
                 Next
 
-                My.Settings.ignored2 = tempIgnored
+                My.Settings.ignored2 = listOfIgnoredRulesToBeSavedToSettings
                 My.Settings.Save()
             End SyncLock
         End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -150,7 +150,7 @@ Public Class IgnoredWordsAndPhrases
     Private Sub IgnoredListView_Click(sender As Object, e As EventArgs) Handles IgnoredListView.Click
         If IgnoredListView.SelectedItems.Count > 0 Then
             BtnDelete.Enabled = True
-            BtnEdit.Enabled = True
+            BtnEdit.Enabled = IgnoredListView.SelectedItems.Count = 1
             BtnEnableDisable.Enabled = True
 
             BtnEnableDisable.Text = If(DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem).BoolEnabled, "Disable", "Enable")

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -67,7 +67,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         If boolChanged Then
-            SyncLock ignoredList
+            SyncLock ignoredListLockingObject
                 ignoredList.Clear()
 
                 Dim ignoredClass As IgnoredClass

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -43,6 +43,7 @@
         End If
 
         AdjustScrollBars(LogText)
+        BringToFront()
     End Sub
 
     Private Sub Log_Viewer_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -43,7 +43,7 @@
         End If
 
         AdjustScrollBars(LogText)
-        BringToFront()
+        NativeMethod.NativeMethods.SetForegroundWindow(Handle)
     End Sub
 
     Private Sub Log_Viewer_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing

--- a/Free SysLog/Windows/OpenExplorer.Designer.vb
+++ b/Free SysLog/Windows/OpenExplorer.Designer.vb
@@ -101,7 +101,7 @@ Partial Class OpenExplorer
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "OpenExplorer"
-        Me.Text = "OpenExplorer"
+        Me.Text = "Open Windows Explorer?"
         Me.Panel1.ResumeLayout(False)
         Me.Panel1.PerformLayout()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()

--- a/Free SysLog/Windows/OpenExplorer.Designer.vb
+++ b/Free SysLog/Windows/OpenExplorer.Designer.vb
@@ -38,7 +38,7 @@ Partial Class OpenExplorer
         Me.ChkAskEveryTime.Location = New System.Drawing.Point(12, 81)
         Me.ChkAskEveryTime.Name = "ChkAskEveryTime"
         Me.ChkAskEveryTime.Size = New System.Drawing.Size(106, 17)
-        Me.ChkAskEveryTime.TabIndex = 8
+        Me.ChkAskEveryTime.TabIndex = 2
         Me.ChkAskEveryTime.Text = "Ask Every Time?"
         Me.ChkAskEveryTime.UseVisualStyleBackColor = True
         '
@@ -47,7 +47,7 @@ Partial Class OpenExplorer
         Me.BtnYes.Location = New System.Drawing.Point(231, 75)
         Me.BtnYes.Name = "BtnYes"
         Me.BtnYes.Size = New System.Drawing.Size(75, 23)
-        Me.BtnYes.TabIndex = 6
+        Me.BtnYes.TabIndex = 0
         Me.BtnYes.Text = "&Yes"
         Me.BtnYes.UseVisualStyleBackColor = True
         '
@@ -56,7 +56,7 @@ Partial Class OpenExplorer
         Me.BtnNo.Location = New System.Drawing.Point(312, 75)
         Me.BtnNo.Name = "BtnNo"
         Me.BtnNo.Size = New System.Drawing.Size(75, 23)
-        Me.BtnNo.TabIndex = 4
+        Me.BtnNo.TabIndex = 1
         Me.BtnNo.Text = "&No"
         Me.BtnNo.UseVisualStyleBackColor = True
         '

--- a/Free SysLog/Windows/OpenExplorer.Designer.vb
+++ b/Free SysLog/Windows/OpenExplorer.Designer.vb
@@ -1,0 +1,119 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class OpenExplorer
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.ChkAskEveryTime = New System.Windows.Forms.CheckBox()
+        Me.BtnYes = New System.Windows.Forms.Button()
+        Me.BtnNo = New System.Windows.Forms.Button()
+        Me.Panel1 = New System.Windows.Forms.Panel()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.PictureBox1 = New System.Windows.Forms.PictureBox()
+        Me.Panel1.SuspendLayout()
+        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
+        '
+        'ChkAskEveryTime
+        '
+        Me.ChkAskEveryTime.AutoSize = True
+        Me.ChkAskEveryTime.Location = New System.Drawing.Point(12, 81)
+        Me.ChkAskEveryTime.Name = "ChkAskEveryTime"
+        Me.ChkAskEveryTime.Size = New System.Drawing.Size(106, 17)
+        Me.ChkAskEveryTime.TabIndex = 8
+        Me.ChkAskEveryTime.Text = "Ask Every Time?"
+        Me.ChkAskEveryTime.UseVisualStyleBackColor = True
+        '
+        'BtnYes
+        '
+        Me.BtnYes.Location = New System.Drawing.Point(231, 75)
+        Me.BtnYes.Name = "BtnYes"
+        Me.BtnYes.Size = New System.Drawing.Size(75, 23)
+        Me.BtnYes.TabIndex = 6
+        Me.BtnYes.Text = "&Yes"
+        Me.BtnYes.UseVisualStyleBackColor = True
+        '
+        'BtnNo
+        '
+        Me.BtnNo.Location = New System.Drawing.Point(312, 75)
+        Me.BtnNo.Name = "BtnNo"
+        Me.BtnNo.Size = New System.Drawing.Size(75, 23)
+        Me.BtnNo.TabIndex = 4
+        Me.BtnNo.Text = "&No"
+        Me.BtnNo.UseVisualStyleBackColor = True
+        '
+        'Panel1
+        '
+        Me.Panel1.BackColor = System.Drawing.Color.White
+        Me.Panel1.Controls.Add(Me.Label1)
+        Me.Panel1.Controls.Add(Me.PictureBox1)
+        Me.Panel1.Location = New System.Drawing.Point(0, 0)
+        Me.Panel1.Name = "Panel1"
+        Me.Panel1.Size = New System.Drawing.Size(400, 69)
+        Me.Panel1.TabIndex = 7
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.Location = New System.Drawing.Point(50, 14)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(316, 39)
+        Me.Label1.TabIndex = 3
+        Me.Label1.Text = "Data exported successfully." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Do you want to open Windows Explorer to the locati" &
+    "on of the file?"
+        '
+        'PictureBox1
+        '
+        Me.PictureBox1.Location = New System.Drawing.Point(12, 14)
+        Me.PictureBox1.Name = "PictureBox1"
+        Me.PictureBox1.Size = New System.Drawing.Size(32, 32)
+        Me.PictureBox1.TabIndex = 2
+        Me.PictureBox1.TabStop = False
+        '
+        'OpenExplorer
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(399, 110)
+        Me.Controls.Add(Me.ChkAskEveryTime)
+        Me.Controls.Add(Me.BtnYes)
+        Me.Controls.Add(Me.BtnNo)
+        Me.Controls.Add(Me.Panel1)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "OpenExplorer"
+        Me.Text = "OpenExplorer"
+        Me.Panel1.ResumeLayout(False)
+        Me.Panel1.PerformLayout()
+        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ChkAskEveryTime As CheckBox
+    Friend WithEvents BtnYes As Button
+    Friend WithEvents BtnNo As Button
+    Friend WithEvents Panel1 As Panel
+    Friend WithEvents Label1 As Label
+    Friend WithEvents PictureBox1 As PictureBox
+End Class

--- a/Free SysLog/Windows/OpenExplorer.Designer.vb
+++ b/Free SysLog/Windows/OpenExplorer.Designer.vb
@@ -92,7 +92,7 @@ Partial Class OpenExplorer
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(399, 110)
+        Me.ClientSize = New System.Drawing.Size(399, 105)
         Me.Controls.Add(Me.ChkAskEveryTime)
         Me.Controls.Add(Me.BtnYes)
         Me.Controls.Add(Me.BtnNo)

--- a/Free SysLog/Windows/OpenExplorer.resx
+++ b/Free SysLog/Windows/OpenExplorer.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Free SysLog/Windows/OpenExplorer.vb
+++ b/Free SysLog/Windows/OpenExplorer.vb
@@ -1,5 +1,5 @@
 ﻿Public Class OpenExplorer
-    Public Property MyParentForm As Form1
+    Public Property MyParentForm As Form
 
     Private Sub OpenExplorer_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         Media.SystemSounds.Asterisk.Play()
@@ -26,7 +26,6 @@
     End Sub
 
     Private Sub ChkAskEveryTime_Click(sender As Object, e As EventArgs) Handles ChkAskEveryTime.Click
-        My.Settings.AskOpenExplorer = ChkAskEveryTime.Checked
-        If MyParentForm IsNot Nothing Then MyParentForm.AskToOpenExplorerWhenSavingData.Checked = ChkAskEveryTime.Checked
+        SupportCode.AskOpenExplorer = ChkAskEveryTime.Checked
     End Sub
 End Class

--- a/Free SysLog/Windows/OpenExplorer.vb
+++ b/Free SysLog/Windows/OpenExplorer.vb
@@ -1,0 +1,32 @@
+﻿Public Class OpenExplorer
+    Public Property MyParentForm As Form1
+
+    Private Sub OpenExplorer_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Media.SystemSounds.Asterisk.Play()
+        PictureBox1.Image = SystemIcons.Question.ToBitmap()
+        ChkAskEveryTime.Checked = My.Settings.AskOpenExplorer
+    End Sub
+
+    Private Sub BtnYes_Click(sender As Object, e As EventArgs) Handles BtnYes.Click
+        DialogResult = DialogResult.Yes
+        Close()
+    End Sub
+
+    Private Sub BtnNo_Click(sender As Object, e As EventArgs) Handles BtnNo.Click
+        DialogResult = DialogResult.No
+        Close()
+    End Sub
+
+    Private Sub CloseFreeSysLogDialog_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
+        If e.KeyCode = Keys.Y Then
+            BtnYes.PerformClick()
+        ElseIf e.KeyCode = Keys.N Then
+            BtnNo.PerformClick()
+        End If
+    End Sub
+
+    Private Sub ChkAskEveryTime_Click(sender As Object, e As EventArgs) Handles ChkAskEveryTime.Click
+        My.Settings.AskOpenExplorer = ChkAskEveryTime.Checked
+        If MyParentForm IsNot Nothing Then MyParentForm.AskToOpenExplorerWhenSavingData.Checked = ChkAskEveryTime.Checked
+    End Sub
+End Class

--- a/Free SysLog/Windows/Replacements.Designer.vb
+++ b/Free SysLog/Windows/Replacements.Designer.vb
@@ -55,6 +55,7 @@ Partial Class Replacements
         '
         'ReplacementsListView
         '
+        Me.ReplacementsListView.AllowDrop = True
         Me.ReplacementsListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -254,7 +254,22 @@ Public Class Replacements
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
 
-            If MsgBox($"Data exported successfully.{vbCrLf}{vbCrLf}Do you want to open Windows Explorer to the location of the file?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + MsgBoxStyle.DefaultButton2, Text) = MsgBoxResult.Yes Then SelectFileInWindowsExplorer(saveFileDialog.FileName)
+            If My.Settings.AskOpenExplorer Then
+                Using OpenExplorer As New OpenExplorer()
+                    OpenExplorer.StartPosition = FormStartPosition.CenterParent
+                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+
+                    If result = DialogResult.No Then
+                        Exit Sub
+                    ElseIf result = DialogResult.Yes Then
+                        SelectFileInWindowsExplorer(saveFileDialog.FileName)
+                    End If
+                End Using
+            Else
+                MsgBox("Data exported successfully.", MsgBoxStyle.Information, SupportCode.ParentForm.Text)
+            End If
         End If
     End Sub
 

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -4,6 +4,46 @@ Public Class Replacements
     Private boolDoneLoading As Boolean = False
     Public boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
+    Private draggedItem As ListViewItem
+
+    Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles ReplacementsListView.ItemDrag
+        draggedItem = CType(e.Item, ListViewItem)
+        DoDragDrop(e.Item, DragDropEffects.Move)
+    End Sub
+
+    Private Sub IgnoredListView_DragEnter(sender As Object, e As DragEventArgs) Handles ReplacementsListView.DragEnter
+        If e.Data.GetDataPresent(GetType(ListViewItem)) Then
+            e.Effect = DragDropEffects.Move
+        Else
+            e.Effect = DragDropEffects.None
+        End If
+    End Sub
+
+    Private Sub IgnoredListView_DragOver(sender As Object, e As DragEventArgs) Handles ReplacementsListView.DragOver
+        e.Effect = DragDropEffects.Move
+    End Sub
+
+    Private Sub IgnoredListView_DragDrop(sender As Object, e As DragEventArgs) Handles ReplacementsListView.DragDrop
+        If draggedItem Is Nothing Then Return
+
+        Dim cp As Point = ReplacementsListView.PointToClient(New Point(e.X, e.Y))
+        Dim targetItem As ListViewItem = ReplacementsListView.GetItemAt(cp.X, cp.Y)
+
+        If targetItem Is Nothing OrElse targetItem Is draggedItem Then Return
+
+        Dim targetIndex As Integer = targetItem.Index
+        Dim draggedIndex As Integer = draggedItem.Index
+
+        ' Remove and re-insert the dragged item
+        ReplacementsListView.Items.RemoveAt(draggedIndex)
+        ReplacementsListView.Items.Insert(targetIndex, draggedItem)
+
+        ' Re-select the moved item
+        draggedItem.Selected = True
+        draggedItem.Focused = True
+
+        boolChanged = True ' Mark changes
+    End Sub
 
     Private Function CheckForExistingItem(strReplace As String, strReplaceWith As String) As Boolean
         Return ReplacementsListView.Items.Cast(Of MyReplacementsListViewItem).Any(Function(item As MyReplacementsListViewItem)

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -249,12 +249,12 @@ Public Class Replacements
             selectedItem.BoolEnabled = False
             selectedItem.SubItems(4).Text = "No"
             BtnEnableDisable.Text = "Enable"
-            selectedItem.BackColor = Color.LightGreen
+            selectedItem.BackColor = Color.Pink
         Else
             selectedItem.BoolEnabled = True
             selectedItem.SubItems(4).Text = "Yes"
             BtnEnableDisable.Text = "Disable"
-            selectedItem.BackColor = Color.Pink
+            selectedItem.BackColor = Color.LightGreen
         End If
 
         boolChanged = True

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -257,9 +257,9 @@ Public Class Replacements
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
-                    OpenExplorer.MyParentForm = SupportCode.ParentForm
+                    OpenExplorer.MyParentForm = Me
 
-                    Dim result As DialogResult = OpenExplorer.ShowDialog(SupportCode.ParentForm)
+                    Dim result As DialogResult = OpenExplorer.ShowDialog(Me)
 
                     If result = DialogResult.No Then
                         Exit Sub

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -30,6 +30,7 @@ Public Class Replacements
                     .BoolRegex = ChkRegex.Checked
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
+                    .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                 End With
 
                 ReplacementsListView.Enabled = True
@@ -52,6 +53,7 @@ Public Class Replacements
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
+                    .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                 End With
 
                 ReplacementsListView.Items.Add(MyReplacementsListViewItem)
@@ -207,10 +209,12 @@ Public Class Replacements
             selectedItem.BoolEnabled = False
             selectedItem.SubItems(4).Text = "No"
             BtnEnableDisable.Text = "Enable"
+            selectedItem.BackColor = Color.LightGreen
         Else
             selectedItem.BoolEnabled = True
             selectedItem.SubItems(4).Text = "Yes"
             BtnEnableDisable.Text = "Disable"
+            selectedItem.BackColor = Color.Pink
         End If
 
         boolChanged = True

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -382,7 +382,7 @@ Public Class ViewLogBackups
                                               End If
                                           End If
 
-                                          listOfSearchResults2 = listOfSearchResults.Distinct().ToList().OrderBy(Function(row) row.Cells(ColumnIndex_LogText).Value.ToString()).ThenBy(Function(row) row.Cells(ColumnIndex_ComputedTime).Value.ToString()).ToList()
+                                          listOfSearchResults2 = listOfSearchResults.Distinct().ToList().OrderBy(Function(row As MyDataGridViewRow) row.DateObject).ToList()
                                       Catch ex As ArgumentException
                                           MsgBox("Malformed RegEx pattern detected, search aborted.", MsgBoxStyle.Critical, Text)
                                       End Try
@@ -639,8 +639,6 @@ Public Class ViewLogBackups
                                           If My.Settings.font IsNot Nothing Then item.Cells(ColumnIndex_FileName).Style.Font = My.Settings.font
                                       Next
 
-                                      listOfSearchResults.Sort(Function(x As MyDataGridViewRow, y As MyDataGridViewRow) x.DateObject.CompareTo(y.DateObject))
-
                                       For Each item As SavedData In currentLogs
                                           If strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
                                               boolDidWeHaveAMatch = String.Equals(item.logType, strLimiter, StringComparison.OrdinalIgnoreCase)
@@ -675,7 +673,7 @@ Public Class ViewLogBackups
                                           End If
                                       End If
 
-                                      listOfSearchResults2 = listOfSearchResults.Distinct().ToList().OrderBy(Function(row) row.Cells(ColumnIndex_LogText).Value.ToString()).ThenBy(Function(row) row.Cells(ColumnIndex_ComputedTime).Value.ToString()).ToList()
+                                      listOfSearchResults2 = listOfSearchResults.Distinct().ToList().OrderBy(Function(row As MyDataGridViewRow) row.DateObject).ToList()
                                   End Sub
 
         AddHandler worker.RunWorkerCompleted, Sub()

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -294,6 +294,12 @@
             <setting name="AskOpenExplorer" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="ignoredLogCount" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="saveIgnoredLogCount" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -291,6 +291,9 @@
             <setting name="LimitNumberOfIgnoredLogs" serializeAs="String">
                 <value>1000</value>
             </setting>
+            <setting name="AskOpenExplorer" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Improved performance when loading large log files on the "Ignored Logs and Search Results" window.
- More performance improvements. Now the program doesn't look like it locks up while loading lots of data.
- Fixed parsing of some syslogs, specifically from some Ubiquity devices.
- We now process the ignored rules on the raw incoming log instead of the parsed log.
- Ignored logs are now created based upon the raw log.
- Fixed counting of ignored logs when recording of ignored logs in program memory is disabled.
- Added error handling and logging to the ProcessIgnoredLogPreferences() function.
- Massively improved the performance of the ProcessIgnoredLogPreferences() function by parallelizing the code.
- Added the ability to not ask the user to open Explorer to a newly saved file to disk.
- Fixed an issue with escaping non-regex search parameters when it contains a space.
- Dropped instances of ".*" from the ProcessIgnoredLogPreferences() function.
- Fixed a race-condition and thread safety issue in the ProcessIgnoredLogPreferences() function.
- Added the ability to ignore logs from specific remote processes or programs.
- Changed some code in the ProcessIgnoredLogPreferences() to handle non-regex patterns as simple string contains.
- Fixed a bug where the "Zero-out Ignored Logs Counter" menu item under the "Log Functions" menu was being disable incorrectly.
- Added a status label to the bottom of the window to indicate the status of auto scrolling.
- Added color to the "Replacements" and "Ignored Words and Phrases" lists.
- Implemented a fix that that solves a long-standing bug with disabling auto-scrolling when you scroll up after the program has been active for some time.
- Fixed sorting from loading data from the "View Log Backups" window.
- Added a new "Copy Raw Log Text" menu item to the Logs context menu.
- Moved the processing of data replacements when ProcessReplacementsInSyslogDataFirst is enabled.
- Added the ability to track how many times an ignored log rule is hit or used by the program. The statistics are displayed on the "Ignored Words and Phrases" window.
- Added the ability to disable multiple items on the "Ignored Words and Phrases" window.
- Added Drag-and-Drop reordering capabilities to many of the user defined settings such as Alerts, "Ignored Words and Phrases", etc.
- Added the Windows API SetForegroundWindow() API and added it to the "Log Viewer" window.

And many other changes under the hood, including over fifty individual commits brought in from the dev branch.