### PR TITLE
Version 4.4 Build 2

### DIFF
--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -117,6 +117,7 @@
     <Compile Include="Support Code\MyDataGridViewFileRow.vb" />
     <Compile Include="Support Code\MyDataGridViewFileRowComparer.vb" />
     <Compile Include="Support Code\Namespace Code\Data Handling.vb" />
+    <Compile Include="Support Code\Namespace Code\listViewSorter.vb" />
     <Compile Include="Support Code\Namespace Code\Syslog Parser.vb" />
     <Compile Include="Support Code\Namespace Code\Task Handling.vb" />
     <Compile Include="Support Code\Namespace Code\Syslog TCP Server.vb" />

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.4.1.101")>
+<Assembly: AssemblyFileVersion("4.4.2.102")>

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -123,6 +123,44 @@ Namespace SupportCode
             End Try
         End Function
 
+        Public Sub SortByClickedColumn(ByRef ListView As ListView, intColumn As Integer, ByRef m_SortingColumn As ColumnHeader)
+            ' Get the new sorting column.
+            Dim new_sorting_column As ColumnHeader = ListView.Columns(intColumn)
+
+            ' Figure out the new sorting order.
+            Dim sort_order As SortOrder
+            If m_SortingColumn Is Nothing Then
+                ' New column. Sort ascending.
+                sort_order = SortOrder.Ascending
+            Else
+                ' See if this is the same column.
+                If new_sorting_column.Equals(m_SortingColumn) Then
+                    ' Same column. Switch the sort order.
+                    If m_SortingColumn.Text.StartsWith("> ") Then
+                        sort_order = SortOrder.Descending
+                    Else
+                        sort_order = SortOrder.Ascending
+                    End If
+                Else
+                    ' New column. Sort ascending.
+                    sort_order = SortOrder.Ascending
+                End If
+
+                ' Remove the old sort indicator.
+                m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
+            End If
+
+            ' Display the new sort order.
+            m_SortingColumn = new_sorting_column
+            m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
+
+            ' Create a comparer.
+            ListView.ListViewItemSorter = New listViewSorter.ListViewComparer(intColumn, sort_order)
+
+            ' Sort.
+            ListView.Sort()
+        End Sub
+
         Public Function GetProcessUsingPort(port As Integer, protocolType As ProtocolType) As Process
             Dim startInfo As New ProcessStartInfo() With {
                 .FileName = "netstat",

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -1,0 +1,42 @@
+﻿Namespace listViewSorter
+    ' Implements a comparer for ListView columns.
+    Class ListViewComparer
+        Implements IComparer
+
+        Private intColumnNumber As Integer
+        Private soSortOrder As SortOrder
+
+        Public Sub New(ByVal intInputColumnNumber As Integer, ByVal soInputSortOrder As SortOrder)
+            intColumnNumber = intInputColumnNumber
+            soSortOrder = soInputSortOrder
+        End Sub
+
+        ' Compare the items in the appropriate column
+        ' for objects x and y.
+        Public Function Compare(lvInputFirstListView As Object, lvInputSecondListView As Object) As Integer Implements IComparer.Compare
+            Dim dbl1, dbl2 As Double
+            Dim long1, long2 As Long
+            Dim date1, date2 As Date
+            Dim strFirstString, strSecondString As String
+            Dim lvFirstListView As ListViewItem = lvInputFirstListView
+            Dim lvSecondListView As ListViewItem = lvInputSecondListView
+            Dim lvFirstListViewType As Type = lvFirstListView.GetType
+            Dim lvSecondListViewType As Type = lvSecondListView.GetType
+
+            ' Get the sub-item values.
+            strFirstString = If(lvFirstListView.SubItems.Count <= intColumnNumber, "", lvFirstListView.SubItems(intColumnNumber).Text)
+            strSecondString = If(lvSecondListView.SubItems.Count <= intColumnNumber, "", lvSecondListView.SubItems(intColumnNumber).Text)
+
+            ' Compare them.
+            If Double.TryParse(strFirstString, dbl1) And Double.TryParse(strSecondString, dbl2) Then
+                Return If(soSortOrder = SortOrder.Ascending, dbl1.CompareTo(dbl2), dbl2.CompareTo(dbl1))
+            ElseIf Date.TryParse(strFirstString, date1) And Date.TryParse(strSecondString, date2) Then
+                Return If(soSortOrder = SortOrder.Ascending, date1.CompareTo(date2), date2.CompareTo(date1))
+            ElseIf Long.TryParse(strFirstString, long1) And Long.TryParse(strSecondString, long2) Then
+                Return If(soSortOrder = SortOrder.Ascending, long1.CompareTo(long2), long2.CompareTo(long1))
+            Else
+                Return If(soSortOrder = SortOrder.Ascending, String.Compare(strFirstString, strSecondString), String.Compare(strSecondString, strFirstString))
+            End If
+        End Function
+    End Class
+End Namespace

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -122,8 +122,8 @@ Public Class Alerts
             If AlertsListView.SelectedItems.Count = 1 Then
                 AlertsListView.Items.Remove(AlertsListView.SelectedItems(0))
             Else
-                For Each item As ListViewItem In AlertsListView.SelectedItems
-                    item.Remove()
+                For i As Integer = AlertsListView.SelectedItems.Count - 1 To 0 Step -1
+                    AlertsListView.SelectedItems(i).Remove()
                 Next
             End If
 

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -5,6 +5,7 @@ Public Class Alerts
     Public boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
     Private draggedItem As ListViewItem
+    Private m_SortingColumn As ColumnHeader
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles AlertsListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -292,6 +293,8 @@ Public Class Alerts
                 tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
             Next
 
+            alertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+
             My.Settings.alerts = tempAlerts
             My.Settings.Save()
         End If
@@ -472,5 +475,43 @@ Public Class Alerts
         ChkRegex.Checked = False
         ChkEnabled.Checked = True
         BtnCancel.Visible = False
+    End Sub
+
+    Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles AlertsListView.ColumnClick
+        ' Get the new sorting column.
+        Dim new_sorting_column As ColumnHeader = AlertsListView.Columns(e.Column)
+
+        ' Figure out the new sorting order.
+        Dim sort_order As SortOrder
+        If m_SortingColumn Is Nothing Then
+            ' New column. Sort ascending.
+            sort_order = SortOrder.Ascending
+        Else
+            ' See if this is the same column.
+            If new_sorting_column.Equals(m_SortingColumn) Then
+                ' Same column. Switch the sort order.
+                If m_SortingColumn.Text.StartsWith("> ") Then
+                    sort_order = SortOrder.Descending
+                Else
+                    sort_order = SortOrder.Ascending
+                End If
+            Else
+                ' New column. Sort ascending.
+                sort_order = SortOrder.Ascending
+            End If
+
+            ' Remove the old sort indicator.
+            m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
+        End If
+
+        ' Display the new sort order.
+        m_SortingColumn = new_sorting_column
+        m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
+
+        ' Create a comparer.
+        AlertsListView.ListViewItemSorter = New listViewSorter.ListViewComparer(e.Column, sort_order)
+
+        ' Sort.
+        AlertsListView.Sort()
     End Sub
 End Class

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -473,40 +473,6 @@ Public Class Alerts
     End Sub
 
     Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles AlertsListView.ColumnClick
-        ' Get the new sorting column.
-        Dim new_sorting_column As ColumnHeader = AlertsListView.Columns(e.Column)
-
-        ' Figure out the new sorting order.
-        Dim sort_order As SortOrder
-        If m_SortingColumn Is Nothing Then
-            ' New column. Sort ascending.
-            sort_order = SortOrder.Ascending
-        Else
-            ' See if this is the same column.
-            If new_sorting_column.Equals(m_SortingColumn) Then
-                ' Same column. Switch the sort order.
-                If m_SortingColumn.Text.StartsWith("> ") Then
-                    sort_order = SortOrder.Descending
-                Else
-                    sort_order = SortOrder.Ascending
-                End If
-            Else
-                ' New column. Sort ascending.
-                sort_order = SortOrder.Ascending
-            End If
-
-            ' Remove the old sort indicator.
-            m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
-        End If
-
-        ' Display the new sort order.
-        m_SortingColumn = new_sorting_column
-        m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
-
-        ' Create a comparer.
-        AlertsListView.ListViewItemSorter = New listViewSorter.ListViewComparer(e.Column, sort_order)
-
-        ' Sort.
-        AlertsListView.Sort()
+        SortByClickedColumn(AlertsListView, e.Column, m_SortingColumn)
     End Sub
 End Class

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -92,12 +92,7 @@ Public Class Alerts
     End Sub
 
     Private Sub AlertsListView_KeyUp(sender As Object, e As KeyEventArgs) Handles AlertsListView.KeyUp
-        If e.KeyCode = Keys.Delete And AlertsListView.SelectedItems().Count > 0 Then
-            AlertsListView.Items.Remove(AlertsListView.SelectedItems(0))
-            BtnDelete.Enabled = False
-            BtnEdit.Enabled = False
-            boolChanged = True
-        End If
+        If e.KeyCode = Keys.Delete And AlertsListView.SelectedItems().Count > 0 Then BtnDelete.PerformClick()
     End Sub
 
     Private Sub AlertsListView_Click(sender As Object, e As EventArgs) Handles AlertsListView.Click

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -204,11 +204,7 @@ Public Class ConfigureSysLogMirrorClients
     End Sub
 
     Private Sub Servers_KeyUp(sender As Object, e As KeyEventArgs) Handles servers.KeyUp
-        If e.KeyCode = Keys.Delete And servers.SelectedItems().Count > 0 Then
-            servers.Items.Remove(servers.SelectedItems(0))
-            BtnDeleteServer.Enabled = False
-            BtnEditServer.Enabled = False
-        End If
+        If e.KeyCode = Keys.Delete And servers.SelectedItems().Count > 0 Then BtnDeleteServer.PerformClick()
     End Sub
 
     Private Sub BtnExport_Click(sender As Object, e As EventArgs) Handles BtnExport.Click

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -157,7 +157,15 @@ Public Class ConfigureSysLogMirrorClients
     End Sub
 
     Private Sub BtnDeleteServer_Click(sender As Object, e As EventArgs) Handles BtnDeleteServer.Click
-        servers.SelectedItems(0).Remove()
+        If servers.SelectedItems.Count > 0 Then
+            If servers.SelectedItems.Count = 1 Then
+                servers.Items.Remove(servers.SelectedItems(0))
+            Else
+                For i As Integer = servers.SelectedItems.Count - 1 To 0 Step -1
+                    servers.SelectedItems(i).Remove()
+                Next
+            End If
+        End If
     End Sub
 
     Private Sub ConfigureSysLogMirrorServers_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -714,9 +714,7 @@ Public Class Form1
     End Sub
 
     Private Sub Logs_KeyUp(sender As Object, e As KeyEventArgs) Handles Logs.KeyUp
-        If e.KeyValue = Keys.Enter Then
-            OpenLogViewerWindow()
-        ElseIf e.KeyValue = Keys.Delete Then
+        If e.KeyValue = Keys.Delete Then
             SyncLock dataGridLockObject
                 Dim intNumberOfLogsDeleted As Integer = Logs.SelectedRows.Count
 
@@ -761,7 +759,10 @@ Public Class Form1
     End Sub
 
     Private Sub Logs_KeyDown(sender As Object, e As KeyEventArgs) Handles Logs.KeyDown
-        If e.KeyCode = Keys.Enter Then e.Handled = True
+        If e.KeyCode = Keys.Enter Then
+            e.Handled = True
+            OpenLogViewerWindow()
+        End If
     End Sub
 
     Private Sub Logs_UserDeletingRow(sender As Object, e As DataGridViewRowCancelEventArgs) Handles Logs.UserDeletingRow

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -248,4 +248,8 @@ Public Class Hostnames
     Private Sub Hostnames_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
         If e.KeyCode = Keys.Delete Then BtnDelete.PerformClick()
     End Sub
+
+    Private Sub ListHostnames_KeyUp(sender As Object, e As KeyEventArgs) Handles ListHostnames.KeyUp
+        If e.KeyCode = Keys.Delete Then BtnDelete.PerformClick()
+    End Sub
 End Class

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -130,8 +130,8 @@ Public Class Hostnames
             If ListHostnames.SelectedItems.Count = 1 Then
                 ListHostnames.Items.Remove(ListHostnames.SelectedItems(0))
             Else
-                For Each item As ListViewItem In ListHostnames.SelectedItems
-                    item.Remove()
+                For i As Integer = ListHostnames.SelectedItems.Count - 1 To 0 Step -1
+                    ListHostnames.SelectedItems(i).Remove()
                 Next
             End If
         End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -179,8 +179,8 @@ Public Class IgnoredWordsAndPhrases
             If IgnoredListView.SelectedItems.Count = 1 Then
                 IgnoredListView.Items.Remove(IgnoredListView.SelectedItems(0))
             Else
-                For Each item As ListViewItem In IgnoredListView.SelectedItems
-                    item.Remove()
+                For i As Integer = IgnoredListView.SelectedItems.Count - 1 To 0 Step -1
+                    IgnoredListView.SelectedItems(i).Remove()
                 Next
             End If
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -436,40 +436,6 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles IgnoredListView.ColumnClick
-        ' Get the new sorting column.
-        Dim new_sorting_column As ColumnHeader = IgnoredListView.Columns(e.Column)
-
-        ' Figure out the new sorting order.
-        Dim sort_order As SortOrder
-        If m_SortingColumn Is Nothing Then
-            ' New column. Sort ascending.
-            sort_order = SortOrder.Ascending
-        Else
-            ' See if this is the same column.
-            If new_sorting_column.Equals(m_SortingColumn) Then
-                ' Same column. Switch the sort order.
-                If m_SortingColumn.Text.StartsWith("> ") Then
-                    sort_order = SortOrder.Descending
-                Else
-                    sort_order = SortOrder.Ascending
-                End If
-            Else
-                ' New column. Sort ascending.
-                sort_order = SortOrder.Ascending
-            End If
-
-            ' Remove the old sort indicator.
-            m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
-        End If
-
-        ' Display the new sort order.
-        m_SortingColumn = new_sorting_column
-        m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
-
-        ' Create a comparer.
-        IgnoredListView.ListViewItemSorter = New listViewSorter.ListViewComparer(e.Column, sort_order)
-
-        ' Sort.
-        IgnoredListView.Sort()
+        SortByClickedColumn(IgnoredListView, e.Column, m_SortingColumn)
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -6,6 +6,7 @@ Public Class IgnoredWordsAndPhrases
     Private boolEditMode As Boolean = False
     Public strIgnoredPattern As String = Nothing
     Private draggedItem As ListViewItem
+    Private m_SortingColumn As ColumnHeader
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -118,6 +119,8 @@ Public Class IgnoredWordsAndPhrases
                     If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
                     listOfIgnoredRulesToBeSavedToSettings.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
                 Next
+
+                ignoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
 
                 My.Settings.ignored2 = listOfIgnoredRulesToBeSavedToSettings
                 My.Settings.Save()
@@ -435,5 +438,43 @@ Public Class IgnoredWordsAndPhrases
         ChkCaseSensitive.Checked = False
         ChkRegex.Checked = False
         ChkEnabled.Checked = True
+    End Sub
+
+    Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles IgnoredListView.ColumnClick
+        ' Get the new sorting column.
+        Dim new_sorting_column As ColumnHeader = IgnoredListView.Columns(e.Column)
+
+        ' Figure out the new sorting order.
+        Dim sort_order As SortOrder
+        If m_SortingColumn Is Nothing Then
+            ' New column. Sort ascending.
+            sort_order = SortOrder.Ascending
+        Else
+            ' See if this is the same column.
+            If new_sorting_column.Equals(m_SortingColumn) Then
+                ' Same column. Switch the sort order.
+                If m_SortingColumn.Text.StartsWith("> ") Then
+                    sort_order = SortOrder.Descending
+                Else
+                    sort_order = SortOrder.Ascending
+                End If
+            Else
+                ' New column. Sort ascending.
+                sort_order = SortOrder.Ascending
+            End If
+
+            ' Remove the old sort indicator.
+            m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
+        End If
+
+        ' Display the new sort order.
+        m_SortingColumn = new_sorting_column
+        m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
+
+        ' Create a comparer.
+        IgnoredListView.ListViewItemSorter = New listViewSorter.ListViewComparer(e.Column, sort_order)
+
+        ' Sort.
+        IgnoredListView.Sort()
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -166,12 +166,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredListView_KeyUp(sender As Object, e As KeyEventArgs) Handles IgnoredListView.KeyUp
-        If e.KeyCode = Keys.Delete And IgnoredListView.SelectedItems().Count > 0 Then
-            IgnoredListView.Items.Remove(IgnoredListView.SelectedItems(0))
-            BtnDelete.Enabled = False
-            BtnEdit.Enabled = False
-            boolChanged = True
-        End If
+        If e.KeyCode = Keys.Delete And IgnoredListView.SelectedItems().Count > 0 Then BtnDelete.PerformClick()
     End Sub
 
     Private Sub BtnDelete_Click(sender As Object, e As EventArgs) Handles BtnDelete.Click

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -168,10 +168,7 @@ Public Class Replacements
     Private Sub ReplacementsListView_KeyUp(sender As Object, e As KeyEventArgs) Handles ReplacementsListView.KeyUp
         If ReplacementsListView.SelectedItems.Count > 0 Then
             If e.KeyCode = Keys.Delete Then
-                ReplacementsListView.Items.Remove(ReplacementsListView.SelectedItems(0))
-                BtnDelete.Enabled = False
-                BtnEdit.Enabled = False
-                boolChanged = True
+                BtnDelete.PerformClick()
             ElseIf e.KeyCode = Keys.Enter Then
                 EditItem()
             End If

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -407,40 +407,6 @@ Public Class Replacements
     End Sub
 
     Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles ReplacementsListView.ColumnClick
-        ' Get the new sorting column.
-        Dim new_sorting_column As ColumnHeader = ReplacementsListView.Columns(e.Column)
-
-        ' Figure out the new sorting order.
-        Dim sort_order As SortOrder
-        If m_SortingColumn Is Nothing Then
-            ' New column. Sort ascending.
-            sort_order = SortOrder.Ascending
-        Else
-            ' See if this is the same column.
-            If new_sorting_column.Equals(m_SortingColumn) Then
-                ' Same column. Switch the sort order.
-                If m_SortingColumn.Text.StartsWith("> ") Then
-                    sort_order = SortOrder.Descending
-                Else
-                    sort_order = SortOrder.Ascending
-                End If
-            Else
-                ' New column. Sort ascending.
-                sort_order = SortOrder.Ascending
-            End If
-
-            ' Remove the old sort indicator.
-            m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
-        End If
-
-        ' Display the new sort order.
-        m_SortingColumn = new_sorting_column
-        m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
-
-        ' Create a comparer.
-        ReplacementsListView.ListViewItemSorter = New listViewSorter.ListViewComparer(e.Column, sort_order)
-
-        ' Sort.
-        ReplacementsListView.Sort()
+        SortByClickedColumn(ReplacementsListView, e.Column, m_SortingColumn)
     End Sub
 End Class

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -183,8 +183,8 @@ Public Class Replacements
             If ReplacementsListView.SelectedItems.Count = 1 Then
                 ReplacementsListView.Items.Remove(ReplacementsListView.SelectedItems(0))
             Else
-                For Each item As ListViewItem In ReplacementsListView.SelectedItems
-                    item.Remove()
+                For i As Integer = ReplacementsListView.SelectedItems.Count - 1 To 0 Step -1
+                    ReplacementsListView.SelectedItems(i).Remove()
                 Next
             End If
 


### PR DESCRIPTION
- Added sorting to the ListView on the Alerts, Replacements, and "Ignored Words and Phrases" windows.
- Fixed multi-delete on the Alerts, Hostnames, "Ignored Words and Phrases", and Replacements windows.
- Added multi-delete to the "Configure SysLog Mirror Clients" window.
- Changed the code of the Delete key event on the Alerts, Replacements, "Ignored Words and Phrases", Hostnames, and "Configure SysLog Mirror Clients" windows.
- Fixed a long-standing bug in which the Log Viewer window will incorrectly appear after pressing the Enter key to close a message box. This kind of behavior is especially evident after deleting logs on the main window.

This is a much smaller update than the last update but no less important.