### PR TITLE
Version 4.5 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.4.2.102")>
+<Assembly: AssemblyFileVersion("4.5.1.103")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1244,6 +1244,18 @@ Namespace My
                 Me("saveIgnoredLogCount") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("180")>  _
+        Public Property colIgnoredDateCreated() As Integer
+            Get
+                Return CType(Me("colIgnoredDateCreated"),Integer)
+            End Get
+            Set
+                Me("colIgnoredDateCreated") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -302,5 +302,8 @@
     <Setting Name="saveIgnoredLogCount" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="colIgnoredDateCreated" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">180</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/AlertsHistoryDataGridViewRow.vb
+++ b/Free SysLog/Support Code/AlertsHistoryDataGridViewRow.vb
@@ -6,6 +6,7 @@
     Public Property strRawLog As String
     Public Property strTime As String
     Public Property strAlertText As String
+    Public alertType As AlertType = AlertType.None
 
     Public Overrides Function Clone()
         Dim AlertsHistoryDataGridViewRow As New AlertsHistoryDataGridViewRow()

--- a/Free SysLog/Support Code/My Custom ListViews.vb
+++ b/Free SysLog/Support Code/My Custom ListViews.vb
@@ -24,6 +24,8 @@ Public Class MyIgnoredListViewItem
     Public Property BoolCaseSensitive As Boolean
     Public Property BoolEnabled As Boolean
     Public Property IgnoreType As IgnoreType
+    Public dateCreated As Date
+    Public strComment As String
 
     Public Sub New(strInput As String)
         Me.Text = strInput

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -118,13 +118,16 @@ End Class
 Public Class IgnoredClass
     Public BoolRegex As Boolean
     Public BoolCaseSensitive As Boolean
-    Public StrIgnore As String
+    Public StrIgnore, strComment As String
     Public BoolEnabled As Boolean = True
     Public IgnoreType As IgnoreType = IgnoreType.MainLog
+    Public dateCreated As Date
 
     Public Function ToListViewItem() As MyIgnoredListViewItem
         Dim intHits As Integer
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
+
+        If dateCreated = beginningDate Then dateCreated = Date.Now
 
         Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
         listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))
@@ -132,10 +135,13 @@ Public Class IgnoredClass
         listViewItem.SubItems.Add(If(BoolEnabled, "Yes", "No"))
         listViewItem.SubItems.Add(intHits.ToString("N0"))
         listViewItem.SubItems.Add(If(IgnoreType = IgnoreType.MainLog, "Main Log Text", "Remote App"))
+        listViewItem.SubItems.Add(dateCreated.ToLongDateString)
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled
         listViewItem.IgnoreType = IgnoreType
+        listViewItem.dateCreated = dateCreated
+        listViewItem.strComment = strComment
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
         listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
         Return listViewItem

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -107,6 +107,7 @@ Public Class AlertsHistory
                 .strLog = strLog
                 .strTime = strTime
                 .strAlertText = strAlertText
+                .alertType = alertType
             End With
 
             Return AlertsHistoryDataGridViewRow
@@ -193,6 +194,7 @@ End Class
 
 Public Class NotificationDataPacket
     Public logtext, alerttext, logdate, sourceip, rawlogtext As String
+    Public alertType As AlertType = AlertType.None
 End Class
 
 Public Class CustomHostname

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -127,7 +127,7 @@ Public Class IgnoredClass
         Dim intHits As Integer
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
 
-        If dateCreated = beginningDate Then dateCreated = Date.Now
+        If dateCreated = Date.MinValue Then dateCreated = Date.Now
 
         Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
         listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -281,7 +281,7 @@ Namespace checkForUpdates
                     strOSName = $"Windows NT {intOSMajorVersion}.{intOSMinorVersion}"
                 End If
 
-                Return $"{strOSName} {If(Environment.Is64BitOperatingSystem, "64", "32")}-bit (Microsoft .NET {dblDOTNETVersion })"
+                Return $"{strOSName} {If(Environment.Is64BitOperatingSystem, "64", "32")}-bit (Microsoft .NET {dblDOTNETVersion})"
             Catch ex As Exception
                 Try
                     Return $"Unknown Windows Operating System ({Environment.OSVersion.VersionString})"

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -100,7 +100,7 @@ Namespace checkForUpdates
 
         Private Function CanWriteToFolder(folderPath As String) As Boolean
             Try
-                Dim testFile = IO.Path.Combine(folderPath, Guid.NewGuid().ToString() & ".tmp")
+                Dim testFile As String = IO.Path.Combine(folderPath, Guid.NewGuid().ToString() & ".tmp")
                 File.WriteAllText(testFile, "test")
                 File.Delete(testFile)
                 Return True

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -5,7 +5,7 @@
         ' Time after which an unused entry is considered stale (in minutes)
         Private Const CleanupThresholdInMinutes As Integer = 10
 
-        Public Sub ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+        Public Sub ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
             ' Get the current time
             Dim currentTime As Date = Date.Now
 
@@ -26,7 +26,7 @@
                 lastNotificationTime(tipText) = currentTime
             End SyncLock
 
-            SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText)
+            SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alertType)
         End Sub
 
         ' Function to clean up old notification entries

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -54,8 +54,6 @@ Namespace SupportCode
         Public IgnoredRegexCacheLockingObject As New Object()
         Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
 
-        Public beginningDate As Date = New Date(1, 1, 1)
-
         Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -113,8 +113,10 @@ Namespace SupportCode
             Try
                 Dim SpecializedStringCollection As New Specialized.StringCollection
 
-                For Each column As DataGridViewTextBoxColumn In columns
-                    SpecializedStringCollection.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New ColumnOrder With {.ColumnName = column.Name, .ColumnIndex = column.DisplayIndex}))
+                For Each column As DataGridViewColumn In columns
+                    If TypeOf column Is DataGridViewTextBoxColumn Then
+                        SpecializedStringCollection.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New ColumnOrder With {.ColumnName = column.Name, .ColumnIndex = column.DisplayIndex}))
+                    End If
                 Next
 
                 Return SpecializedStringCollection

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -54,6 +54,8 @@ Namespace SupportCode
         Public IgnoredRegexCacheLockingObject As New Object()
         Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
 
+        Public beginningDate As Date = New Date(1, 1, 1)
+
         Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New List(Of ReplacementsClass)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -219,7 +219,7 @@ Namespace SupportCode
             Return Nothing
         End Function
 
-        Public Sub ShowToastNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+        Public Sub ShowToastNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
             Dim strIconPath As String = Nothing
             Dim notification As New ToastContentBuilder()
 
@@ -235,7 +235,7 @@ Namespace SupportCode
             End If
 
             If My.Settings.IncludeButtonsOnNotifications Then
-                Dim strNotificationPacket As String = Newtonsoft.Json.JsonConvert.SerializeObject(New NotificationDataPacket With {.alerttext = tipText, .logdate = strLogDate, .logtext = strLogText, .sourceip = strSourceIP, .rawlogtext = strRawLogText})
+                Dim strNotificationPacket As String = Newtonsoft.Json.JsonConvert.SerializeObject(New NotificationDataPacket With {.alerttext = tipText, .logdate = strLogDate, .logtext = strLogText, .sourceip = strSourceIP, .rawlogtext = strRawLogText, .alertType = alertType})
 
                 notification.AddButton(New ToastButton().SetContent("View Log").AddArgument("action", strViewLog).AddArgument("datapacket", strNotificationPacket))
                 notification.AddButton(New ToastButton().SetContent("Open SysLog").AddArgument("action", strOpenSysLog))

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -585,9 +585,9 @@ Namespace SyslogParser
                         End If
 
                         If alert.BoolLimited Then
-                            NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText)
+                            NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType)
                         Else
-                            ShowToastNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText)
+                            ShowToastNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType)
                         End If
 
                         strOutgoingAlertText = strAlertText

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -11,10 +11,10 @@ Public Class Alerts_History
         End Set
     End Property
 
-    Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+    Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
         strRawLogText = strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase)
 
-        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = alertType}
             LogViewerInstance.LblLogDate.Text = $"Log Date: {strLogDate}"
             LogViewerInstance.LblSource.Text = $"Source IP Address: {strSourceIP}"
             LogViewerInstance.TopMost = True
@@ -78,7 +78,7 @@ Public Class Alerts_History
             Dim AlertsHistoryDataGridViewRow As AlertsHistoryDataGridViewRow = DirectCast(AlertHistoryList.SelectedRows(0), AlertsHistoryDataGridViewRow)
 
             With AlertsHistoryDataGridViewRow
-                OpenLogViewerWindow(.strLog, .strAlertText, .strTime, .strIP, .strRawLog)
+                OpenLogViewerWindow(.strLog, .strAlertText, .strTime, .strIP, .strRawLog, .alertType)
             End With
         End If
     End Sub

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -218,6 +218,7 @@ Public Class Alerts
                     .AlertType = AlertType
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolLimited = ChkLimited.Checked
+                    .BackColor = If(ChkEnabled.Checked, Color.LightGreen, Color.Pink)
                 End With
 
                 AlertsListView.Enabled = True
@@ -254,6 +255,7 @@ Public Class Alerts
                     .AlertType = AlertType
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolLimited = ChkLimited.Checked
+                    .BackColor = If(ChkEnabled.Checked, Color.LightGreen, Color.Pink)
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
                 End With
 

--- a/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
+++ b/Free SysLog/Windows/Close Free SysLog Dialog.Designer.vb
@@ -67,7 +67,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnNo.Location = New System.Drawing.Point(189, 64)
         Me.BtnNo.Name = "BtnNo"
         Me.BtnNo.Size = New System.Drawing.Size(75, 23)
-        Me.BtnNo.TabIndex = 0
+        Me.BtnNo.TabIndex = 1
         Me.BtnNo.Text = "&No"
         Me.ToolTip.SetToolTip(Me.BtnNo, "Can be activated by pressing the N key.")
         Me.BtnNo.UseVisualStyleBackColor = True
@@ -77,7 +77,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnYes.Location = New System.Drawing.Point(108, 64)
         Me.BtnYes.Name = "BtnYes"
         Me.BtnYes.Size = New System.Drawing.Size(75, 23)
-        Me.BtnYes.TabIndex = 2
+        Me.BtnYes.TabIndex = 0
         Me.BtnYes.Text = "&Yes"
         Me.ToolTip.SetToolTip(Me.BtnYes, "Can be activated by pressing the Y key.")
         Me.BtnYes.UseVisualStyleBackColor = True
@@ -87,7 +87,7 @@ Partial Class CloseFreeSysLogDialog
         Me.BtnMinimize.Location = New System.Drawing.Point(271, 64)
         Me.BtnMinimize.Name = "BtnMinimize"
         Me.BtnMinimize.Size = New System.Drawing.Size(75, 23)
-        Me.BtnMinimize.TabIndex = 1
+        Me.BtnMinimize.TabIndex = 2
         Me.BtnMinimize.Text = "&Minimize"
         Me.ToolTip.SetToolTip(Me.BtnMinimize, "Can be activated by pressing the M key.")
         Me.BtnMinimize.UseVisualStyleBackColor = True

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -979,7 +979,7 @@ Partial Class Form1
         Me.colDelete.HeaderText = "Delete?"
         Me.colDelete.Name = "colDelete"
         Me.colDelete.ReadOnly = True
-        Me.colDelete.Width = 50
+        Me.colDelete.Width = 60
         '
         'Form1
         '

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -141,6 +141,7 @@ Partial Class Form1
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
         Me.lblLimitBy = New System.Windows.Forms.Label()
+        Me.colDelete = New System.Windows.Forms.DataGridViewCheckBoxColumn()
         Me.StatusStrip.SuspendLayout()
         Me.MenuStrip.SuspendLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -586,7 +587,7 @@ Partial Class Form1
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.Logs.BackgroundColor = System.Drawing.SystemColors.ButtonHighlight
         Me.Logs.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
-        Me.Logs.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.ColTime, Me.colServerTime, Me.colLogType, Me.ColIPAddress, Me.ColHostname, Me.ColRemoteProcess, Me.ColLog, Me.ColAlerts})
+        Me.Logs.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.ColTime, Me.colServerTime, Me.colLogType, Me.ColIPAddress, Me.ColHostname, Me.ColRemoteProcess, Me.ColLog, Me.ColAlerts, Me.colDelete})
         Me.Logs.ContextMenuStrip = Me.LogsMenu
         Me.Logs.Location = New System.Drawing.Point(12, 52)
         Me.Logs.Name = "Logs"
@@ -973,6 +974,13 @@ Partial Class Form1
         Me.boxLimitBy.Text = "(Not Specified)"
         Me.boxLimitBy.TabIndex = 43
         '
+        'colDelete
+        '
+        Me.colDelete.HeaderText = "Delete?"
+        Me.colDelete.Name = "colDelete"
+        Me.colDelete.ReadOnly = True
+        Me.colDelete.Width = 50
+        '
         'Form1
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -1125,4 +1133,5 @@ Partial Class Form1
     Friend WithEvents boxLimitBy As ComboBox
     Friend WithEvents lblLimitBy As Label
     Friend WithEvents btnShowLimit As Button
+    Friend WithEvents colDelete As DataGridViewCheckBoxColumn
 End Class

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -787,6 +787,11 @@ Public Class Form1
             If Logs.SelectedCells.Count > 0 Then
                 Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
                 selectedRow.Cells(colDelete.Index).Value = Not selectedRow.Cells(colDelete.Index).Value
+
+                Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
+
+                LblItemsSelected.Visible = True
+                LblItemsSelected.Text = $"Checked Logs: {intNumberOfCheckedLogs:N0}"
             End If
         End If
     End Sub
@@ -1589,8 +1594,12 @@ Public Class Form1
     End Sub
 
     Private Sub Logs_SelectionChanged(sender As Object, e As EventArgs) Handles Logs.SelectionChanged
-        LblItemsSelected.Visible = Logs.SelectedRows.Count > 1
-        LblItemsSelected.Text = $"Selected Logs: {Logs.SelectedRows.Count:N0}"
+        Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
+
+        If intNumberOfCheckedLogs = 0 Then
+            LblItemsSelected.Visible = Logs.SelectedRows.Count > 1
+            LblItemsSelected.Text = $"Selected Logs: {Logs.SelectedRows.Count:N0}"
+        End If
     End Sub
 
     Private Sub ChkDeselectItemAfterMinimizingWindow_Click(sender As Object, e As EventArgs) Handles ChkDeselectItemAfterMinimizingWindow.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -496,7 +496,7 @@ Public Class Form1
                                                                            Try
                                                                                Dim NotificationDataPacket As NotificationDataPacket = Newtonsoft.Json.JsonConvert.DeserializeObject(Of NotificationDataPacket)(argsDictionary("datapacket").ToString, JSONDecoderSettingsForSettingsFiles)
 
-                                                                               OpenLogViewerWindow(NotificationDataPacket.logtext, NotificationDataPacket.alerttext, NotificationDataPacket.logdate, NotificationDataPacket.sourceip, NotificationDataPacket.rawlogtext)
+                                                                               OpenLogViewerWindow(NotificationDataPacket.logtext, NotificationDataPacket.alerttext, NotificationDataPacket.logdate, NotificationDataPacket.sourceip, NotificationDataPacket.rawlogtext, NotificationDataPacket.alertType)
                                                                            Catch ex As Exception
                                                                            End Try
                                                                        End If
@@ -676,10 +676,10 @@ Public Class Form1
         SelectFileInWindowsExplorer(strPathToDataFile)
     End Sub
 
-    Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String)
+    Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
         strRawLogText = strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase)
 
-        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = alertType}
             LogViewerInstance.LblLogDate.Text = $"Log Date: {strLogDate}"
             LogViewerInstance.LblSource.Text = $"Source IP Address: {strSourceIP}"
             LogViewerInstance.TopMost = True
@@ -695,7 +695,7 @@ Public Class Form1
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
             Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
-            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .MyParentForm = Me}
+            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .MyParentForm = Me, .alertType = selectedRow.alertType}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"
                 LogViewerInstance.LblSource.Text = $"Source IP Address: {selectedRow.Cells(ColumnIndex_IPAddress).Value}"
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -398,6 +398,14 @@ Public Class Form1
         Return String.Join(" and ", parts)
     End Function
 
+    Private Sub Logs_CellPainting(sender As Object, e As DataGridViewCellPaintingEventArgs) Handles Logs.CellPainting
+        If e.RowIndex = -1 AndAlso e.ColumnIndex = ColAlerts.Index Then
+            e.PaintBackground(e.CellBounds, False)
+            TextRenderer.DrawText(e.Graphics, e.FormattedValue.ToString(), e.CellStyle.Font, e.CellBounds, e.CellStyle.ForeColor, TextFormatFlags.HorizontalCenter Or TextFormatFlags.VerticalCenter)
+            e.Handled = True
+        End If
+    End Sub
+
     Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         SupportCode.ParentForm = Me
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -785,13 +785,24 @@ Public Class Form1
             e.Handled = True
 
             If Logs.SelectedCells.Count > 0 Then
-                Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
-                selectedRow.Cells(colDelete.Index).Value = Not selectedRow.Cells(colDelete.Index).Value
+                If Logs.SelectedCells.Count = 1 Then
+                    Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
+                    selectedRow.Cells(colDelete.Index).Value = Not selectedRow.Cells(colDelete.Index).Value
+                Else
+                    For Each item As MyDataGridViewRow In Logs.SelectedRows
+                        item.Cells(colDelete.Index).Value = Not item.Cells(colDelete.Index).Value
+                    Next
+                End If
 
                 Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
 
-                LblItemsSelected.Visible = True
-                LblItemsSelected.Text = $"Checked Logs: {intNumberOfCheckedLogs:N0}"
+                If intNumberOfCheckedLogs = 0 Then
+                    LblItemsSelected.Visible = False
+                    LblItemsSelected.Text = Nothing
+                Else
+                    LblItemsSelected.Visible = True
+                    LblItemsSelected.Text = $"Checked Logs: {intNumberOfCheckedLogs:N0}"
+                End If
             End If
         End If
     End Sub

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1322,10 +1322,11 @@ Public Class Form1
 
     Private Sub CopyLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyLogTextToolStripMenuItem.Click
         Dim intLogCount As Integer = Logs.SelectedRows().Count
+        Dim boolCopyToClipboardResults As Boolean = False
 
         If intLogCount <> 0 Then
             If intLogCount = 1 Then
-                CopyTextToWindowsClipboard(Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value, Text)
+                boolCopyToClipboardResults = CopyTextToWindowsClipboard(Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value, Text)
             Else
                 Dim allSelectedLogs As New StringBuilder()
                 Dim selectedItem As MyDataGridViewRow
@@ -1335,10 +1336,10 @@ Public Class Form1
                     If selectedItem IsNot Nothing Then allSelectedLogs.AppendLine(selectedItem.Cells(ColumnIndex_LogText).Value)
                 Next
 
-                If allSelectedLogs.Length > 0 Then CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
+                If allSelectedLogs.Length > 0 Then boolCopyToClipboardResults = CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
             End If
 
-            MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
+            If boolCopyToClipboardResults Then MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
         End If
     End Sub
 
@@ -2009,11 +2010,12 @@ Public Class Form1
 
     Private Sub CopyRawLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyRawLogTextToolStripMenuItem.Click
         Dim intLogCount As Integer = Logs.SelectedRows().Count
+        Dim boolCopyToClipboardResults As Boolean = False
 
         If intLogCount <> 0 Then
             If intLogCount = 1 Then
                 Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
-                If selectedItem IsNot Nothing Then CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
+                If selectedItem IsNot Nothing Then boolCopyToClipboardResults = CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
             Else
                 Dim allSelectedLogs As New StringBuilder()
                 Dim selectedItem As MyDataGridViewRow
@@ -2023,10 +2025,10 @@ Public Class Form1
                     If selectedItem IsNot Nothing Then allSelectedLogs.AppendLine(selectedItem.RawLogData)
                 Next
 
-                If allSelectedLogs.Length > 0 Then CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
+                If allSelectedLogs.Length > 0 Then boolCopyToClipboardResults = CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
             End If
 
-            MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
+            If boolCopyToClipboardResults Then MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -776,6 +776,8 @@ Public Class Form1
 
                 Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {rowsToDelete.Count:N0} log {If(rowsToDelete.Count = 1, "entry", "entries")}.", Logs))
 
+                BtnSaveLogsToDisk.Enabled = True
+
                 SelectLatestLogEntry()
             End SyncLock
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1121,6 +1121,7 @@ Public Class Form1
     End Sub
 
     Private Sub ZerooutIgnoredLogsCounterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ZerooutIgnoredLogsCounterToolStripMenuItem.Click
+        IgnoredHits.Clear()
         longNumberOfIgnoredLogs = 0
         LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
     End Sub

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1309,13 +1309,11 @@ Public Class Form1
             Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
             If selectedItem IsNot Nothing Then CopyRawLogTextToolStripMenuItem.Visible = Not String.IsNullOrEmpty(selectedItem.RawLogData)
         Else
-            CopyLogTextToolStripMenuItem.Visible = False
             OpenLogViewerToolStripMenuItem.Visible = False
             CreateAlertToolStripMenuItem.Visible = False
             CreateReplacementToolStripMenuItem.Visible = False
             CreateIgnoredLogToolStripMenuItem.Visible = False
             DeleteSimilarLogsToolStripMenuItem.Visible = False
-            CopyRawLogTextToolStripMenuItem.Visible = False
         End If
 
         DeleteLogsToolStripMenuItem.Text = If(Logs.SelectedRows.Count = 1, "Delete Selected Log", "Delete Selected Logs")
@@ -1323,7 +1321,25 @@ Public Class Form1
     End Sub
 
     Private Sub CopyLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyLogTextToolStripMenuItem.Click
-        CopyTextToWindowsClipboard(Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value, Text)
+        Dim intLogCount As Integer = Logs.SelectedRows().Count
+
+        If intLogCount <> 0 Then
+            If intLogCount = 1 Then
+                CopyTextToWindowsClipboard(Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value, Text)
+            Else
+                Dim allSelectedLogs As New StringBuilder()
+                Dim selectedItem As MyDataGridViewRow
+
+                For Each item As DataGridViewRow In Logs.SelectedRows
+                    selectedItem = TryCast(item, MyDataGridViewRow)
+                    If selectedItem IsNot Nothing Then allSelectedLogs.AppendLine(selectedItem.Cells(ColumnIndex_LogText).Value)
+                Next
+
+                If allSelectedLogs.Length > 0 Then CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
+            End If
+
+            MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
+        End If
     End Sub
 
     Private Sub Logs_CellMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles Logs.CellMouseClick
@@ -1992,9 +2008,25 @@ Public Class Form1
     End Sub
 
     Private Sub CopyRawLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyRawLogTextToolStripMenuItem.Click
-        If Logs.SelectedRows().Count <> 0 Then
-            Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
-            If selectedItem IsNot Nothing Then CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
+        Dim intLogCount As Integer = Logs.SelectedRows().Count
+
+        If intLogCount <> 0 Then
+            If intLogCount = 1 Then
+                Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+                If selectedItem IsNot Nothing Then CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
+            Else
+                Dim allSelectedLogs As New StringBuilder()
+                Dim selectedItem As MyDataGridViewRow
+
+                For Each item As DataGridViewRow In Logs.SelectedRows
+                    selectedItem = TryCast(item, MyDataGridViewRow)
+                    If selectedItem IsNot Nothing Then allSelectedLogs.AppendLine(selectedItem.RawLogData)
+                Next
+
+                If allSelectedLogs.Length > 0 Then CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
+            End If
+
+            MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -123,6 +123,14 @@ Public Class IgnoredLogsAndSearchResults
         End If
     End Sub
 
+    Private Sub Logs_CellPainting(sender As Object, e As DataGridViewCellPaintingEventArgs) Handles Logs.CellPainting
+        If e.RowIndex = -1 AndAlso e.ColumnIndex = ColAlerts.Index Then
+            e.PaintBackground(e.CellBounds, False)
+            TextRenderer.DrawText(e.Graphics, e.FormattedValue.ToString(), e.CellStyle.Font, e.CellBounds, e.CellStyle.ForeColor, TextFormatFlags.HorizontalCenter Or TextFormatFlags.VerticalCenter)
+            e.Handled = True
+        End If
+    End Sub
+
     Private Sub Ignored_Logs_and_Search_Results_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If My.Settings.font IsNot Nothing Then
             Logs.DefaultCellStyle.Font = My.Settings.font

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -29,7 +29,7 @@ Public Class IgnoredLogsAndSearchResults
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
             Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
-            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = selectedRow.alertType}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"
                 LogViewerInstance.LblSource.Text = $"Source IP Address: {selectedRow.Cells(ColumnIndex_IPAddress).Value}"
 
@@ -596,7 +596,7 @@ Public Class IgnoredLogsAndSearchResults
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
             Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
-            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = selectedRow.alertType}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"
                 LogViewerInstance.LblSource.Text = $"Source IP Address: {selectedRow.Cells(ColumnIndex_IPAddress).Value}"
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -52,13 +52,16 @@ Partial Class IgnoredWordsAndPhrases
         Me.colHits = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.colTarget = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.btnResetHits = New System.Windows.Forms.Button()
+        Me.colDateCreated = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.txtComment = New System.Windows.Forms.TextBox()
+        Me.lblCommentLabel = New System.Windows.Forms.Label()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
         'BtnAdd
         '
         Me.BtnAdd.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnAdd.Location = New System.Drawing.Point(12, 348)
+        Me.BtnAdd.Location = New System.Drawing.Point(12, 402)
         Me.BtnAdd.Name = "BtnAdd"
         Me.BtnAdd.Size = New System.Drawing.Size(65, 23)
         Me.BtnAdd.TabIndex = 1
@@ -69,7 +72,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.BtnDelete.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnDelete.Enabled = False
-        Me.BtnDelete.Location = New System.Drawing.Point(12, 225)
+        Me.BtnDelete.Location = New System.Drawing.Point(12, 251)
         Me.BtnDelete.Name = "BtnDelete"
         Me.BtnDelete.Size = New System.Drawing.Size(65, 23)
         Me.BtnDelete.TabIndex = 2
@@ -82,13 +85,13 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
         Me.IgnoredListView.Location = New System.Drawing.Point(12, 12)
         Me.IgnoredListView.Name = "IgnoredListView"
-        Me.IgnoredListView.Size = New System.Drawing.Size(745, 207)
+        Me.IgnoredListView.Size = New System.Drawing.Size(950, 233)
         Me.IgnoredListView.TabIndex = 5
         Me.IgnoredListView.UseCompatibleStateImageBehavior = False
         Me.IgnoredListView.View = System.Windows.Forms.View.Details
@@ -127,7 +130,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.BtnEdit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnEdit.Enabled = False
-        Me.BtnEdit.Location = New System.Drawing.Point(83, 225)
+        Me.BtnEdit.Location = New System.Drawing.Point(83, 251)
         Me.BtnEdit.Name = "BtnEdit"
         Me.BtnEdit.Size = New System.Drawing.Size(75, 23)
         Me.BtnEdit.TabIndex = 8
@@ -138,7 +141,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.BtnEnableDisable.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnEnableDisable.Enabled = False
-        Me.BtnEnableDisable.Location = New System.Drawing.Point(164, 225)
+        Me.BtnEnableDisable.Location = New System.Drawing.Point(164, 251)
         Me.BtnEnableDisable.Name = "BtnEnableDisable"
         Me.BtnEnableDisable.Size = New System.Drawing.Size(75, 23)
         Me.BtnEnableDisable.TabIndex = 10
@@ -148,7 +151,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnImport
         '
         Me.BtnImport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnImport.Location = New System.Drawing.Point(712, 225)
+        Me.BtnImport.Location = New System.Drawing.Point(917, 251)
         Me.BtnImport.Name = "BtnImport"
         Me.BtnImport.Size = New System.Drawing.Size(75, 23)
         Me.BtnImport.TabIndex = 11
@@ -158,7 +161,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnExport
         '
         Me.BtnExport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnExport.Location = New System.Drawing.Point(631, 225)
+        Me.BtnExport.Location = New System.Drawing.Point(836, 251)
         Me.BtnExport.Name = "BtnExport"
         Me.BtnExport.Size = New System.Drawing.Size(75, 23)
         Me.BtnExport.TabIndex = 12
@@ -168,7 +171,7 @@ Partial Class IgnoredWordsAndPhrases
         'btnDeleteAll
         '
         Me.btnDeleteAll.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.btnDeleteAll.Location = New System.Drawing.Point(245, 225)
+        Me.btnDeleteAll.Location = New System.Drawing.Point(245, 251)
         Me.btnDeleteAll.Name = "btnDeleteAll"
         Me.btnDeleteAll.Size = New System.Drawing.Size(75, 23)
         Me.btnDeleteAll.TabIndex = 17
@@ -178,7 +181,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnDown
         '
         Me.BtnDown.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnDown.Location = New System.Drawing.Point(764, 196)
+        Me.BtnDown.Location = New System.Drawing.Point(969, 222)
         Me.BtnDown.Name = "BtnDown"
         Me.BtnDown.Size = New System.Drawing.Size(24, 23)
         Me.BtnDown.TabIndex = 19
@@ -188,7 +191,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnUp
         '
         Me.BtnUp.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnUp.Location = New System.Drawing.Point(763, 12)
+        Me.BtnUp.Location = New System.Drawing.Point(968, 12)
         Me.BtnUp.Name = "BtnUp"
         Me.BtnUp.Size = New System.Drawing.Size(24, 23)
         Me.BtnUp.TabIndex = 18
@@ -200,16 +203,16 @@ Partial Class IgnoredWordsAndPhrases
         Me.SeparatingLine.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.SeparatingLine.BackColor = System.Drawing.Color.Black
-        Me.SeparatingLine.Location = New System.Drawing.Point(-1, 260)
+        Me.SeparatingLine.Location = New System.Drawing.Point(-1, 286)
         Me.SeparatingLine.Name = "SeparatingLine"
-        Me.SeparatingLine.Size = New System.Drawing.Size(805, 1)
+        Me.SeparatingLine.Size = New System.Drawing.Size(1010, 1)
         Me.SeparatingLine.TabIndex = 26
         '
         'Label4
         '
         Me.Label4.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label4.AutoSize = True
-        Me.Label4.Location = New System.Drawing.Point(12, 273)
+        Me.Label4.Location = New System.Drawing.Point(12, 299)
         Me.Label4.Name = "Label4"
         Me.Label4.Size = New System.Drawing.Size(161, 13)
         Me.Label4.TabIndex = 39
@@ -221,7 +224,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkEnabled.AutoSize = True
         Me.ChkEnabled.Checked = True
         Me.ChkEnabled.CheckState = System.Windows.Forms.CheckState.Checked
-        Me.ChkEnabled.Location = New System.Drawing.Point(607, 325)
+        Me.ChkEnabled.Location = New System.Drawing.Point(607, 351)
         Me.ChkEnabled.Name = "ChkEnabled"
         Me.ChkEnabled.Size = New System.Drawing.Size(71, 17)
         Me.ChkEnabled.TabIndex = 44
@@ -232,7 +235,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.ChkCaseSensitive.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkCaseSensitive.AutoSize = True
-        Me.ChkCaseSensitive.Location = New System.Drawing.Point(499, 325)
+        Me.ChkCaseSensitive.Location = New System.Drawing.Point(499, 351)
         Me.ChkCaseSensitive.Name = "ChkCaseSensitive"
         Me.ChkCaseSensitive.Size = New System.Drawing.Size(102, 17)
         Me.ChkCaseSensitive.TabIndex = 43
@@ -243,7 +246,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.ChkRegex.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkRegex.AutoSize = True
-        Me.ChkRegex.Location = New System.Drawing.Point(15, 325)
+        Me.ChkRegex.Location = New System.Drawing.Point(15, 351)
         Me.ChkRegex.Name = "ChkRegex"
         Me.ChkRegex.Size = New System.Drawing.Size(478, 17)
         Me.ChkRegex.TabIndex = 42
@@ -255,16 +258,16 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.TxtIgnored.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TxtIgnored.Location = New System.Drawing.Point(61, 299)
+        Me.TxtIgnored.Location = New System.Drawing.Point(61, 325)
         Me.TxtIgnored.Name = "TxtIgnored"
-        Me.TxtIgnored.Size = New System.Drawing.Size(727, 20)
+        Me.TxtIgnored.Size = New System.Drawing.Size(932, 20)
         Me.TxtIgnored.TabIndex = 41
         '
         'Label1
         '
         Me.Label1.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label1.AutoSize = True
-        Me.Label1.Location = New System.Drawing.Point(12, 302)
+        Me.Label1.Location = New System.Drawing.Point(12, 328)
         Me.Label1.Name = "Label1"
         Me.Label1.Size = New System.Drawing.Size(43, 13)
         Me.Label1.TabIndex = 40
@@ -274,7 +277,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnCancel
         '
         Me.BtnCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnCancel.Location = New System.Drawing.Point(83, 348)
+        Me.BtnCancel.Location = New System.Drawing.Point(83, 402)
         Me.BtnCancel.Name = "BtnCancel"
         Me.BtnCancel.Size = New System.Drawing.Size(75, 23)
         Me.BtnCancel.TabIndex = 45
@@ -284,7 +287,7 @@ Partial Class IgnoredWordsAndPhrases
         'btnDeleteDuringEditing
         '
         Me.btnDeleteDuringEditing.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.btnDeleteDuringEditing.Location = New System.Drawing.Point(164, 348)
+        Me.btnDeleteDuringEditing.Location = New System.Drawing.Point(164, 402)
         Me.btnDeleteDuringEditing.Name = "btnDeleteDuringEditing"
         Me.btnDeleteDuringEditing.Size = New System.Drawing.Size(75, 23)
         Me.btnDeleteDuringEditing.TabIndex = 46
@@ -295,7 +298,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.ChkRemoteProcess.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkRemoteProcess.AutoSize = True
-        Me.ChkRemoteProcess.Location = New System.Drawing.Point(684, 325)
+        Me.ChkRemoteProcess.Location = New System.Drawing.Point(684, 351)
         Me.ChkRemoteProcess.Name = "ChkRemoteProcess"
         Me.ChkRemoteProcess.Size = New System.Drawing.Size(110, 17)
         Me.ChkRemoteProcess.TabIndex = 47
@@ -316,18 +319,42 @@ Partial Class IgnoredWordsAndPhrases
         'btnResetHits
         '
         Me.btnResetHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.btnResetHits.Location = New System.Drawing.Point(326, 225)
+        Me.btnResetHits.Location = New System.Drawing.Point(326, 251)
         Me.btnResetHits.Name = "btnResetHits"
         Me.btnResetHits.Size = New System.Drawing.Size(75, 23)
         Me.btnResetHits.TabIndex = 48
         Me.btnResetHits.Text = "Reset Hits"
         Me.btnResetHits.UseVisualStyleBackColor = True
         '
+        'colDateCreated
+        '
+        Me.colDateCreated.Text = "Date Created"
+        Me.colDateCreated.Width = 180
+        '
+        'txtComment
+        '
+        Me.txtComment.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.txtComment.Location = New System.Drawing.Point(73, 374)
+        Me.txtComment.Name = "txtComment"
+        Me.txtComment.Size = New System.Drawing.Size(919, 20)
+        Me.txtComment.TabIndex = 49
+        '
+        'lblCommentLabel
+        '
+        Me.lblCommentLabel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.lblCommentLabel.AutoSize = True
+        Me.lblCommentLabel.Location = New System.Drawing.Point(16, 377)
+        Me.lblCommentLabel.Name = "lblCommentLabel"
+        Me.lblCommentLabel.Size = New System.Drawing.Size(51, 13)
+        Me.lblCommentLabel.TabIndex = 50
+        Me.lblCommentLabel.Text = "Comment"
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(799, 378)
+        Me.ClientSize = New System.Drawing.Size(1004, 437)
         Me.Controls.Add(Me.ChkRemoteProcess)
         Me.Controls.Add(Me.btnDeleteDuringEditing)
         Me.Controls.Add(Me.BtnCancel)
@@ -349,6 +376,8 @@ Partial Class IgnoredWordsAndPhrases
         Me.Controls.Add(Me.BtnDelete)
         Me.Controls.Add(Me.BtnAdd)
         Me.Controls.Add(Me.btnResetHits)
+        Me.Controls.Add(Me.lblCommentLabel)
+        Me.Controls.Add(Me.txtComment)
         Me.KeyPreview = True
         Me.MinimumSize = New System.Drawing.Size(815, 417)
         Me.Name = "IgnoredWordsAndPhrases"
@@ -387,4 +416,7 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents colHits As ColumnHeader
     Friend WithEvents colTarget As ColumnHeader
     Friend WithEvents btnResetHits As Button
+    Friend WithEvents colDateCreated As ColumnHeader
+    Friend WithEvents txtComment As TextBox
+    Friend WithEvents lblCommentLabel As Label
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -51,6 +51,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkRemoteProcess = New System.Windows.Forms.CheckBox()
         Me.colHits = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.colTarget = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.btnResetHits = New System.Windows.Forms.Button()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -312,6 +313,16 @@ Partial Class IgnoredWordsAndPhrases
         Me.colTarget.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         Me.colTarget.Width = 125
         '
+        'btnResetHits
+        '
+        Me.btnResetHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnResetHits.Location = New System.Drawing.Point(326, 225)
+        Me.btnResetHits.Name = "btnResetHits"
+        Me.btnResetHits.Size = New System.Drawing.Size(75, 23)
+        Me.btnResetHits.TabIndex = 48
+        Me.btnResetHits.Text = "Reset Hits"
+        Me.btnResetHits.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -337,6 +348,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.Controls.Add(Me.IgnoredListView)
         Me.Controls.Add(Me.BtnDelete)
         Me.Controls.Add(Me.BtnAdd)
+        Me.Controls.Add(Me.btnResetHits)
         Me.KeyPreview = True
         Me.MinimumSize = New System.Drawing.Size(815, 417)
         Me.Name = "IgnoredWordsAndPhrases"
@@ -374,4 +386,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents ChkRemoteProcess As CheckBox
     Friend WithEvents colHits As ColumnHeader
     Friend WithEvents colTarget As ColumnHeader
+    Friend WithEvents btnResetHits As Button
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -76,8 +76,10 @@ Public Class IgnoredWordsAndPhrases
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                     .strComment = txtComment.Text
 
-                    If .dateCreated = Date.MinValue Then .dateCreated = Date.Now ' Just in case it was never set
-                    .SubItems(6).Text = Date.Now.ToLongDateString
+                    If .dateCreated = Date.MinValue Then ' Just in case it was never set
+                        .dateCreated = Date.Now
+                        .SubItems(6).Text = Date.Now.ToLongDateString
+                    End If
                 End With
 
                 IgnoredListView.Enabled = True

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -441,4 +441,12 @@ Public Class IgnoredWordsAndPhrases
     Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles IgnoredListView.ColumnClick
         SortByClickedColumn(IgnoredListView, e.Column, m_SortingColumn)
     End Sub
+
+    Private Sub btnResetHits_Click(sender As Object, e As EventArgs) Handles btnResetHits.Click
+        IgnoredHits.Clear()
+
+        For Each item As MyIgnoredListViewItem In IgnoredListView.Items
+            item.SubItems(4).Text = "0"
+        Next
+    End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -74,6 +74,7 @@ Public Class IgnoredWordsAndPhrases
                     .BoolRegex = ChkRegex.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
+                    .strComment = txtComment.Text
                 End With
 
                 IgnoredListView.Enabled = True
@@ -92,6 +93,7 @@ Public Class IgnoredWordsAndPhrases
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
+                    .strComment = txtComment.Text
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                 End With
@@ -118,7 +120,7 @@ Public Class IgnoredWordsAndPhrases
                 Dim listOfIgnoredRulesToBeSavedToSettings As New Specialized.StringCollection()
 
                 For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType}
+                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment}
                     If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
                     listOfIgnoredRulesToBeSavedToSettings.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
                 Next
@@ -228,6 +230,7 @@ Public Class IgnoredWordsAndPhrases
             ChkRegex.Checked = selectedItemObject.BoolRegex
             ChkCaseSensitive.Checked = selectedItemObject.BoolCaseSensitive
             ChkEnabled.Checked = selectedItemObject.BoolEnabled
+            txtComment.Text = selectedItemObject.strComment
         End If
     End Sub
 
@@ -313,7 +316,7 @@ Public Class IgnoredWordsAndPhrases
 
         If saveFileDialog.ShowDialog() = DialogResult.OK Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType})
+                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment})
             Next
 
             IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -428,6 +428,7 @@ Public Class IgnoredWordsAndPhrases
         boolEditMode = False
         boolChanged = True
         TxtIgnored.Text = Nothing
+        txtComment.Text = Nothing
         ChkCaseSensitive.Checked = False
         ChkRegex.Checked = False
         ChkEnabled.Checked = True

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -68,6 +68,7 @@ Public Class IgnoredWordsAndPhrases
                     .SubItems(1).Text = If(ChkRegex.Checked, "Yes", "No")
                     .SubItems(2).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
                     .SubItems(3).Text = If(ChkEnabled.Checked, "Yes", "No")
+                    .SubItems(5).Text = If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text")
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolRegex = ChkRegex.Checked
@@ -85,6 +86,8 @@ Public Class IgnoredWordsAndPhrases
                     .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
                     .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
                     .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
+                    .SubItems.Add("0")
+                    .SubItems.Add(If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text"))
                     .BoolRegex = ChkRegex.Checked
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -75,6 +75,9 @@ Public Class IgnoredWordsAndPhrases
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                     .strComment = txtComment.Text
+
+                    If .dateCreated = Date.MinValue Then .dateCreated = Date.Now ' Just in case it was never set
+                    .SubItems(6).Text = Date.Now.ToLongDateString
                 End With
 
                 IgnoredListView.Enabled = True
@@ -89,11 +92,13 @@ Public Class IgnoredWordsAndPhrases
                     .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
                     .SubItems.Add("0")
                     .SubItems.Add(If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text"))
+                    .SubItems.Add(Date.Now.ToLongDateString)
                     .BoolRegex = ChkRegex.Checked
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     .strComment = txtComment.Text
+                    .dateCreated = Date.Now
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                 End With
@@ -104,6 +109,7 @@ Public Class IgnoredWordsAndPhrases
             boolEditMode = False
             boolChanged = True
             TxtIgnored.Text = Nothing
+            txtComment.Text = Nothing
             ChkCaseSensitive.Checked = False
             ChkRegex.Checked = False
             ChkEnabled.Checked = True

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -159,6 +159,7 @@ Public Class IgnoredWordsAndPhrases
         Regex.Width = My.Settings.colIgnoredRegex
         CaseSensitive.Width = My.Settings.colIgnoredCaseSensitive
         ColEnabled.Width = My.Settings.colIgnoredEnabled
+        colDateCreated.Width = My.Settings.colIgnoredDateCreated
 
         Size = My.Settings.ConfigureIgnoredSize
 
@@ -306,6 +307,7 @@ Public Class IgnoredWordsAndPhrases
             My.Settings.colIgnoredRegex = Regex.Width
             My.Settings.colIgnoredCaseSensitive = CaseSensitive.Width
             My.Settings.colIgnoredEnabled = ColEnabled.Width
+            My.Settings.colIgnoredDateCreated = colDateCreated.Width
         End If
     End Sub
 

--- a/Free SysLog/Windows/Log Viewer.Designer.vb
+++ b/Free SysLog/Windows/Log Viewer.Designer.vb
@@ -32,6 +32,7 @@ Partial Class LogViewer
         Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
         Me.txtAlertText = New System.Windows.Forms.TextBox()
         Me.IconImageBox = New System.Windows.Forms.PictureBox()
+        Me.lblAlertType = New System.Windows.Forms.ToolStripStatusLabel()
         Me.StatusStrip1.SuspendLayout()
         Me.TableLayoutPanel1.SuspendLayout()
         CType(Me.IconImageBox, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -49,7 +50,7 @@ Partial Class LogViewer
         '
         'StatusStrip1
         '
-        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblLogDate, Me.LblSource})
+        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblLogDate, Me.LblSource, Me.lblAlertType})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 239)
         Me.StatusStrip1.Name = "StatusStrip1"
         Me.StatusStrip1.Size = New System.Drawing.Size(810, 22)
@@ -150,6 +151,13 @@ Partial Class LogViewer
         Me.IconImageBox.TabIndex = 8
         Me.IconImageBox.TabStop = False
         '
+        'lblAlertType
+        '
+        Me.lblAlertType.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
+        Me.lblAlertType.Name = "lblAlertType"
+        Me.lblAlertType.Size = New System.Drawing.Size(63, 17)
+        Me.lblAlertType.Text = "Alert Type:"
+        '
         'LogViewer
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -184,4 +192,5 @@ Partial Class LogViewer
     Friend WithEvents LogText As TextBox
     Friend WithEvents txtAlertText As TextBox
     Friend WithEvents IconImageBox As PictureBox
+    Friend WithEvents lblAlertType As ToolStripStatusLabel
 End Class

--- a/Free SysLog/Windows/Log Viewer.Designer.vb
+++ b/Free SysLog/Windows/Log Viewer.Designer.vb
@@ -64,7 +64,7 @@ Partial Class LogViewer
         '
         'LblSource
         '
-        Me.LblSource.Margin = New System.Windows.Forms.Padding(100, 3, 0, 2)
+        Me.LblSource.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
         Me.LblSource.Name = "LblSource"
         Me.LblSource.Size = New System.Drawing.Size(104, 17)
         Me.LblSource.Text = "Source IP Address:"

--- a/Free SysLog/Windows/Log Viewer.Designer.vb
+++ b/Free SysLog/Windows/Log Viewer.Designer.vb
@@ -22,6 +22,7 @@ Partial Class LogViewer
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.LogText = New System.Windows.Forms.TextBox()
         Me.BtnClose = New System.Windows.Forms.Button()
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
@@ -33,6 +34,7 @@ Partial Class LogViewer
         Me.txtAlertText = New System.Windows.Forms.TextBox()
         Me.IconImageBox = New System.Windows.Forms.PictureBox()
         Me.lblAlertType = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.ToolTip1 = New System.Windows.Forms.ToolTip(Me.components)
         Me.StatusStrip1.SuspendLayout()
         Me.TableLayoutPanel1.SuspendLayout()
         CType(Me.IconImageBox, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -193,4 +195,5 @@ Partial Class LogViewer
     Friend WithEvents txtAlertText As TextBox
     Friend WithEvents IconImageBox As PictureBox
     Friend WithEvents lblAlertType As ToolStripStatusLabel
+    Friend WithEvents ToolTip1 As ToolTip
 End Class

--- a/Free SysLog/Windows/Log Viewer.Designer.vb
+++ b/Free SysLog/Windows/Log Viewer.Designer.vb
@@ -31,10 +31,10 @@ Partial Class LogViewer
         Me.ChkShowRawLog = New System.Windows.Forms.CheckBox()
         Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
         Me.txtAlertText = New System.Windows.Forms.TextBox()
-        Me.PictureBox1 = New System.Windows.Forms.PictureBox()
+        Me.IconImageBox = New System.Windows.Forms.PictureBox()
         Me.StatusStrip1.SuspendLayout()
         Me.TableLayoutPanel1.SuspendLayout()
-        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.IconImageBox, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'BtnClose
@@ -101,7 +101,7 @@ Partial Class LogViewer
         Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
         Me.TableLayoutPanel1.Controls.Add(Me.LogText, 0, 0)
         Me.TableLayoutPanel1.Controls.Add(Me.lblAlertText, 1, 1)
-        Me.TableLayoutPanel1.Controls.Add(Me.PictureBox1, 0, 2)
+        Me.TableLayoutPanel1.Controls.Add(Me.IconImageBox, 0, 2)
         Me.TableLayoutPanel1.Controls.Add(Me.txtAlertText, 1, 2)
         Me.TableLayoutPanel1.Location = New System.Drawing.Point(12, 30)
         Me.TableLayoutPanel1.Name = "TableLayoutPanel1"
@@ -139,16 +139,16 @@ Partial Class LogViewer
         Me.txtAlertText.Size = New System.Drawing.Size(702, 72)
         Me.txtAlertText.TabIndex = 7
         '
-        'PictureBox1
+        'IconImageBox
         '
-        Me.PictureBox1.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+        Me.IconImageBox.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.PictureBox1.Location = New System.Drawing.Point(3, 99)
-        Me.PictureBox1.Name = "PictureBox1"
-        Me.PictureBox1.Size = New System.Drawing.Size(72, 72)
-        Me.PictureBox1.TabIndex = 8
-        Me.PictureBox1.TabStop = False
+        Me.IconImageBox.Location = New System.Drawing.Point(3, 99)
+        Me.IconImageBox.Name = "IconImageBox"
+        Me.IconImageBox.Size = New System.Drawing.Size(72, 72)
+        Me.IconImageBox.TabIndex = 8
+        Me.IconImageBox.TabStop = False
         '
         'LogViewer
         '
@@ -169,7 +169,7 @@ Partial Class LogViewer
         Me.StatusStrip1.PerformLayout()
         Me.TableLayoutPanel1.ResumeLayout(False)
         Me.TableLayoutPanel1.PerformLayout()
-        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()
+        CType(Me.IconImageBox, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -183,5 +183,5 @@ Partial Class LogViewer
     Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
     Friend WithEvents LogText As TextBox
     Friend WithEvents txtAlertText As TextBox
-    Friend WithEvents PictureBox1 As PictureBox
+    Friend WithEvents IconImageBox As PictureBox
 End Class

--- a/Free SysLog/Windows/Log Viewer.Designer.vb
+++ b/Free SysLog/Windows/Log Viewer.Designer.vb
@@ -31,14 +31,16 @@ Partial Class LogViewer
         Me.ChkShowRawLog = New System.Windows.Forms.CheckBox()
         Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
         Me.txtAlertText = New System.Windows.Forms.TextBox()
+        Me.PictureBox1 = New System.Windows.Forms.PictureBox()
         Me.StatusStrip1.SuspendLayout()
         Me.TableLayoutPanel1.SuspendLayout()
+        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'BtnClose
         '
         Me.BtnClose.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnClose.Location = New System.Drawing.Point(713, 136)
+        Me.BtnClose.Location = New System.Drawing.Point(723, 210)
         Me.BtnClose.Name = "BtnClose"
         Me.BtnClose.Size = New System.Drawing.Size(75, 26)
         Me.BtnClose.TabIndex = 0
@@ -48,9 +50,9 @@ Partial Class LogViewer
         'StatusStrip1
         '
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblLogDate, Me.LblSource})
-        Me.StatusStrip1.Location = New System.Drawing.Point(0, 165)
+        Me.StatusStrip1.Location = New System.Drawing.Point(0, 239)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(800, 22)
+        Me.StatusStrip1.Size = New System.Drawing.Size(810, 22)
         Me.StatusStrip1.TabIndex = 4
         Me.StatusStrip1.Text = "StatusStrip1"
         '
@@ -72,9 +74,9 @@ Partial Class LogViewer
         Me.lblAlertText.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblAlertText.AutoSize = True
-        Me.lblAlertText.Location = New System.Drawing.Point(3, 41)
+        Me.lblAlertText.Location = New System.Drawing.Point(81, 78)
         Me.lblAlertText.Name = "lblAlertText"
-        Me.lblAlertText.Size = New System.Drawing.Size(52, 18)
+        Me.lblAlertText.Size = New System.Drawing.Size(39, 13)
         Me.lblAlertText.TabIndex = 6
         Me.lblAlertText.Text = "Alert Text"
         Me.lblAlertText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
@@ -94,18 +96,20 @@ Partial Class LogViewer
         Me.TableLayoutPanel1.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TableLayoutPanel1.ColumnCount = 1
+        Me.TableLayoutPanel1.ColumnCount = 2
+        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 78.0!))
         Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
         Me.TableLayoutPanel1.Controls.Add(Me.LogText, 0, 0)
-        Me.TableLayoutPanel1.Controls.Add(Me.lblAlertText, 0, 1)
-        Me.TableLayoutPanel1.Controls.Add(Me.txtAlertText, 0, 2)
+        Me.TableLayoutPanel1.Controls.Add(Me.lblAlertText, 1, 1)
+        Me.TableLayoutPanel1.Controls.Add(Me.PictureBox1, 0, 2)
+        Me.TableLayoutPanel1.Controls.Add(Me.txtAlertText, 1, 2)
         Me.TableLayoutPanel1.Location = New System.Drawing.Point(12, 30)
         Me.TableLayoutPanel1.Name = "TableLayoutPanel1"
         Me.TableLayoutPanel1.RowCount = 3
         Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
         Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 18.0!))
         Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
-        Me.TableLayoutPanel1.Size = New System.Drawing.Size(776, 100)
+        Me.TableLayoutPanel1.Size = New System.Drawing.Size(786, 174)
         Me.TableLayoutPanel1.TabIndex = 8
         '
         'LogText
@@ -114,11 +118,12 @@ Partial Class LogViewer
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.LogText.BackColor = System.Drawing.SystemColors.Window
+        Me.TableLayoutPanel1.SetColumnSpan(Me.LogText, 2)
         Me.LogText.Location = New System.Drawing.Point(3, 3)
         Me.LogText.Multiline = True
         Me.LogText.Name = "LogText"
         Me.LogText.ReadOnly = True
-        Me.LogText.Size = New System.Drawing.Size(770, 35)
+        Me.LogText.Size = New System.Drawing.Size(780, 72)
         Me.LogText.TabIndex = 2
         '
         'txtAlertText
@@ -127,18 +132,29 @@ Partial Class LogViewer
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.txtAlertText.BackColor = System.Drawing.SystemColors.Window
-        Me.txtAlertText.Location = New System.Drawing.Point(3, 62)
+        Me.txtAlertText.Location = New System.Drawing.Point(81, 99)
         Me.txtAlertText.Multiline = True
         Me.txtAlertText.Name = "txtAlertText"
         Me.txtAlertText.ReadOnly = True
-        Me.txtAlertText.Size = New System.Drawing.Size(770, 35)
+        Me.txtAlertText.Size = New System.Drawing.Size(702, 72)
         Me.txtAlertText.TabIndex = 7
+        '
+        'PictureBox1
+        '
+        Me.PictureBox1.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.PictureBox1.Location = New System.Drawing.Point(3, 99)
+        Me.PictureBox1.Name = "PictureBox1"
+        Me.PictureBox1.Size = New System.Drawing.Size(72, 72)
+        Me.PictureBox1.TabIndex = 8
+        Me.PictureBox1.TabStop = False
         '
         'LogViewer
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(800, 187)
+        Me.ClientSize = New System.Drawing.Size(810, 261)
         Me.Controls.Add(Me.TableLayoutPanel1)
         Me.Controls.Add(Me.ChkShowRawLog)
         Me.Controls.Add(Me.StatusStrip1)
@@ -146,13 +162,14 @@ Partial Class LogViewer
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(816, 226)
+        Me.MinimumSize = New System.Drawing.Size(826, 300)
         Me.Name = "LogViewer"
         Me.Text = "Log Viewer"
         Me.StatusStrip1.ResumeLayout(False)
         Me.StatusStrip1.PerformLayout()
         Me.TableLayoutPanel1.ResumeLayout(False)
         Me.TableLayoutPanel1.PerformLayout()
+        CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -166,4 +183,5 @@ Partial Class LogViewer
     Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
     Friend WithEvents LogText As TextBox
     Friend WithEvents txtAlertText As TextBox
+    Friend WithEvents PictureBox1 As PictureBox
 End Class

--- a/Free SysLog/Windows/Log Viewer.resx
+++ b/Free SysLog/Windows/Log Viewer.resx
@@ -120,4 +120,7 @@
   <metadata name="StatusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ToolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>133, 17</value>
+  </metadata>
 </root>

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -1,5 +1,8 @@
-﻿Public Class LogViewer
+﻿Imports Windows.UI.Xaml.Controls.Maps
+
+Public Class LogViewer
     Public strLogText, strRawLogText As String
+    Public alertType As AlertType = AlertType.None
     Public MyParentForm As Form1
 
     Private Sub AdjustScrollBars(ByRef textBoxControl As TextBox)
@@ -37,9 +40,20 @@
         If String.IsNullOrWhiteSpace(txtAlertText.Text) Then
             txtAlertText.Visible = False
             lblAlertText.Visible = False
+            PictureBox1.Visible = False
             TableLayoutPanel1.SetRowSpan(LogText, 3)
         Else
             AdjustScrollBars(txtAlertText)
+
+            If alertType <> AlertType.None Then
+                If alertType = ToolTipIcon.Error Then
+                    PictureBox1.Image = Image.FromFile(IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png"))
+                ElseIf alertType = ToolTipIcon.Warning Then
+                    PictureBox1.Image = Image.FromFile(IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png"))
+                ElseIf alertType = ToolTipIcon.Info Then
+                    PictureBox1.Image = Image.FromFile(IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png"))
+                End If
+            End If
         End If
 
         AdjustScrollBars(LogText)

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -40,7 +40,7 @@ Public Class LogViewer
         If String.IsNullOrWhiteSpace(txtAlertText.Text) Then
             txtAlertText.Visible = False
             lblAlertText.Visible = False
-            PictureBox1.Visible = False
+            IconImageBox.Visible = False
             TableLayoutPanel1.SetRowSpan(LogText, 3)
         Else
             AdjustScrollBars(txtAlertText)
@@ -56,7 +56,7 @@ Public Class LogViewer
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
                 End If
 
-                If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then PictureBox1.Image = Image.FromFile(strIconPath)
+                If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then IconImageBox.Image = Image.FromFile(strIconPath)
             End If
         End If
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -65,12 +65,15 @@ Public Class LogViewer
                 If alertType = ToolTipIcon.Error Then
                     lblAlertType.Text = "Alert Type: Error"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png")
+                    ToolTip1.SetToolTip(IconImageBox, "Error alert type is used for critical issues." & vbCrLf & "It indicates a serious problem that needs immediate attention.")
                 ElseIf alertType = ToolTipIcon.Warning Then
                     lblAlertType.Text = "Alert Type: Warning"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png")
+                    ToolTip1.SetToolTip(IconImageBox, "Warning alert type is used for non-critical issues." & vbCrLf & "It indicates a potential problem that may need attention.")
                 ElseIf alertType = ToolTipIcon.Info Then
                     lblAlertType.Text = "Alert Type: Information"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
+                    ToolTip1.SetToolTip(IconImageBox, "Information alert type is used for general information alerts." & vbCrLf & "It does not indicate any problem.")
                 End If
 
                 If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -26,6 +26,16 @@ Public Class LogViewer
         End If
     End Sub
 
+    Private Sub HideTheImageBox()
+        TableLayoutPanel1.Controls.Remove(lblAlertText)
+        TableLayoutPanel1.Controls.Add(lblAlertText, 0, 1)
+
+        TableLayoutPanel1.Controls.Remove(txtAlertText)
+        TableLayoutPanel1.Controls.Add(txtAlertText, 0, 2)
+
+        TableLayoutPanel1.SetColumnSpan(txtAlertText, 2)
+    End Sub
+
     Private Sub Log_Viewer_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If My.Settings.font IsNot Nothing Then
             LogText.Font = My.Settings.font
@@ -46,13 +56,7 @@ Public Class LogViewer
             AdjustScrollBars(txtAlertText)
 
             If alertType = AlertType.None Then
-                TableLayoutPanel1.Controls.Remove(lblAlertText)
-                TableLayoutPanel1.Controls.Add(lblAlertText, 0, 1)
-
-                TableLayoutPanel1.Controls.Remove(txtAlertText)
-                TableLayoutPanel1.Controls.Add(txtAlertText, 0, 2)
-
-                TableLayoutPanel1.SetColumnSpan(txtAlertText, 2)
+                HideTheImageBox()
             Else
                 Dim strIconPath As String = Nothing
 
@@ -64,7 +68,11 @@ Public Class LogViewer
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
                 End If
 
-                If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then IconImageBox.Image = Image.FromFile(strIconPath)
+                If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then
+                    IconImageBox.Image = Image.FromFile(strIconPath)
+                Else
+                    HideTheImageBox()
+                End If
             End If
         End If
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -34,6 +34,8 @@ Public Class LogViewer
         TableLayoutPanel1.Controls.Add(txtAlertText, 0, 2)
 
         TableLayoutPanel1.SetColumnSpan(txtAlertText, 2)
+
+        lblAlertType.Visible = False
     End Sub
 
     Private Sub Log_Viewer_Load(sender As Object, e As EventArgs) Handles MyBase.Load
@@ -61,10 +63,13 @@ Public Class LogViewer
                 Dim strIconPath As String = Nothing
 
                 If alertType = ToolTipIcon.Error Then
+                    lblAlertType.Text = "Alert Type: Error"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png")
                 ElseIf alertType = ToolTipIcon.Warning Then
+                    lblAlertType.Text = "Alert Type: Warning"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png")
                 ElseIf alertType = ToolTipIcon.Info Then
+                    lblAlertType.Text = "Alert Type: Information"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
                 End If
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -46,13 +46,17 @@ Public Class LogViewer
             AdjustScrollBars(txtAlertText)
 
             If alertType <> AlertType.None Then
+                Dim strIconPath As String = Nothing
+
                 If alertType = ToolTipIcon.Error Then
-                    PictureBox1.Image = Image.FromFile(IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png"))
+                    strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png")
                 ElseIf alertType = ToolTipIcon.Warning Then
-                    PictureBox1.Image = Image.FromFile(IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png"))
+                    strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png")
                 ElseIf alertType = ToolTipIcon.Info Then
-                    PictureBox1.Image = Image.FromFile(IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png"))
+                    strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
                 End If
+
+                If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then PictureBox1.Image = Image.FromFile(strIconPath)
             End If
         End If
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -45,7 +45,15 @@ Public Class LogViewer
         Else
             AdjustScrollBars(txtAlertText)
 
-            If alertType <> AlertType.None Then
+            If alertType = AlertType.None Then
+                TableLayoutPanel1.Controls.Remove(lblAlertText)
+                TableLayoutPanel1.Controls.Add(lblAlertText, 0, 1)
+
+                TableLayoutPanel1.Controls.Remove(txtAlertText)
+                TableLayoutPanel1.Controls.Add(txtAlertText, 0, 2)
+
+                TableLayoutPanel1.SetColumnSpan(txtAlertText, 2)
+            Else
                 Dim strIconPath As String = Nothing
 
                 If alertType = ToolTipIcon.Error Then

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -116,7 +116,7 @@ Public Class ViewLogBackups
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        .Cells(3).Value = $"{intCount:N0}"
-                                                       .Cells(3).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
+                                                       .Cells(3).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
                                                        .Cells(4).Value = If(boolIsHidden, "Yes", "No")
                                                        .Cells(4).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
@@ -161,7 +161,18 @@ Public Class ViewLogBackups
                End Sub)
     End Sub
 
+    Private Sub DataGridView1_CellPainting(sender As Object, e As DataGridViewCellPaintingEventArgs) Handles FileList.CellPainting
+        If e.RowIndex = -1 AndAlso (e.ColumnIndex = colHidden.Index Or e.ColumnIndex = colEntryCount.Index) Then
+            e.PaintBackground(e.CellBounds, False)
+            TextRenderer.DrawText(e.Graphics, e.FormattedValue.ToString(), e.CellStyle.Font, e.CellBounds, e.CellStyle.ForeColor, TextFormatFlags.HorizontalCenter Or TextFormatFlags.VerticalCenter)
+            e.Handled = True
+        End If
+    End Sub
+
     Private Sub ViewLogBackups_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        colHidden.HeaderCell.Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+        colEntryCount.HeaderCell.Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+
         ChkIgnoreSearchResultsLimits.Checked = My.Settings.IgnoreSearchResultLimits
         Dim flags As Reflection.BindingFlags = Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance Or Reflection.BindingFlags.SetProperty
         Dim propInfo As Reflection.PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -300,6 +300,9 @@
             <setting name="saveIgnoredLogCount" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="colIgnoredDateCreated" serializeAs="String">
+                <value>180</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Added a call to clear the contents of IgnoredHits when zeroing out the NumberOfIgnoredLogs.
- Added the ability to show the alert type as an image on the "Log Viewer" window.
- Added some code to the "Log Viewer" window to hide the image box if the alert type is somehow not one of the predetermined types. This normally shouldn't happen, but hey... let's account for it in the code.
- Made it so that the image box is hidden if the alert type images can't be found in the file system. Again, this shouldn't happen but hey... let's code for the possibility.
- Made some column header text centered in the file list on the "View Log Backups" window.
- Shrank the margins on the labels on the bottom of the "Log Viewer" window.
- Added a label to the bottom of the "Log Viewer" window to indicate the alert type.
- Added the ability to copy multiple logs to the Windows clipboard.
- Added a tooltip to the "Log Viewer" window.
- Fixed editing and adding new entries on the "Ignored Words and Phrases".
- Added a "Reset Hits" button to the "Ignored Words and Phrases" window.
- Added code to check to see if copying to the Windows Clipboard worked before giving a confirmation message box.
- Added the ability to delete logs using checkboxes on the main window.
- Added date created and a place to put a comment for a log ignored rule on the "Ignored Words and Phrases" window.
- Fixed tabs on the "Close Free SysLog" dialog box.
- Fixed a bug on the Alerts window where the ListView background color wasn't being set when adding a new alert type.
- Fixed a bug on the main window in which the "Save Log" function in the menu wasn't enabled after deleting logs.

And a whole lot of other under the hood changes to the code.