### PR TITLE
Version 4.6 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.5.1.103")>
+<Assembly: AssemblyFileVersion("4.6.1.104")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1256,6 +1256,18 @@ Namespace My
                 Me("colIgnoredDateCreated") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property ShowCloseButtonOnNotifications() As Boolean
+            Get
+                Return CType(Me("ShowCloseButtonOnNotifications"),Boolean)
+            End Get
+            Set
+                Me("ShowCloseButtonOnNotifications") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -305,5 +305,8 @@
     <Setting Name="colIgnoredDateCreated" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">180</Value>
     </Setting>
+    <Setting Name="ShowCloseButtonOnNotifications" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/MyDataGridViewRow.vb
+++ b/Free SysLog/Support Code/MyDataGridViewRow.vb
@@ -9,6 +9,18 @@
     Public Property alertType As AlertType
     Public Property IgnoredPattern As String
 
+    Public Sub UncheckRow()
+        Me.Cells("colDelete").Value = False
+    End Sub
+
+    Public Sub CheckRow()
+        Me.Cells("colDelete").Value = True
+    End Sub
+
+    Public Sub InvertRowCheckboxStatus()
+        Me.Cells("colDelete").Value = Not Me.Cells("colDelete").Value
+    End Sub
+
     Public Overrides Function Clone()
         Dim newDataGridRow As New MyDataGridViewRow()
         newDataGridRow.CreateCells(Me.DataGridView)

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -99,14 +99,36 @@ Namespace checkForUpdates
         End Function
 
         Private Function CanWriteToFolder(folderPath As String) As Boolean
-            Try
-                Dim testFile As String = IO.Path.Combine(folderPath, Guid.NewGuid().ToString() & ".tmp")
-                File.WriteAllText(testFile, "test")
-                File.Delete(testFile)
-                Return True
-            Catch
+            ' Checks to see if the specified folder exists.
+            If Directory.Exists(folderPath) Then
+                Dim strTestFilePath As String = Nothing
+
+                Try
+                    ' Create the path for the temporary file
+                    strTestFilePath = Path.Combine(folderPath, Guid.NewGuid().ToString() & ".tmp")
+
+                    ' Try writing a test message to the file
+                    File.WriteAllText(strTestFilePath, "test")
+
+                    ' If writing succeeds, return true
+                    Return True
+                Catch ex As Exception
+                    ' Something went wrong, we return false.
+                    Return False
+                Finally
+                    ' Ensure the temporary file is deleted if it was created
+                    If Not String.IsNullOrWhiteSpace(strTestFilePath) AndAlso File.Exists(strTestFilePath) Then
+                        Try
+                            File.Delete(strTestFilePath) ' Delete it.
+                        Catch ex As Exception
+                            ' Handle any exceptions that occur during file deletion.
+                        End Try
+                    End If
+                End Try
+            Else
+                ' The directory doesn't exist, so we return false.
                 Return False
-            End Try
+            End If
         End Function
 
         Public Shared Function CreateNewHTTPHelperObject() As HttpHelper

--- a/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
+++ b/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
@@ -32,9 +32,67 @@ Namespace NativeMethod
         <DllImport("user32.dll")>
         Public Shared Function SetForegroundWindow(hwnd As IntPtr) As Boolean
         End Function
+
+        <DllImport("iphlpapi.dll", SetLastError:=True)>
+        Public Shared Function GetExtendedTcpTable(pTcpTable As IntPtr, ByRef dwOutBufLen As Integer, sort As Boolean, ipVersion As Integer, tblClass As TCP_TABLE_CLASS, reserved As Integer) As UInteger
+        End Function
+
+        <DllImport("iphlpapi.dll", SetLastError:=True)>
+        Public Shared Function GetExtendedUdpTable(pUdpTable As IntPtr, ByRef dwOutBufLen As Integer, sort As Boolean, ipVersion As Integer, tableClass As UDP_TABLE_CLASS, reserved As Integer) As UInteger
+        End Function
     End Class
 
     Module APIs
+        Public Enum UDP_TABLE_CLASS
+            UDP_TABLE_BASIC
+            UDP_TABLE_OWNER_PID
+            UDP_TABLE_OWNER_MODULE
+        End Enum
+
+        <StructLayout(LayoutKind.Sequential)>
+        Public Structure MIB_UDPROW_OWNER_PID
+            Public localAddr As UInteger
+            Public localPort As UInteger
+            Public owningPid As UInteger
+        End Structure
+
+        Public Enum MIB_TCP_STATE
+            CLOSED = 1
+            LISTENING = 2
+            SYN_SENT = 3
+            SYN_RCVD = 4
+            ESTABLISHED = 5
+            FIN_WAIT1 = 6
+            FIN_WAIT2 = 7
+            CLOSE_WAIT = 8
+            CLOSING = 9
+            LAST_ACK = 10
+            TIME_WAIT = 11
+            DELETE_TCB = 12
+        End Enum
+
+        <StructLayout(LayoutKind.Sequential)>
+        Public Structure MIB_TCPROW_OWNER_PID
+            Public state As UInteger
+            Public localAddr As UInteger
+            Public localPort As UInteger
+            Public remoteAddr As UInteger
+            Public remotePort As UInteger
+            Public owningPid As UInteger
+        End Structure
+
+        Public Enum TCP_TABLE_CLASS
+            TCP_TABLE_BASIC_LISTENER
+            TCP_TABLE_BASIC_CONNECTIONS
+            TCP_TABLE_BASIC_ALL
+            TCP_TABLE_OWNER_PID_LISTENER
+            TCP_TABLE_OWNER_PID_CONNECTIONS
+            TCP_TABLE_OWNER_PID_ALL
+            TCP_TABLE_OWNER_MODULE_LISTENER
+            TCP_TABLE_OWNER_MODULE_CONNECTIONS
+            TCP_TABLE_OWNER_MODULE_ALL
+        End Enum
+
         <Flags>
         Public Enum ProcessAccessFlags As UInteger
             PROCESS_QUERY_LIMITED_INFORMATION = &H1000

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -46,11 +46,11 @@ Namespace SupportCode
     Module SupportCode
         Public ParentForm As Form1
 
-        Public AlertsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public AlertsRegexCache As New Dictionary(Of String, Regex)
         Public AlertsRegexCacheLockingObject As New Object
-        Public ReplacementsRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public ReplacementsRegexCache As New Dictionary(Of String, Regex)
         Public ReplacementsRegexCacheLockingObject As New Object
-        Public IgnoredRegexCache As New Dictionary(Of String, RegularExpressions.Regex)
+        Public IgnoredRegexCache As New Dictionary(Of String, Regex)
         Public IgnoredRegexCacheLockingObject As New Object()
         Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
 
@@ -366,7 +366,7 @@ Namespace SupportCode
 
         Public Function IsRegexPatternValid(pattern As String) As Boolean
             Try
-                Dim regex As New RegularExpressions.Regex(pattern)
+                Dim regex As New Regex(pattern)
                 Return True
             Catch ex As ArgumentException
                 Return False

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -200,8 +200,6 @@ Namespace SupportCode
             Dim highAsIs As Integer = high16
             Dim highSwapped As Integer = Swap16(high16)
 
-            Debug.WriteLine($"raw port = {port} ({rawHex}) | low16={low16} lowSwapped={lowSwapped} high16={high16} highSwapped={highSwapped}")
-
             ' Heuristic priority (keeps your original ordering intent):
             ' 1) If high16 != 0 => prefer highSwapped, then highAsIs
             ' 2) Else prefer lowAsIs (if nonzero & plausible)
@@ -209,21 +207,17 @@ Namespace SupportCode
             ' 4) Fallback: any plausible candidate in a consistent order
             If high16 <> 0 Then
                 If IsPlausiblePort(highSwapped) Then
-                    Debug.WriteLine($"-> chosen: highSwapped = {highSwapped}")
                     Return highSwapped
                 ElseIf IsPlausiblePort(highAsIs) Then
-                    Debug.WriteLine($"-> chosen: highAsIs = {highAsIs}")
                     Return highAsIs
                 End If
             End If
 
             If lowAsIs <> 0 AndAlso IsPlausiblePort(lowAsIs) Then
-                Debug.WriteLine($"-> chosen: lowAsIs = {lowAsIs}")
                 Return lowAsIs
             End If
 
             If lowSwapped <> 0 AndAlso IsPlausiblePort(lowSwapped) Then
-                Debug.WriteLine($"-> chosen: lowSwapped = {lowSwapped}")
                 Return lowSwapped
             End If
 
@@ -235,7 +229,6 @@ Namespace SupportCode
                 End If
             Next
 
-            Debug.WriteLine("-> no plausible port found, returning 0")
             Return 0
         End Function
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -169,9 +169,9 @@ Namespace SupportCode
         ''' </summary>
         Private Function Swap16(value As UShort) As UShort
             ' Do the shifts in an unsigned 32-bit space then mask down to 16 bits.
-            Dim widened As UInteger = CUInt(value)
+            Dim widened As UInteger = value
             Dim swapped As UInteger = ((widened << 8) Or (widened >> 8)) And &HFFFFUI
-            Return CUShort(swapped)
+            Return swapped
         End Function
 
         ''' <summary>
@@ -191,14 +191,14 @@ Namespace SupportCode
             Dim rawHex As String = "0x" & port.ToString("X8")
 
             ' extract 16-bit halves
-            Dim low16 As UShort = CUShort(port And &HFFFFUI)
-            Dim high16 As UShort = CUShort((port >> 16) And &HFFFFUI)
+            Dim low16 As UShort = port And &HFFFFUI
+            Dim high16 As UShort = (port >> 16) And &HFFFFUI
 
             ' possible decodings (as integers for IsPlausiblePort)
-            Dim lowAsIs As Integer = CInt(low16)
-            Dim lowSwapped As Integer = CInt(Swap16(low16))
-            Dim highAsIs As Integer = CInt(high16)
-            Dim highSwapped As Integer = CInt(Swap16(high16))
+            Dim lowAsIs As Integer = low16
+            Dim lowSwapped As Integer = Swap16(low16)
+            Dim highAsIs As Integer = high16
+            Dim highSwapped As Integer = Swap16(high16)
 
             Debug.WriteLine($"raw port = {port} ({rawHex}) | low16={low16} lowSwapped={lowSwapped} high16={high16} highSwapped={highSwapped}")
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -241,7 +241,7 @@ Namespace SupportCode
 
                 notification.AddButton(New ToastButton().SetContent("View Log").AddArgument("action", strViewLog).AddArgument("datapacket", strNotificationPacket))
                 notification.AddButton(New ToastButton().SetContent("Open SysLog").AddArgument("action", strOpenSysLog))
-                notification.AddButton(New ToastButton().SetContent("Close").SetDismissActivation())
+                If My.Settings.ShowCloseButtonOnNotifications Then notification.AddButton(New ToastButton().SetContent("Close").SetDismissActivation())
             Else
                 notification.AddArgument("action", strOpenSysLog)
             End If

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -241,6 +241,7 @@ Namespace SupportCode
 
                 notification.AddButton(New ToastButton().SetContent("View Log").AddArgument("action", strViewLog).AddArgument("datapacket", strNotificationPacket))
                 notification.AddButton(New ToastButton().SetContent("Open SysLog").AddArgument("action", strOpenSysLog))
+                notification.AddButton(New ToastButton().SetContent("Close").SetDismissActivation())
             Else
                 notification.AddArgument("action", strOpenSysLog)
             End If

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -232,8 +232,8 @@ Namespace SupportCode
             Return 0
         End Function
 
-        Public Function GetProcessByUdpPort(port As Integer) As Process
-            Dim AF_INET As Integer = 2 ' IPv4
+        Public Function GetProcessByUdpPort(port As Integer, protocolType As AddressFamily) As Process
+            Dim AF_INET As Integer = protocolType
             Dim bufferSize As Integer = 0
 
             ' Initial call to get required buffer size
@@ -263,8 +263,8 @@ Namespace SupportCode
             Return Nothing
         End Function
 
-        Public Function GetProcessByTcpPort(port As Integer) As Process
-            Dim AF_INET As Integer = 2 ' IPv4
+        Public Function GetProcessByTcpPort(port As Integer, protocolType As AddressFamily) As Process
+            Dim AF_INET As Integer = protocolType
             Dim bufferSize As Integer = 0
 
             ' First call to determine required buffer size

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -186,7 +186,7 @@ Namespace SupportCode
         ''' either the low 16 bits or high 16 bits, and each 16-bit word may itself
         ''' be in host or swapped byte order. Uses a small heuristic to choose the best candidate.
         ''' </summary>
-        Public Function GetPortFromDWORD(port As UInteger) As Integer
+        Private Function GetPortFromDWORD(port As UInteger) As Integer
             ' helpful debug hex
             Dim rawHex As String = "0x" & port.ToString("X8")
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -232,7 +232,7 @@ Namespace SupportCode
             Return 0
         End Function
 
-        Public Function GetProcessByUdpPort(port As Integer, protocolType As AddressFamily) As Process
+        Private Function GetProcessByUdpPort(port As Integer, protocolType As AddressFamily) As Process
             Dim AF_INET As Integer = protocolType
             Dim bufferSize As Integer = 0
 
@@ -263,7 +263,7 @@ Namespace SupportCode
             Return Nothing
         End Function
 
-        Public Function GetProcessByTcpPort(port As Integer, protocolType As AddressFamily) As Process
+        Private Function GetProcessByTcpPort(port As Integer, protocolType As AddressFamily) As Process
             Dim AF_INET As Integer = protocolType
             Dim bufferSize As Integer = 0
 
@@ -292,6 +292,27 @@ Namespace SupportCode
             End Try
 
             Return Nothing
+        End Function
+
+        Public Function GetProcessByPort(protocolType As ProtocolType) As Process
+            Dim processIPv4 As Process = Nothing
+            Dim processIPv6 As Process = Nothing
+
+            If protocolType = ProtocolType.Tcp Then
+                processIPv4 = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
+                processIPv6 = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
+            ElseIf protocolType = ProtocolType.Udp Then
+                processIPv4 = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
+                processIPv6 = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
+            End If
+
+            If processIPv4 IsNot Nothing Then
+                Return processIPv4
+            ElseIf processIPv6 IsNot Nothing Then
+                Return processIPv6
+            Else
+                Return Nothing
+            End If
         End Function
 
         Public Sub ShowToastNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -41,7 +41,7 @@ Namespace SyslogTcpServer
                 If activeProcess Is Nothing Then
                     _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)
                 Else
-                    Dim strLogText As String = $"Unable to start syslog server. A process with a PID of {activeProcess.Id} already has the port open."
+                    Dim strLogText As String = $"Unable to start syslog TCP server. A process with a PID of {activeProcess.Id} already has the TCP port open."
                     _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}{vbCrLf}{vbCrLf}{strLogText}", IPAddress.Loopback.ToString)
                 End If
             End Try

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -36,7 +36,7 @@ Namespace SyslogTcpServer
                     Await HandleClientAsync(tcpClient)
                 End While
             Catch ex As Exception
-                Dim process As Process = GetProcessUsingPort(My.Settings.sysLogPort, ProtocolType.Tcp)
+                Dim process As Process = GetProcessByTcpPort(My.Settings.sysLogPort)
 
                 If process Is Nothing Then
                     _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -36,15 +36,7 @@ Namespace SyslogTcpServer
                     Await HandleClientAsync(tcpClient)
                 End While
             Catch ex As Exception
-                Dim processIPv4 As Process = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
-                Dim processIPv6 As Process = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
-                Dim activeProcess As Process = Nothing
-
-                If processIPv4 IsNot Nothing Then
-                    activeProcess = processIPv4
-                ElseIf processIPv6 IsNot Nothing Then
-                    activeProcess = processIPv6
-                End If
+                Dim activeProcess As Process = GetProcessByPort(ProtocolType.Tcp)
 
                 If activeProcess Is Nothing Then
                     _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -39,10 +39,9 @@ Namespace SyslogTcpServer
                 Dim activeProcess As Process = GetProcessByPort(ProtocolType.Tcp)
 
                 If activeProcess Is Nothing Then
-                    _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)
+                    ParentForm.Logs.Invoke(Sub() ParentForm.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", ParentForm.Logs)))
                 Else
-                    Dim strLogText As String = $"Unable to start syslog TCP server. A process with a PID of {activeProcess.Id} already has the TCP port open."
-                    _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}{vbCrLf}{vbCrLf}{strLogText}", IPAddress.Loopback.ToString)
+                    ParentForm.Logs.Invoke(Sub() ParentForm.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Unable to start syslog TCP server. A process with a PID of {activeProcess.Id} already has the TCP port open.", ParentForm.Logs)))
                 End If
             End Try
         End Function

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -36,12 +36,20 @@ Namespace SyslogTcpServer
                     Await HandleClientAsync(tcpClient)
                 End While
             Catch ex As Exception
-                Dim process As Process = GetProcessByTcpPort(My.Settings.sysLogPort)
+                Dim processIPv4 As Process = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
+                Dim processIPv6 As Process = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
+                Dim activeProcess As Process = Nothing
 
-                If process Is Nothing Then
+                If processIPv4 IsNot Nothing Then
+                    activeProcess = processIPv4
+                ElseIf processIPv6 IsNot Nothing Then
+                    activeProcess = processIPv6
+                End If
+
+                If activeProcess Is Nothing Then
                     _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", IPAddress.Loopback.ToString)
                 Else
-                    Dim strLogText As String = $"Unable to start syslog server. A process with a PID of {process.Id} already has the port open."
+                    Dim strLogText As String = $"Unable to start syslog server. A process with a PID of {activeProcess.Id} already has the port open."
                     _syslogMessageHandler($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}{vbCrLf}{vbCrLf}{strLogText}", IPAddress.Loopback.ToString)
                 End If
             End Try

--- a/Free SysLog/Support Code/Namespace Code/Task Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Task Handling.vb
@@ -99,20 +99,12 @@ Namespace TaskHandling
         End Sub
 
         Public Sub ConvertRegistryRunCommandToTask()
-            Dim boolDoesRegistryStartupKeyExist As Boolean = False
-
-            Using registryKey As RegistryKey = Registry.CurrentUser.OpenSubKey("Software\Microsoft\Windows\CurrentVersion\Run", False)
-                If registryKey.GetValue("Free Syslog") IsNot Nothing Then
-                    boolDoesRegistryStartupKeyExist = True
-                    CreateTask()
+            Using registryKey As RegistryKey = Registry.CurrentUser.OpenSubKey("Software\Microsoft\Windows\CurrentVersion\Run", True) ' Opens the registry key with write access.
+                If registryKey.GetValue("Free Syslog") IsNot Nothing Then ' Check if the "Free Syslog" key exists
+                    CreateTask() ' Create the task if the registry value exists
+                    registryKey.DeleteValue("Free Syslog", False) ' Delete the registry value
                 End If
             End Using
-
-            If boolDoesRegistryStartupKeyExist Then
-                Using registryKey As RegistryKey = Registry.CurrentUser.OpenSubKey("Software\Microsoft\Windows\CurrentVersion\Run", True)
-                    registryKey.DeleteValue("Free Syslog")
-                End Using
-            End If
         End Sub
     End Module
 End Namespace

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -113,6 +113,7 @@ Partial Class Form1
         Me.ProcessReplacementsInSyslogDataFirst = New System.Windows.Forms.ToolStripMenuItem()
         Me.RemoveNumbersFromRemoteApp = New System.Windows.Forms.ToolStripMenuItem()
         Me.ShowRawLogOnLogViewer = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ShowCloseButtonOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
         Me.SaveIgnoredLogCount = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkShowLogTypeColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkShowServerTimeColumn = New System.Windows.Forms.ToolStripMenuItem()
@@ -472,7 +473,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -882,6 +883,13 @@ Partial Class Form1
         Me.ProcessReplacementsInSyslogDataFirst.Size = New System.Drawing.Size(319, 22)
         Me.ProcessReplacementsInSyslogDataFirst.Text = "Process Replacements in Syslog Data First"
         '
+        'ShowCloseButtonOnNotifications
+        '
+        Me.ShowCloseButtonOnNotifications.CheckOnClick = True
+        Me.ShowCloseButtonOnNotifications.Name = "ShowCloseButtonOnNotifications"
+        Me.ShowCloseButtonOnNotifications.Size = New System.Drawing.Size(319, 22)
+        Me.ShowCloseButtonOnNotifications.Text = "Show Close Button on Notifications"
+        '
         'ShowRawLogOnLogViewer
         '
         Me.ShowRawLogOnLogViewer.CheckOnClick = True
@@ -1114,6 +1122,7 @@ Partial Class Form1
     Friend WithEvents ProcessReplacementsInSyslogDataFirst As ToolStripMenuItem
     Friend WithEvents RemoveNumbersFromRemoteApp As ToolStripMenuItem
     Friend WithEvents ShowRawLogOnLogViewer As ToolStripMenuItem
+    Friend WithEvents ShowCloseButtonOnNotifications As ToolStripMenuItem
     Friend WithEvents SaveIgnoredLogCount As ToolStripMenuItem
     Friend WithEvents ChkShowLogTypeColumn As ToolStripMenuItem
     Friend WithEvents ChkShowServerTimeColumn As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -727,6 +727,15 @@ Public Class Form1
                 Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
                 Dim intNumberOfSelectedLogs As Integer = Logs.SelectedRows.Count
 
+                If intNumberOfCheckedLogs <> intNumberOfSelectedLogs AndAlso MsgBox("The checked logs does not match the selected logs, do you want to make the checked logs match the selected logs?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
+                    For Each item As MyDataGridViewRow In Logs.SelectedRows
+                        item.Cells(colDelete.Index).Value = True
+                    Next
+
+                    intNumberOfCheckedLogs = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
+                    intNumberOfSelectedLogs = Logs.SelectedRows.Count
+                End If
+
                 If ConfirmDelete.Checked Then
                     Dim choice As Confirm_Delete.UserChoice
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -179,7 +179,7 @@ Public Class Form1
                     Logs.ClearSelection()
 
                     For Each item As MyDataGridViewRow In Logs.Rows
-                        item.Cells(colDelete.Index).Value = False
+                        item.UncheckRow()
                     Next
 
                     LblItemsSelected.Visible = False
@@ -735,7 +735,7 @@ Public Class Form1
 
                 If intNumberOfCheckedLogs <> 0 And intNumberOfCheckedLogs <> 1 And intNumberOfSelectedLogs <> 0 And intNumberOfSelectedLogs <> 1 AndAlso intNumberOfCheckedLogs <> intNumberOfSelectedLogs AndAlso MsgBox("The checked logs does not match the selected logs, do you want to make the checked logs match the selected logs?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
                     For Each item As MyDataGridViewRow In Logs.SelectedRows
-                        item.Cells(colDelete.Index).Value = True
+                        item.CheckRow()
                     Next
 
                     intNumberOfCheckedLogs = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
@@ -804,10 +804,10 @@ Public Class Form1
             If Logs.SelectedCells.Count > 0 Then
                 If Logs.SelectedCells.Count = 1 Then
                     Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
-                    selectedRow.Cells(colDelete.Index).Value = Not selectedRow.Cells(colDelete.Index).Value
+                    selectedRow.InvertRowCheckboxStatus()
                 Else
                     For Each item As MyDataGridViewRow In Logs.SelectedRows
-                        item.Cells(colDelete.Index).Value = Not item.Cells(colDelete.Index).Value
+                        item.InvertRowCheckboxStatus()
                     Next
                 End If
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -727,7 +727,7 @@ Public Class Form1
                 Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
                 Dim intNumberOfSelectedLogs As Integer = Logs.SelectedRows.Count
 
-                If intNumberOfCheckedLogs <> 0 And intNumberOfSelectedLogs <> 0 AndAlso intNumberOfCheckedLogs <> intNumberOfSelectedLogs AndAlso MsgBox("The checked logs does not match the selected logs, do you want to make the checked logs match the selected logs?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
+                If intNumberOfCheckedLogs <> 0 And intNumberOfCheckedLogs <> 1 And intNumberOfSelectedLogs <> 0 And intNumberOfSelectedLogs <> 1 AndAlso intNumberOfCheckedLogs <> intNumberOfSelectedLogs AndAlso MsgBox("The checked logs does not match the selected logs, do you want to make the checked logs match the selected logs?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
                     For Each item As MyDataGridViewRow In Logs.SelectedRows
                         item.Cells(colDelete.Index).Value = True
                     Next

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -544,15 +544,7 @@ Public Class Form1
 
             boolServerRunning = True
         Else
-            Dim processIPv4 As Process = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
-            Dim processIPv6 As Process = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
-            Dim activeProcess As Process = Nothing
-
-            If processIPv4 IsNot Nothing Then
-                activeProcess = processIPv4
-            ElseIf processIPv6 IsNot Nothing Then
-                activeProcess = processIPv6
-            End If
+            Dim activeProcess As Process = GetProcessByPort(ProtocolType.Udp)
 
             If activeProcess Is Nothing Then
                 MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
@@ -2175,15 +2167,7 @@ Public Class Form1
             ' Does nothing
         Catch e As Exception
             Invoke(Sub()
-                       Dim processIPv4 As Process = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
-                       Dim processIPv6 As Process = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
-                       Dim activeProcess As Process = Nothing
-
-                       If processIPv4 IsNot Nothing Then
-                           activeProcess = processIPv4
-                       ElseIf processIPv6 IsNot Nothing Then
-                           activeProcess = processIPv6
-                       End If
+                       Dim activeProcess As Process = GetProcessByPort(ProtocolType.Udp)
 
                        If activeProcess Is Nothing Then
                            MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -549,7 +549,7 @@ Public Class Form1
             If activeProcess Is Nothing Then
                 MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
             Else
-                Dim strLogText As String = $"Unable to start syslog server. A process with a PID of {activeProcess.Id} already has the port open."
+                Dim strLogText As String = $"Unable to start UDP syslog server. A process with a PID of {activeProcess.Id} already has the UDP port open."
 
                 SyncLock dataGridLockObject
                     Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry(strLogText, Logs))
@@ -2172,7 +2172,7 @@ Public Class Form1
                        If activeProcess Is Nothing Then
                            MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
                        Else
-                           Dim strLogText As String = $"Unable to start syslog server. A process with a PID of {activeProcess.Id} already has the port open."
+                           Dim strLogText As String = $"Unable to start UDP syslog server. A process with a PID of {activeProcess.Id} already has the UDP port open."
 
                            SyncLock dataGridLockObject
                                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {e.GetType}{vbCrLf}Exception Message: {e.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{e.StackTrace}", Logs))

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -274,6 +274,7 @@ Public Class Form1
         ChkDebug.Checked = My.Settings.boolDebug
         ConfirmDelete.Checked = My.Settings.ConfirmDelete
         ProcessReplacementsInSyslogDataFirst.Checked = My.Settings.ProcessReplacementsInSyslogDataFirst
+        ShowCloseButtonOnNotifications.Checked = My.Settings.ShowCloseButtonOnNotifications
     End Sub
 
     Private Sub LoadAndDeserializeArrays()
@@ -2089,6 +2090,10 @@ Public Class Form1
 
             If boolCopyToClipboardResults Then MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
         End If
+    End Sub
+
+    Private Sub ShowCloseButtonOnNotifications_Click(sender As Object, e As EventArgs) Handles ShowCloseButtonOnNotifications.Click
+        My.Settings.ShowCloseButtonOnNotifications = ShowCloseButtonOnNotifications.Checked
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -2111,11 +2111,13 @@ Public Class Form1
                 Dim buffer(4095) As Byte
                 Dim remoteEndPoint As EndPoint = New IPEndPoint(ipAddressSetting, 0)
                 Dim ProxiedSysLogData As ProxiedSysLogData
+                Dim bytesReceived As Integer
+                Dim strReceivedData, strSourceIP As String
 
                 While boolDoServerLoop
-                    Dim bytesReceived As Integer = socket.ReceiveFrom(buffer, remoteEndPoint)
-                    Dim strReceivedData As String = Encoding.UTF8.GetString(buffer, 0, bytesReceived)
-                    Dim strSourceIP As String = GetIPv4Address(CType(remoteEndPoint, IPEndPoint).Address).ToString()
+                    bytesReceived = socket.ReceiveFrom(buffer, remoteEndPoint)
+                    strReceivedData = Encoding.UTF8.GetString(buffer, 0, bytesReceived)
+                    strSourceIP = GetIPv4Address(CType(remoteEndPoint, IPEndPoint).Address).ToString()
 
                     If strReceivedData.Trim.Equals(strRestore, StringComparison.OrdinalIgnoreCase) Then
                         Invoke(Sub() RestoreWindowAfterReceivingRestoreCommand())
@@ -2148,6 +2150,7 @@ Public Class Form1
 
                     strReceivedData = Nothing
                     strSourceIP = Nothing
+                    bytesReceived = Nothing
                 End While
             End Using
         Catch ex As Threading.ThreadAbortException

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -548,6 +548,12 @@ Public Class Form1
             Dim processIPv6 As Process = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
             Dim activeProcess As Process = Nothing
 
+            If processIPv4 IsNot Nothing Then
+                activeProcess = processIPv4
+            ElseIf processIPv6 IsNot Nothing Then
+                activeProcess = processIPv6
+            End If
+
             If activeProcess Is Nothing Then
                 MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
             Else

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -544,7 +544,7 @@ Public Class Form1
 
             boolServerRunning = True
         Else
-            Dim process As Process = GetProcessUsingPort(My.Settings.sysLogPort, ProtocolType.Udp)
+            Dim process As Process = GetProcessByUdpPort(My.Settings.sysLogPort)
 
             If process Is Nothing Then
                 MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
@@ -2167,7 +2167,7 @@ Public Class Form1
             ' Does nothing
         Catch e As Exception
             Invoke(Sub()
-                       Dim process As Process = GetProcessUsingPort(My.Settings.sysLogPort, ProtocolType.Udp)
+                       Dim process As Process = GetProcessByUdpPort(My.Settings.sysLogPort)
 
                        If process Is Nothing Then
                            MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -177,6 +177,11 @@ Public Class Form1
             If WindowState = FormWindowState.Minimized Then
                 If My.Settings.boolDeselectItemsWhenMinimizing Then
                     Logs.ClearSelection()
+
+                    For Each item As MyDataGridViewRow In Logs.Rows
+                        item.Cells(colDelete.Index).Value = False
+                    Next
+
                     LblItemsSelected.Visible = False
                 End If
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -843,7 +843,7 @@ Public Class Form1
     Private Sub ChkAutoScroll_Click(sender As Object, e As EventArgs) Handles ChkEnableAutoScroll.Click
         My.Settings.autoScroll = ChkEnableAutoScroll.Checked
         ChkDisableAutoScrollUponScrolling.Enabled = ChkEnableAutoScroll.Checked
-        LblAutoScrollStatus.Text = "Auto Scroll Status: Enabled"
+        LblAutoScrollStatus.Text = $"Auto Scroll Status: {If(ChkEnableAutoScroll.Checked, "Enabled", "Disabled")}"
     End Sub
 
     Private Sub Logs_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles Logs.ColumnWidthChanged

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -727,7 +727,7 @@ Public Class Form1
                 Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Where(Function(row As MyDataGridViewRow) row.Cells(colDelete.Index).Value).Count()
                 Dim intNumberOfSelectedLogs As Integer = Logs.SelectedRows.Count
 
-                If intNumberOfCheckedLogs <> intNumberOfSelectedLogs AndAlso MsgBox("The checked logs does not match the selected logs, do you want to make the checked logs match the selected logs?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
+                If intNumberOfCheckedLogs <> 0 And intNumberOfSelectedLogs <> 0 AndAlso intNumberOfCheckedLogs <> intNumberOfSelectedLogs AndAlso MsgBox("The checked logs does not match the selected logs, do you want to make the checked logs match the selected logs?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
                     For Each item As MyDataGridViewRow In Logs.SelectedRows
                         item.Cells(colDelete.Index).Value = True
                     Next

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -570,7 +570,7 @@ Public Class IgnoredLogsAndSearchResults
                                                   MyDataGridRowItem = TryCast(item, MyDataGridViewRow)
 
                                                   If MyDataGridRowItem IsNot Nothing Then
-                                                      strLogText = MyDataGridRowItem.Cells(ColumnIndex_RemoteProcess).Value
+                                                      strLogText = MyDataGridRowItem.Cells(ColumnIndex_LogText).Value
 
                                                       If Not String.IsNullOrWhiteSpace(strLogText) AndAlso regexCompiledObject.IsMatch(strLogText) Then
                                                           listOfSearchResults.Add(MyDataGridRowItem.Clone())

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -53,12 +53,14 @@ Public Class LogViewer
             txtAlertText.Visible = False
             lblAlertText.Visible = False
             IconImageBox.Visible = False
+            lblAlertType.Visible = False
             TableLayoutPanel1.SetRowSpan(LogText, 3)
         Else
             AdjustScrollBars(txtAlertText)
 
             If alertType = AlertType.None Then
                 HideTheImageBox()
+                lblAlertType.Visible = False
             Else
                 Dim strIconPath As String = Nothing
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -64,15 +64,15 @@ Public Class LogViewer
             Else
                 Dim strIconPath As String = Nothing
 
-                If alertType = ToolTipIcon.Error Then
+                If alertType = AlertType.ErrorMsg Then
                     lblAlertType.Text = "Alert Type: Error"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png")
                     ToolTip1.SetToolTip(IconImageBox, "Error alert type is used for critical issues." & vbCrLf & "It indicates a serious problem that needs immediate attention.")
-                ElseIf alertType = ToolTipIcon.Warning Then
+                ElseIf alertType = AlertType.Warning Then
                     lblAlertType.Text = "Alert Type: Warning"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png")
                     ToolTip1.SetToolTip(IconImageBox, "Warning alert type is used for non-critical issues." & vbCrLf & "It indicates a potential problem that may need attention.")
-                ElseIf alertType = ToolTipIcon.Info Then
+                ElseIf alertType = AlertType.Info Then
                     lblAlertType.Text = "Alert Type: Information"
                     strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
                     ToolTip1.SetToolTip(IconImageBox, "Information alert type is used for general information alerts." & vbCrLf & "It does not indicate any problem.")

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -303,6 +303,9 @@
             <setting name="colIgnoredDateCreated" serializeAs="String">
                 <value>180</value>
             </setting>
+            <setting name="ShowCloseButtonOnNotifications" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Fixed a bug on the "Log Viewer" window where the Alert Type label at the bottom of the window wasn't made invisible if the log didn't have an alert attached to it.
- Put in code to handle the (should be) rare occurance where the checked logs doesn't match the selected logs.
- Added a Close button to the notifications and a setting to include it or not.
- Fixed a bug in the new code that checks to see if the number of checked logs equals the number of selected logs when deleting logs.
- Fixed a bug on the "Log Viewer" window where alert types may not be displayed properly.
- Added code to uncheck all checked rows in the logs DataGridView when minimizing the window if the user has "DeselectI tems When Minimizing" enabled.
- Fixed a bug in which the "Auto Scroll Status" label on the bottom of the window wasn't being updated properly by the "Enable Auto-Scroll" menu item under Settings.
- We now use native APIs to get the process that has ports open on the system instead of using the NetStat command.
- Fixed a bug on the "Ignored Logs and Search Results" in which the search function on it wasn't working properly.

And a whole lot of other under the hood changes to the code.