### PR TITLE
Version 4.6 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.6.1.104")>
+<Assembly: AssemblyFileVersion("4.6.2.105")>

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -515,6 +515,7 @@ Public Class IgnoredLogsAndSearchResults
                                 Logs.ResumeLayout()
                                 LogsLoadedInLabel.Visible = True
                                 LogsLoadedInLabel.Text = $"Logs Loaded In: {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
+                                Logs.Sort(Logs.Columns(0), ListSortDirection.Ascending)
                                 boolDoneLoading = True
                             End Sub)
             End If


### PR DESCRIPTION
Fixed sorting on the "Ignored Logs and Search Results" window after loading a log backup file. This is because I literally forgot to make a call to sort the data.