### PR TITLE
Version 4.6 Build 3

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -7,22 +7,31 @@ Namespace My
     ' Startup: Raised when the application starts, before the startup form is created.
     ' Shutdown: Raised after all application forms are closed.  This event is not raised if the application terminates abnormally.
     ' UnhandledException: Raised if the application encounters an unhandled exception.
-    ' StartupNextInstance: Raised when launching a single-instance application and the application is already active. 
+    ' StartupNextInstance: Raised when launching a single-instance application and the application is already active.
     ' NetworkAvailabilityChanged: Raised when the network connection is connected or disconnected.
     Partial Friend Class MyApplication
         Private _reportCrash As ReportCrash
 
         Private Sub MyApplication_Startup(sender As Object, e As StartupEventArgs) Handles Me.Startup
             If My.Settings.FirstRun Then
-                If IO.File.Exists(strPathToConfigBackupFile) Then
-                    If Not SaveAppSettings.LoadApplicationSettingsFromFile(strPathToConfigBackupFile, "Free Syslog") Then
-                        MsgBox("There was an error loading the previous configuration, the program will launch with a clean config.", MsgBoxStyle.Critical, "Error loading configuration")
+                Try
+                    ' Check if backup file exists
+                    If IO.File.Exists(strPathToConfigBackupFile) Then
+                        ' Attempt to load the settings from the backup file
+                        If Not SaveAppSettings.LoadApplicationSettingsFromFile(strPathToConfigBackupFile, "Free Syslog") Then
+	                        MsgBox("There was an error loading the previous configuration, the program will launch with a clean config.", MsgBoxStyle.Critical, "Error Loading Configuration")
+                        End If
                     End If
-                End If
+                Catch ex As Exception
+                    ' Log or show a message for any unexpected errors during file processing
+                    MsgBox($"An unexpected error occurred: {ex.Message}", MsgBoxStyle.Critical, "Error")
+                End Try
 
+                ' Mark as not the first run
                 My.Settings.FirstRun = False
                 My.Settings.Save()
             Else
+                ' If not the first run, delete the backup file if it exists
                 If IO.File.Exists(strPathToConfigBackupFile) Then IO.File.Delete(strPathToConfigBackupFile)
             End If
 

--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -13,6 +13,19 @@ Namespace My
         Private _reportCrash As ReportCrash
 
         Private Sub MyApplication_Startup(sender As Object, e As StartupEventArgs) Handles Me.Startup
+            If My.Settings.FirstRun Then
+                If IO.File.Exists(strPathToConfigBackupFile) Then
+                    If Not SaveAppSettings.LoadApplicationSettingsFromFile(strPathToConfigBackupFile, "Free Syslog") Then
+                        MsgBox("There was an error loading the previous configuration, the program will launch with a clean config.", MsgBoxStyle.Critical, "Error loading configuration")
+                    End If
+                End If
+
+                My.Settings.FirstRun = False
+                My.Settings.Save()
+            Else
+                If IO.File.Exists(strPathToConfigBackupFile) Then IO.File.Delete(strPathToConfigBackupFile)
+            End If
+
             If Not Debugger.IsAttached Then
                 AddHandler System.Windows.Forms.Application.ThreadException, Sub(exSender, args) SendReport(args.Exception, "I crashed!")
                 AddHandler AppDomain.CurrentDomain.UnhandledException, Sub(exSender, args)

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.6.2.105")>
+<Assembly: AssemblyFileVersion("4.6.3.106")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1268,6 +1268,18 @@ Namespace My
                 Me("ShowCloseButtonOnNotifications") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property FirstRun() As Boolean
+            Get
+                Return CType(Me("FirstRun"),Boolean)
+            End Get
+            Set
+                Me("FirstRun") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -308,5 +308,8 @@
     <Setting Name="ShowCloseButtonOnNotifications" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="FirstRun" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/HTTPHelper.vb
+++ b/Free SysLog/Support Code/HTTPHelper.vb
@@ -205,7 +205,7 @@ Public Delegate Sub CustomErrorHandlerDelegate(ex As Exception, thisInstance As 
 
 ''' <summary>Allows you to easily POST and upload files to a remote HTTP server without you, the programmer, knowing anything about how it all works. This class does it all for you. It handles adding a User Agent String, additional HTTP Request Headers, string data to your HTTP POST data, and files to be uploaded in the HTTP POST data.</summary>
 Public Class HttpHelper
-    Private Const classVersion As String = "1.347"
+    Private Const classVersion As String = "1.348"
 
     Private strUserAgentString As String = Nothing
     Private boolUseProxy As Boolean = False
@@ -1387,7 +1387,11 @@ beginAgain:
     End Function
 
     Private Sub CaptureSSLInfo(url As String, ByRef httpWebRequest As Net.HttpWebRequest)
-        sslCertificate = If(url.StartsWith("https://", StringComparison.OrdinalIgnoreCase), New X509Certificates.X509Certificate2(httpWebRequest.ServicePoint.Certificate), Nothing)
+        If httpWebRequest.ServicePoint.Certificate Is Nothing Then
+            sslCertificate = Nothing
+        Else
+            sslCertificate = If(url.StartsWith("https://", StringComparison.OrdinalIgnoreCase), New X509Certificates.X509Certificate2(httpWebRequest.ServicePoint.Certificate), Nothing)
+        End If
     End Sub
 
     Private Sub AddPostDataToWebRequest(ByRef httpWebRequest As Net.HttpWebRequest)

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -242,6 +242,12 @@ Namespace checkForUpdates
                 End Using
 
                 If boolDebugBuild Or My.Settings.boolDebug Then
+                    MakeLogEntry($"Saving program configuration to ""{strPathToConfigBackupFile}"".")
+                End If
+
+                SaveAppSettings.SaveApplicationSettingsToFile(strPathToConfigBackupFile)
+
+                If boolDebugBuild Or My.Settings.boolDebug Then
                     MakeLogEntry("Launching updater module.")
                 End If
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -72,6 +72,7 @@ Namespace SupportCode
         Public strPathToDataFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog")
         Public strPathToDataBackupFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog", "Backup")
         Public strPathToDataFile As String = IO.Path.Combine(strPathToDataFolder, "log.json")
+        Public strPathToConfigBackupFile As String = IO.Path.Combine(strPathToDataFolder, "config_backup.json")
         Public Const strProxiedString As String = "proxied|"
         Public Const strQuote As String = Chr(34)
         Public Const strViewLog As String = "viewlog"

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -1,9 +1,10 @@
-﻿Imports System.IO
+﻿Imports System.ComponentModel
+Imports System.IO
 Imports System.Text.RegularExpressions
-Imports System.ComponentModel
+Imports System.Threading
 Imports System.Threading.Tasks
 Imports Free_SysLog.SupportCode
-Imports System.Threading
+Imports Microsoft.VisualBasic.Logging
 
 Public Class ViewLogBackups
     Public MyParentForm As Form1
@@ -204,7 +205,8 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub FileList_DoubleClick(sender As Object, e As EventArgs) Handles FileList.DoubleClick
-        BtnView.PerformClick()
+        Dim hitTest As DataGridView.HitTestInfo = FileList.HitTest(FileList.PointToClient(MousePosition).X, FileList.PointToClient(MousePosition).Y)
+        If hitTest.Type = DataGridViewHitTestType.Cell And hitTest.RowIndex <> -1 Then BtnView.PerformClick()
     End Sub
 
     Private Sub BtnView_Click(sender As Object, e As EventArgs) Handles BtnView.Click

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -306,6 +306,9 @@
             <setting name="ShowCloseButtonOnNotifications" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="FirstRun" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Fixed a bug on the "View Log Backups" window where double-clicking on the column headers to automatically resize them would open the log file for viewing instead of resizing the column.
- Updated the HTTPHelper Class to 1.348 which fixed a potential crash in the CaptureSSLInfo() function.
- Added a flag to the program's settings to determine if it's the first run of the program.
- Added code to load the previous configuration of the program upon updating the program if the configuration were to have been wiped for some reason.