### PR TITLE
Version 4.8 Build 1

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -111,14 +111,12 @@ Namespace My
                     collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
 
                     Threading.Tasks.Parallel.ForEach(collectionOfSavedData, Sub(savedData As SavedData)
-                                                                                SyncLock lockObject
-                                                                                    With uniqueObjects
-                                                                                        If Not String.IsNullOrWhiteSpace(savedData.logType) Then .logTypes.Add(savedData.logType)
-                                                                                        If Not String.IsNullOrWhiteSpace(savedData.appName) Then .processes.Add(savedData.appName)
-                                                                                        If Not String.IsNullOrWhiteSpace(savedData.hostname) Then .hostNames.Add(savedData.hostname)
-                                                                                        If Not String.IsNullOrWhiteSpace(savedData.ip) Then .ipAddresses.Add(savedData.ip)
-                                                                                    End With
-                                                                                End SyncLock
+                                                                                With uniqueObjects
+                                                                                    If Not String.IsNullOrWhiteSpace(savedData.logType) Then .logTypes.Add(savedData.logType)
+                                                                                    If Not String.IsNullOrWhiteSpace(savedData.appName) Then .processes.Add(savedData.appName)
+                                                                                    If Not String.IsNullOrWhiteSpace(savedData.hostname) Then .hostNames.Add(savedData.hostname)
+                                                                                    If Not String.IsNullOrWhiteSpace(savedData.ip) Then .ipAddresses.Add(savedData.ip)
+                                                                                End With
                                                                             End Sub)
                 End Using
             End If

--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -344,7 +344,7 @@
       <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.3</Version>
+      <Version>13.0.4</Version>
     </PackageReference>
     <PackageReference Include="TaskScheduler">
       <Version>2.12.2</Version>

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.7.1.107")>
+<Assembly: AssemblyFileVersion("4.8.1.108")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1316,6 +1316,18 @@ Namespace My
                 Me("IgnoredWordsAndPhrasesColumnOrder") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+        Public Property alertsColumnOrder() As String
+            Get
+                Return CType(Me("alertsColumnOrder"),String)
+            End Get
+            Set
+                Me("alertsColumnOrder") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1304,6 +1304,18 @@ Namespace My
                 Me("DateOfLastEventColumnWidth") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+        Public Property IgnoredWordsAndPhrasesColumnOrder() As String
+            Get
+                Return CType(Me("IgnoredWordsAndPhrasesColumnOrder"),String)
+            End Get
+            Set
+                Me("IgnoredWordsAndPhrasesColumnOrder") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1292,6 +1292,18 @@ Namespace My
                 Me("OnlySaveAlertedLogs") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("240")>  _
+        Public Property DateOfLastEventColumnWidth() As Integer
+            Get
+                Return CType(Me("DateOfLastEventColumnWidth"),Integer)
+            End Get
+            Set
+                Me("DateOfLastEventColumnWidth") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1340,6 +1340,18 @@ Namespace My
                 Me("replacementsColumnOrder") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("100")>  _
+        Public Property ColSinceLastEventWidth() As Integer
+            Get
+                Return CType(Me("ColSinceLastEventWidth"),Integer)
+            End Get
+            Set
+                Me("ColSinceLastEventWidth") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1328,6 +1328,18 @@ Namespace My
                 Me("alertsColumnOrder") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+        Public Property replacementsColumnOrder() As String
+            Get
+                Return CType(Me("replacementsColumnOrder"),String)
+            End Get
+            Set
+                Me("replacementsColumnOrder") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -323,5 +323,8 @@
     <Setting Name="alertsColumnOrder" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="replacementsColumnOrder" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -320,5 +320,8 @@
     <Setting Name="IgnoredWordsAndPhrasesColumnOrder" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="alertsColumnOrder" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -317,5 +317,8 @@
     <Setting Name="DateOfLastEventColumnWidth" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">240</Value>
     </Setting>
+    <Setting Name="IgnoredWordsAndPhrasesColumnOrder" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -326,5 +326,8 @@
     <Setting Name="replacementsColumnOrder" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ColSinceLastEventWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">100</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -314,5 +314,8 @@
     <Setting Name="OnlySaveAlertedLogs" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="DateOfLastEventColumnWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">240</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/My Custom ListViews.vb
+++ b/Free SysLog/Support Code/My Custom ListViews.vb
@@ -26,6 +26,7 @@ Public Class MyIgnoredListViewItem
     Public Property IgnoreType As IgnoreType
     Public Property timeSpanOfLastOccurrence As TimeSpan
     Public Property dateOfLastOccurrence As Date
+    Public Property intHits As Integer
     Public dateCreated As Date
     Public strComment As String
 

--- a/Free SysLog/Support Code/My Custom ListViews.vb
+++ b/Free SysLog/Support Code/My Custom ListViews.vb
@@ -25,6 +25,7 @@ Public Class MyIgnoredListViewItem
     Public Property BoolEnabled As Boolean
     Public Property IgnoreType As IgnoreType
     Public Property timeSpanOfLastOccurrence As TimeSpan
+    Public Property dateOfLastOccurrence As Date
     Public dateCreated As Date
     Public strComment As String
 

--- a/Free SysLog/Support Code/My Custom ListViews.vb
+++ b/Free SysLog/Support Code/My Custom ListViews.vb
@@ -24,6 +24,7 @@ Public Class MyIgnoredListViewItem
     Public Property BoolCaseSensitive As Boolean
     Public Property BoolEnabled As Boolean
     Public Property IgnoreType As IgnoreType
+    Public Property timeSpanOfLastOccurrence As TimeSpan
     Public dateCreated As Date
     Public strComment As String
 

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -143,6 +143,8 @@ Public Class IgnoredClass
         If Not dateLastEvent.Equals(Date.MinValue) Then
             dateLastEvent = dateLastEvent.ToLocalTime()
             listViewItem.SubItems.Add(dateLastEvent.ToLongDateString & " " & dateLastEvent.ToLongTimeString)
+        Else
+            listViewItem.SubItems.Add("")
         End If
 
         listViewItem.BoolRegex = BoolRegex

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -125,10 +125,10 @@ Public Class IgnoredClass
 
     Public Function ToListViewItem(ByRef longTotalHits As Long) As MyIgnoredListViewItem
         Dim intHits As Integer
-        Dim dateLastEvent As Date = Date.MinValue
+        Dim dateLastEvent As Date
         Dim intSecondsSinceLastEvent As Integer
 
-        IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent)
+        If Not IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent) Then dateLastEvent = Date.MinValue
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
         longTotalHits += intHits
 

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -145,6 +145,7 @@ Public Class IgnoredClass
         If Not dateLastEvent.Equals(Date.MinValue) Then
             dateLastEvent = dateLastEvent.ToLocalTime()
             sinceLastEvent = Now.ToLocalTime - dateLastEvent
+            listViewItem.timeSpanOfLastOccurrence = sinceLastEvent
             listViewItem.SubItems.Add($"{dateLastEvent.ToLongDateString} {dateLastEvent.ToLongTimeString}")
             listViewItem.SubItems.Add(TimespanToHMS(sinceLastEvent))
         Else

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -11,7 +11,7 @@ Public Class SavedData
     Public DateObject, ServerDate As Date
     Public BoolAlerted As Boolean = False
 
-    Public Function MakeDataGridRow(ByRef dataGrid As DataGridView) As MyDataGridViewRow
+    Public Function MakeDataGridRow(dataGrid As DataGridView) As MyDataGridViewRow
         Using MyDataGridViewRow As New MyDataGridViewRow
             With MyDataGridViewRow
                 .CreateCells(dataGrid)
@@ -76,7 +76,7 @@ Public Class AlertsHistory
     Public strTime, strAlertText, strIP, strLog, strRawLog As String
     Public alertType As AlertType
 
-    Public Function MakeDataGridRow(ByRef dataGrid As DataGridView) As AlertsHistoryDataGridViewRow
+    Public Function MakeDataGridRow(dataGrid As DataGridView) As AlertsHistoryDataGridViewRow
         Using AlertsHistoryDataGridViewRow As New AlertsHistoryDataGridViewRow
             With AlertsHistoryDataGridViewRow
                 .CreateCells(dataGrid)

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -126,6 +126,8 @@ Public Class IgnoredClass
     Public Function ToListViewItem(ByRef longTotalHits As Long) As MyIgnoredListViewItem
         Dim intHits As Integer
         Dim dateLastEvent As Date = Date.MinValue
+        Dim intSecondsSinceLastEvent As Integer
+
         IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent)
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
         longTotalHits += intHits
@@ -142,8 +144,11 @@ Public Class IgnoredClass
 
         If Not dateLastEvent.Equals(Date.MinValue) Then
             dateLastEvent = dateLastEvent.ToLocalTime()
-            listViewItem.SubItems.Add(dateLastEvent.ToLongDateString & " " & dateLastEvent.ToLongTimeString)
+            intSecondsSinceLastEvent = (Now.ToLocalTime - dateLastEvent).TotalSeconds
+            listViewItem.SubItems.Add($"{dateLastEvent.ToLongDateString} {dateLastEvent.ToLongTimeString}")
+            listViewItem.SubItems.Add(intSecondsSinceLastEvent.ToString("N0"))
         Else
+            listViewItem.SubItems.Add("")
             listViewItem.SubItems.Add("")
         End If
 

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -160,6 +160,7 @@ Public Class IgnoredClass
         listViewItem.IgnoreType = IgnoreType
         listViewItem.dateCreated = dateCreated
         listViewItem.strComment = strComment
+        listViewItem.intHits = intHits
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
         listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
         Return listViewItem
@@ -184,6 +185,7 @@ Public Class IgnoredClass
         listViewItem.IgnoreType = IgnoreType
         listViewItem.dateCreated = dateCreated
         listViewItem.strComment = strComment
+        listViewItem.intHits = intHits
         If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
         listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
         Return listViewItem

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -146,6 +146,7 @@ Public Class IgnoredClass
             dateLastEvent = dateLastEvent.ToLocalTime()
             sinceLastEvent = Now.ToLocalTime - dateLastEvent
             listViewItem.timeSpanOfLastOccurrence = sinceLastEvent
+            listViewItem.dateOfLastOccurrence = dateLastEvent
             listViewItem.SubItems.Add($"{dateLastEvent.ToLongDateString} {dateLastEvent.ToLongTimeString}")
             listViewItem.SubItems.Add(TimespanToHMS(sinceLastEvent))
         Else

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -125,6 +125,8 @@ Public Class IgnoredClass
 
     Public Function ToListViewItem(ByRef longTotalHits As Long) As MyIgnoredListViewItem
         Dim intHits As Integer
+        Dim dateLastEvent As Date = Date.MinValue
+        IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent)
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
         longTotalHits += intHits
 
@@ -137,6 +139,12 @@ Public Class IgnoredClass
         listViewItem.SubItems.Add(intHits.ToString("N0"))
         listViewItem.SubItems.Add(If(IgnoreType = IgnoreType.MainLog, "Main Log Text", "Remote App"))
         listViewItem.SubItems.Add(dateCreated.ToLongDateString)
+
+        If Not dateLastEvent.Equals(Date.MinValue) Then
+            dateLastEvent = dateLastEvent.ToLocalTime()
+            listViewItem.SubItems.Add(dateLastEvent.ToLongDateString & " " & dateLastEvent.ToLongTimeString)
+        End If
+
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -138,7 +138,7 @@ Public Class IgnoredClass
         listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolCaseSensitive, "Yes", "No"))
         listViewItem.SubItems.Add(If(BoolEnabled, "Yes", "No"))
-        listViewItem.SubItems.Add(intHits.ToString("N0"))
+        listViewItem.SubItems.Add(If(BoolEnabled, intHits.ToString("N0"), ""))
         listViewItem.SubItems.Add(If(IgnoreType = IgnoreType.MainLog, "Main Log Text", "Remote App"))
         listViewItem.SubItems.Add(dateCreated.ToLongDateString)
 

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -126,7 +126,7 @@ Public Class IgnoredClass
     Public Function ToListViewItem(ByRef longTotalHits As Long) As MyIgnoredListViewItem
         Dim intHits As Integer
         Dim dateLastEvent As Date
-        Dim intSecondsSinceLastEvent As Integer
+        Dim sinceLastEvent As TimeSpan
 
         If Not IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent) Then dateLastEvent = Date.MinValue
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
@@ -144,9 +144,9 @@ Public Class IgnoredClass
 
         If Not dateLastEvent.Equals(Date.MinValue) Then
             dateLastEvent = dateLastEvent.ToLocalTime()
-            intSecondsSinceLastEvent = (Now.ToLocalTime - dateLastEvent).TotalSeconds
+            sinceLastEvent = Now.ToLocalTime - dateLastEvent
             listViewItem.SubItems.Add($"{dateLastEvent.ToLongDateString} {dateLastEvent.ToLongTimeString}")
-            listViewItem.SubItems.Add(intSecondsSinceLastEvent.ToString("N0"))
+            listViewItem.SubItems.Add(TimespanToHMS(sinceLastEvent))
         Else
             listViewItem.SubItems.Add("")
             listViewItem.SubItems.Add("")

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -12,42 +12,42 @@ Public Class SavedData
     Public BoolAlerted As Boolean = False
 
     Public Function MakeDataGridRow(dataGrid As DataGridView) As MyDataGridViewRow
-        Using MyDataGridViewRow As New MyDataGridViewRow
-            With MyDataGridViewRow
-                .CreateCells(dataGrid)
-                .Cells(ColumnIndex_ComputedTime).Value = Date.Parse(time)
-                .Cells(ColumnIndex_ComputedTime).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-                .Cells(ColumnIndex_LogType).Value = If(String.IsNullOrWhiteSpace(logType), "", logType)
-                .Cells(ColumnIndex_IPAddress).Value = ip
-                .Cells(ColumnIndex_RemoteProcess).Value = If(String.IsNullOrWhiteSpace(appName), "", appName)
-                .Cells(ColumnIndex_Hostname).Value = If(String.IsNullOrWhiteSpace(hostname), "", hostname)
-                .Cells(ColumnIndex_LogText).Value = log
-                .Cells(ColumnIndex_Alerted).Value = If(BoolAlerted, "Yes", "No")
-                .Cells(ColumnIndex_Alerted).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-                .Cells(ColumnIndex_Alerted).Style.WrapMode = DataGridViewTriState.True
-                .Cells(ColumnIndex_ServerTime).Value = If(ServerDate = Date.MinValue, "", ToIso8601Format(ServerDate))
-                .DateObject = DateObject
-                .BoolAlerted = BoolAlerted
-                .RawLogData = rawLogData
-                .AlertText = alertText
-                .alertType = alertType
+        Dim MyDataGridViewRow As New MyDataGridViewRow
 
-                If My.Settings.font IsNot Nothing Then
-                    .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_LogType).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_IPAddress).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_RemoteProcess).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_Hostname).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_LogText).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_Alerted).Style.Font = My.Settings.font
-                    .Cells(ColumnIndex_ServerTime).Style.Font = My.Settings.font
-                End If
+        With MyDataGridViewRow
+            .CreateCells(dataGrid)
+            .Cells(ColumnIndex_ComputedTime).Value = Date.Parse(time)
+            .Cells(ColumnIndex_ComputedTime).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+            .Cells(ColumnIndex_LogType).Value = If(String.IsNullOrWhiteSpace(logType), "", logType)
+            .Cells(ColumnIndex_IPAddress).Value = ip
+            .Cells(ColumnIndex_RemoteProcess).Value = If(String.IsNullOrWhiteSpace(appName), "", appName)
+            .Cells(ColumnIndex_Hostname).Value = If(String.IsNullOrWhiteSpace(hostname), "", hostname)
+            .Cells(ColumnIndex_LogText).Value = log
+            .Cells(ColumnIndex_Alerted).Value = If(BoolAlerted, "Yes", "No")
+            .Cells(ColumnIndex_Alerted).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+            .Cells(ColumnIndex_Alerted).Style.WrapMode = DataGridViewTriState.True
+            .Cells(ColumnIndex_ServerTime).Value = If(ServerDate = Date.MinValue, "", ToIso8601Format(ServerDate))
+            .DateObject = DateObject
+            .BoolAlerted = BoolAlerted
+            .RawLogData = rawLogData
+            .AlertText = alertText
+            .alertType = alertType
 
-                .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
-            End With
+            If My.Settings.font IsNot Nothing Then
+                .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_LogType).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_IPAddress).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_RemoteProcess).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_Hostname).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_LogText).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_Alerted).Style.Font = My.Settings.font
+                .Cells(ColumnIndex_ServerTime).Style.Font = My.Settings.font
+            End If
 
-            Return MyDataGridViewRow
-        End Using
+            .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+        End With
+
+        Return MyDataGridViewRow
     End Function
 End Class
 
@@ -77,41 +77,41 @@ Public Class AlertsHistory
     Public alertType As AlertType
 
     Public Function MakeDataGridRow(dataGrid As DataGridView) As AlertsHistoryDataGridViewRow
-        Using AlertsHistoryDataGridViewRow As New AlertsHistoryDataGridViewRow
-            With AlertsHistoryDataGridViewRow
-                .CreateCells(dataGrid)
-                .Cells(0).Value = strTime
-                .Cells(0).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+        Dim AlertsHistoryDataGridViewRow As New AlertsHistoryDataGridViewRow
 
-                If alertType = AlertType.ErrorMsg Then
-                    .Cells(1).Value = "Error"
-                ElseIf alertType = AlertType.Warning Then
-                    .Cells(1).Value = "Warning"
-                ElseIf alertType = AlertType.Info Then
-                    .Cells(1).Value = "Information"
-                Else
-                    .Cells(1).Value = ""
-                End If
+        With AlertsHistoryDataGridViewRow
+            .CreateCells(dataGrid)
+            .Cells(0).Value = strTime
+            .Cells(0).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
-                .Cells(1).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-                .Cells(2).Value = strAlertText
+            If alertType = AlertType.ErrorMsg Then
+                .Cells(1).Value = "Error"
+            ElseIf alertType = AlertType.Warning Then
+                .Cells(1).Value = "Warning"
+            ElseIf alertType = AlertType.Info Then
+                .Cells(1).Value = "Information"
+            Else
+                .Cells(1).Value = ""
+            End If
 
-                If My.Settings.font IsNot Nothing Then
-                    .Cells(0).Style.Font = My.Settings.font
-                    .Cells(1).Style.Font = My.Settings.font
-                    .Cells(2).Style.Font = My.Settings.font
-                End If
+            .Cells(1).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+            .Cells(2).Value = strAlertText
 
-                .strRawLog = strRawLog
-                .strIP = strIP
-                .strLog = strLog
-                .strTime = strTime
-                .strAlertText = strAlertText
-                .alertType = alertType
-            End With
+            If My.Settings.font IsNot Nothing Then
+                .Cells(0).Style.Font = My.Settings.font
+                .Cells(1).Style.Font = My.Settings.font
+                .Cells(2).Style.Font = My.Settings.font
+            End If
 
-            Return AlertsHistoryDataGridViewRow
-        End Using
+            .strRawLog = strRawLog
+            .strIP = strIP
+            .strLog = strLog
+            .strTime = strTime
+            .strAlertText = strAlertText
+            .alertType = alertType
+        End With
+
+        Return AlertsHistoryDataGridViewRow
     End Function
 End Class
 

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -123,6 +123,31 @@ Public Class IgnoredClass
     Public IgnoreType As IgnoreType = IgnoreType.MainLog
     Public dateCreated As Date
 
+    Public Function ToListViewItem(ByRef longTotalHits As Long) As MyIgnoredListViewItem
+        Dim intHits As Integer
+        If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
+        longTotalHits += intHits
+
+        If dateCreated = Date.MinValue Then dateCreated = Date.Now
+
+        Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
+        listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))
+        listViewItem.SubItems.Add(If(BoolCaseSensitive, "Yes", "No"))
+        listViewItem.SubItems.Add(If(BoolEnabled, "Yes", "No"))
+        listViewItem.SubItems.Add(intHits.ToString("N0"))
+        listViewItem.SubItems.Add(If(IgnoreType = IgnoreType.MainLog, "Main Log Text", "Remote App"))
+        listViewItem.SubItems.Add(dateCreated.ToLongDateString)
+        listViewItem.BoolRegex = BoolRegex
+        listViewItem.BoolCaseSensitive = BoolCaseSensitive
+        listViewItem.BoolEnabled = BoolEnabled
+        listViewItem.IgnoreType = IgnoreType
+        listViewItem.dateCreated = dateCreated
+        listViewItem.strComment = strComment
+        If My.Settings.font IsNot Nothing Then listViewItem.Font = My.Settings.font
+        listViewItem.BackColor = If(listViewItem.BoolEnabled, Color.LightGreen, Color.Pink)
+        Return listViewItem
+    End Function
+
     Public Function ToListViewItem() As MyIgnoredListViewItem
         Dim intHits As Integer
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0

--- a/Free SysLog/Support Code/Namespace Code/Data Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Data Handling.vb
@@ -165,49 +165,5 @@ Namespace DataHandling
                 End If
             End SyncLock
         End Sub
-
-        Public Sub WriteLogsToDisk()
-            SyncLock ParentForm.dataGridLockObject
-                Dim collectionOfSavedData As New List(Of SavedData)
-                Dim myItem As MyDataGridViewRow
-
-                For Each item As DataGridViewRow In ParentForm.Logs.Rows
-                    If Not String.IsNullOrWhiteSpace(item.Cells(ColumnIndex_ComputedTime).Value) Then
-                        myItem = DirectCast(item, MyDataGridViewRow)
-
-                        collectionOfSavedData.Add(New SavedData With {
-                                            .time = myItem.Cells(ColumnIndex_ComputedTime).Value,
-                                            .logType = myItem.Cells(ColumnIndex_LogType).Value,
-                                            .ip = myItem.Cells(ColumnIndex_IPAddress).Value,
-                                            .appName = myItem.Cells(ColumnIndex_RemoteProcess).Value,
-                                            .log = myItem.Cells(ColumnIndex_LogText).Value,
-                                            .hostname = myItem.Cells(ColumnIndex_Hostname).Value,
-                                            .DateObject = myItem.DateObject,
-                                            .BoolAlerted = myItem.BoolAlerted,
-                                            .ServerDate = myItem.ServerDate,
-                                            .rawLogData = myItem.RawLogData,
-                                            .alertText = myItem.AlertText,
-                                            .alertType = myItem.alertType
-                                          })
-                    End If
-                Next
-
-                Try
-                    Using fileStream As New StreamWriter(strPathToDataFile & ".new")
-                        fileStream.Write(Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
-                    End Using
-
-                    File.Delete(strPathToDataFile)
-                    File.Move(strPathToDataFile & ".new", strPathToDataFile)
-                Catch ex As Exception
-                    MsgBox("A critical error occurred while writing log data to disk. The old data had been saved to prevent data corruption.", MsgBoxStyle.Critical, ParentForm.Text)
-                    Process.GetCurrentProcess.Kill()
-                End Try
-
-                ParentForm.LblLogFileSize.Text = $"Log File Size: {FileSizeToHumanSize(New FileInfo(strPathToDataFile).Length)}"
-
-                ParentForm.BtnSaveLogsToDisk.Enabled = False
-            End SyncLock
-        End Sub
     End Module
 End Namespace

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -1,7 +1,6 @@
 ﻿Namespace NotificationLimiter
     Public Module NotificationLimiter
-        Public lastNotificationTime As New Dictionary(Of String, Date)(StringComparison.OrdinalIgnoreCase)
-        Public lastNotificationTimeLockingObject As New Object()
+        Public lastNotificationTime As New Concurrent.ConcurrentDictionary(Of String, Date)(StringComparer.OrdinalIgnoreCase)
 
         ' Time after which an unused entry is considered stale (in minutes)
         Private Const CleanupThresholdInMinutes As Integer = 10
@@ -10,22 +9,20 @@
             ' Get the current time
             Dim currentTime As Date = Date.Now
 
-            SyncLock lastNotificationTimeLockingObject
-                ' Clean up old notification entries
-                CleanUpOldEntries(currentTime)
+            ' Clean up old notification entries
+            CleanUpOldEntries(currentTime)
 
-                ' Check if this message has been shown recently
-                If lastNotificationTime.ContainsKey(tipText) Then
-                    Dim lastTime As Date = lastNotificationTime(tipText)
-                    Dim timeSinceLastNotification As TimeSpan = currentTime - lastTime
+            ' Check if this message has been shown recently
+            If lastNotificationTime.ContainsKey(tipText) Then
+                Dim lastTime As Date = lastNotificationTime(tipText)
+                Dim timeSinceLastNotification As TimeSpan = currentTime - lastTime
 
-                    ' If the message was shown within the time limit, do not show it again
-                    If timeSinceLastNotification.TotalSeconds < My.Settings.TimeBetweenSameNotifications Then Exit Sub
-                End If
+                ' If the message was shown within the time limit, do not show it again
+                If timeSinceLastNotification.TotalSeconds < My.Settings.TimeBetweenSameNotifications Then Exit Sub
+            End If
 
-                ' Update the last shown time for this message
-                lastNotificationTime(tipText) = currentTime
-            End SyncLock
+            ' Update the last shown time for this message
+            lastNotificationTime(tipText) = currentTime
 
             SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alertType)
         End Sub
@@ -35,7 +32,7 @@
             Dim keysToRemove As List(Of String) = lastNotificationTime.Where(Function(kvp As KeyValuePair(Of String, Date)) (currentTime - kvp.Value).TotalMinutes > CleanupThresholdInMinutes).Select(Function(kvp As KeyValuePair(Of String, Date)) kvp.Key).ToList()
 
             For Each key As String In keysToRemove
-                lastNotificationTime.Remove(key)
+                lastNotificationTime.TryRemove(key, Nothing)
             Next
         End Sub
     End Module

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -124,7 +124,7 @@ Namespace SupportCode
             End Try
         End Function
 
-        Public Sub LoadSavedListViewColumnOrder(ByRef columns As ListView.ColumnHeaderCollection, strToLoadFrom As String)
+        Public Sub LoadColumnOrders(ByRef columns As ListView.ColumnHeaderCollection, strToLoadFrom As String)
             Try
                 If String.IsNullOrWhiteSpace(strToLoadFrom) Then Exit Sub
 
@@ -137,7 +137,7 @@ Namespace SupportCode
             End Try
         End Sub
 
-        Public Function SaveListViewColumnOrder(ByRef columns As ListView.ColumnHeaderCollection) As String
+        Public Function SaveColumnOrders(ByRef columns As ListView.ColumnHeaderCollection) As String
             Dim columnOrder As New List(Of Integer)
 
             For i As Integer = 0 To columns.Count - 1

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -91,7 +91,6 @@ Namespace SupportCode
 
         Public allUniqueObjects As uniqueObjectsClass
         Public recentUniqueObjects As uniqueObjectsClass
-        Public ReadOnly recentUniqueObjectsLock As New Object()
         Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()
 
         Public WriteOnly Property AskOpenExplorer As Boolean

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -51,6 +51,7 @@ Namespace SupportCode
         Public ReplacementsRegexCache As New ConcurrentDictionary(Of String, Regex)
         Public IgnoredRegexCache As New ConcurrentDictionary(Of String, Regex)
         Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
+        Public IgnoredLastEvent As New ConcurrentDictionary(Of String, Date)
 
         Public longNumberOfIgnoredLogs As Long = 0
         Public boolIsProgrammaticScroll As Boolean = False

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -124,24 +124,24 @@ Namespace SupportCode
             End Try
         End Function
 
-        Public Sub LoadSavedListViewColumnOrder(ByRef listView As ListView, strToLoadFrom As String)
+        Public Sub LoadSavedListViewColumnOrder(ByRef columns As ListView.ColumnHeaderCollection, strToLoadFrom As String)
             Try
                 If String.IsNullOrWhiteSpace(strToLoadFrom) Then Exit Sub
 
                 Dim columnOrder As Integer() = Array.ConvertAll(strToLoadFrom.Split(","), Function(s As String) Integer.Parse(s))
 
-                For i As Integer = 0 To Math.Min(columnOrder.Length - 1, listView.Columns.Count - 1)
-                    listView.Columns(i).DisplayIndex = columnOrder(i)
+                For i As Integer = 0 To Math.Min(columnOrder.Length - 1, columns.Count - 1)
+                    columns(i).DisplayIndex = columnOrder(i)
                 Next
             Catch
             End Try
         End Sub
 
-        Public Function SaveListViewColumnOrder(ByRef listView As ListView) As String
+        Public Function SaveListViewColumnOrder(ByRef columns As ListView.ColumnHeaderCollection) As String
             Dim columnOrder As New List(Of Integer)
 
-            For i As Integer = 0 To listView.Columns.Count - 1
-                columnOrder.Add(listView.Columns(i).DisplayIndex)
+            For i As Integer = 0 To columns.Count - 1
+                columnOrder.Add(columns(i).DisplayIndex)
             Next
 
             Return String.Join(",", columnOrder)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -124,6 +124,29 @@ Namespace SupportCode
             End Try
         End Function
 
+        Public Sub LoadSavedListViewColumnOrder(ByRef listView As ListView, strToLoadFrom As String)
+            Try
+                If String.IsNullOrWhiteSpace(strToLoadFrom) Then Exit Sub
+
+                Dim columnOrder As Integer() = Array.ConvertAll(strToLoadFrom.Split(","), Function(s As String) Integer.Parse(s))
+
+                For i As Integer = 0 To Math.Min(columnOrder.Length - 1, listView.Columns.Count - 1)
+                    listView.Columns(i).DisplayIndex = columnOrder(i)
+                Next
+            Catch
+            End Try
+        End Sub
+
+        Public Function SaveListViewColumnOrder(ByRef listView As ListView) As String
+            Dim columnOrder As New List(Of Integer)
+
+            For i As Integer = 0 To listView.Columns.Count - 1
+                columnOrder.Add(listView.Columns(i).DisplayIndex)
+            Next
+
+            Return String.Join(",", columnOrder)
+        End Function
+
         Public Sub SortByClickedColumn(ByRef ListView As ListView, intColumn As Integer, ByRef m_SortingColumn As ColumnHeader)
             ' Get the new sorting column.
             Dim new_sorting_column As ColumnHeader = ListView.Columns(intColumn)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -108,6 +108,19 @@ Namespace SupportCode
         Public Const boolDebugBuild As Boolean = False
 #End If
 
+        Public Function TimespanToHMS(timeSpan As TimeSpan) As String
+            Dim parts As New List(Of String)
+
+            If timeSpan.Hours > 0 Then parts.Add($"{timeSpan.Hours}h")
+            If timeSpan.Minutes > 0 Then parts.Add($"{timeSpan.Minutes}m")
+            If timeSpan.Seconds > 0 Then parts.Add($"{timeSpan.Seconds}s")
+
+            ' If everything is zero (unlikely but possible), show 0s
+            If parts.Count = 0 Then Return "0s"
+
+            Return String.Join(", ", parts)
+        End Function
+
         Public Function SaveColumnOrders(columns As DataGridViewColumnCollection) As Specialized.StringCollection
             Try
                 Dim SpecializedStringCollection As New Specialized.StringCollection

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -52,6 +52,7 @@ Namespace SupportCode
         Public IgnoredRegexCache As New ConcurrentDictionary(Of String, Regex)
         Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
 
+        Public longNumberOfIgnoredLogs As Long = 0
         Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
         Public replacementsList As New ThreadSafetyLists.ThreadSafeReplacementsList

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -109,14 +109,13 @@ Namespace SupportCode
 #End If
 
         Public Function TimespanToHMS(timeSpan As TimeSpan) As String
+            If timeSpan.TotalSeconds = 0 Then Return "0s"
+
             Dim parts As New List(Of String)
 
             If timeSpan.Hours > 0 Then parts.Add($"{timeSpan.Hours}h")
             If timeSpan.Minutes > 0 Then parts.Add($"{timeSpan.Minutes}m")
             If timeSpan.Seconds > 0 Then parts.Add($"{timeSpan.Seconds}s")
-
-            ' If everything is zero (unlikely but possible), show 0s
-            If parts.Count = 0 Then Return "0s"
 
             Return String.Join(", ", parts)
         End Function

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -109,7 +109,7 @@ Namespace SupportCode
 #End If
 
         Public Function TimespanToHMS(timeSpan As TimeSpan) As String
-            If timeSpan.TotalSeconds = 0 Then Return "0s"
+            If timeSpan.TotalMilliseconds < 1 Then Return "0s"
 
             Dim parts As New List(Of String)
 
@@ -117,7 +117,7 @@ Namespace SupportCode
             If timeSpan.Minutes > 0 Then parts.Add($"{timeSpan.Minutes}m")
             If timeSpan.Seconds > 0 Then parts.Add($"{timeSpan.Seconds}s")
 
-            Return String.Join(", ", parts)
+            Return If(parts.Count > 0, String.Join(", ", parts), "0s")
         End Function
 
         Public Function SaveColumnOrders(columns As DataGridViewColumnCollection) As Specialized.StringCollection

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -427,7 +427,7 @@ Namespace SupportCode
             ElseIf size > (2 ^ 50) And size <= (2 ^ 60) Then
                 result = $"{MyRoundingFunction(size / (2 ^ 50), shortRoundNumber)} PBs"
             ElseIf size > (2 ^ 60) And size <= (2 ^ 70) Then
-                result = $"{MyRoundingFunction(size / (2 ^ 50), shortRoundNumber)} EBs"
+                result = $"{MyRoundingFunction(size / (2 ^ 60), shortRoundNumber)} EBs"
             Else
                 result = "(None)"
             End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -334,25 +334,23 @@ Namespace SyslogParser
 
                         Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
 
-                        SyncLock recentUniqueObjectsLock
-                            With recentUniqueObjects
-                                If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                                    ParentForm.boxLimiter.Items.Add(logType)
-                                End If
+                        With recentUniqueObjects
+                            If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(logType)
+                            End If
 
-                                If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                                    ParentForm.boxLimiter.Items.Add(appName)
-                                End If
+                            If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(appName)
+                            End If
 
-                                If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-                                    ParentForm.boxLimiter.Items.Add(hostname)
-                                End If
+                            If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(hostname)
+                            End If
 
-                                If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-                                    ParentForm.boxLimiter.Items.Add(strSourceIP)
-                                End If
-                            End With
-                        End SyncLock
+                            If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(strSourceIP)
+                            End If
+                        End With
                     End If
 
                     ' Step 4: Add to log list, separating header and message

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -408,6 +408,7 @@ Namespace SyslogParser
                                                                                                _strIgnoredPattern = strRegexPattern
                                                                                                matchFound = True
                                                                                                IgnoredHits.AddOrUpdate(strRegexPattern, 1, Function(key As String, oldValue As Integer) oldValue + 1)
+                                                                                               IgnoredLastEvent.AddOrUpdate(strRegexPattern, Date.Now, Function(key As String, oldValue As Date) Date.Now)
                                                                                                state.Stop()
                                                                                                If ParentForm IsNot Nothing Then ParentForm.Invoke(Sub() Interlocked.Increment(longNumberOfIgnoredLogs))
                                                                                            End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -512,7 +512,6 @@ Namespace SyslogParser
                         ParentForm.Invoke(Sub() ParentForm.ClearIgnoredLogsToolStripMenuItem.Enabled = True)
                     End SyncLock
                 Else
-                    Interlocked.Increment(longNumberOfIgnoredLogs)
                     ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
                 End If
             End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -407,7 +407,7 @@ Namespace SyslogParser
                                                                                            If Not matchFound Then
                                                                                                _strIgnoredPattern = strRegexPattern
                                                                                                matchFound = True
-                                                                                               IgnoredHits.AddOrUpdate(strRegexPattern, 1, Function(key, oldValue) oldValue + 1)
+                                                                                               IgnoredHits.AddOrUpdate(strRegexPattern, 1, Function(key As String, oldValue As Integer) oldValue + 1)
                                                                                                state.Stop()
                                                                                                If ParentForm IsNot Nothing Then ParentForm.Invoke(Sub() Interlocked.Increment(longNumberOfIgnoredLogs))
                                                                                            End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -409,7 +409,7 @@ Namespace SyslogParser
                                                                                                matchFound = True
                                                                                                IgnoredHits.AddOrUpdate(strRegexPattern, 1, Function(key, oldValue) oldValue + 1)
                                                                                                state.Stop()
-                                                                                               If ParentForm IsNot Nothing Then ParentForm.Invoke(Sub() Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs))
+                                                                                               If ParentForm IsNot Nothing Then ParentForm.Invoke(Sub() Interlocked.Increment(longNumberOfIgnoredLogs))
                                                                                            End If
                                                                                        End SyncLock
                                                                                    End If
@@ -501,7 +501,7 @@ Namespace SyslogParser
                                 ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.IgnoredLogs.Count:N0}"
                             Else
                                 ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
-                                ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.longNumberOfIgnoredLogs:N0}"
+                                ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
                             End If
                         End SyncLock
 
@@ -512,8 +512,8 @@ Namespace SyslogParser
                         ParentForm.Invoke(Sub() ParentForm.ClearIgnoredLogsToolStripMenuItem.Enabled = True)
                     End SyncLock
                 Else
-                    Interlocked.Increment(ParentForm.longNumberOfIgnoredLogs)
-                    ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.longNumberOfIgnoredLogs:N0}"
+                    Interlocked.Increment(longNumberOfIgnoredLogs)
+                    ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
                 End If
             End If
         End Sub

--- a/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
+++ b/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
@@ -130,6 +130,12 @@ Namespace ThreadSafetyLists
             End SyncLock
         End Sub
 
+        Public Sub Merge(items As IEnumerable(Of T))
+            SyncLock _lock
+                _list.AddRange(items)
+            End SyncLock
+        End Sub
+
         Public Sub Clear()
             SyncLock _lock
                 _list.Clear()

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -83,9 +83,8 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1, hits2 As Long
-                If Not Long.TryParse(item1.SubItems(4).Text, hits1) Then hits1 = 0
-                If Not Long.TryParse(item2.SubItems(4).Text, hits2) Then hits2 = 0
+                Dim hits1 As Integer = item1.intHits
+                Dim hits2 As Integer = item2.intHits
 
                 Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
 
@@ -116,9 +115,8 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1, hits2 As Long
-                If Not Long.TryParse(item1.SubItems(4).Text, hits1) Then hits1 = 0
-                If Not Long.TryParse(item2.SubItems(4).Text, hits2) Then hits2 = 0
+                Dim hits1 As Integer = item1.intHits
+                Dim hits2 As Integer = item2.intHits
 
                 Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
 
@@ -146,9 +144,8 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1, hits2 As Long
-                If Not Long.TryParse(item1.SubItems(4).Text, hits1) Then hits1 = 0
-                If Not Long.TryParse(item2.SubItems(4).Text, hits2) Then hits2 = 0
+                Dim hits1 As Integer = item1.intHits
+                Dim hits2 As Integer = item2.intHits
 
                 Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
 

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -129,6 +129,35 @@
 
                 ' If both are enabled, sort by dateOfLastOccurrence
                 Return If(soSortOrder = SortOrder.Ascending, item1.dateOfLastOccurrence.CompareTo(item2.dateOfLastOccurrence), item2.dateOfLastOccurrence.CompareTo(item1.dateOfLastOccurrence))
+            ElseIf intColumnNumber = 4 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
+                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+
+                Dim enabled1 As Boolean = item1.BoolEnabled
+                Dim enabled2 As Boolean = item2.BoolEnabled
+
+                ' Always keep enabled items above disabled items (independent of sort order)
+                If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
+                If Not enabled1 AndAlso enabled2 Then Return 1      ' item2 first
+
+                ' If both disabled, don't change their relative order
+                If Not enabled1 AndAlso Not enabled2 Then Return 0
+
+                ' --- Now compare ENABLED items by hits first ---
+                Dim hits1 As Long = Long.Parse(item1.SubItems(4).Text)
+                Dim hits2 As Long = Long.Parse(item2.SubItems(4).Text)
+
+                Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
+
+                ' Enabled items with hits > 0 should sort ahead of hits = 0
+                If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
+                If hits1 <> 0 AndAlso hits2 = 0 Then Return -1   ' item1 goes above
+
+                ' If both have zero hits, do not reorder them
+                If bothZeroHits Then Return 0
+
+                ' If both are enabled, sort by dateOfLastOccurrence
+                Return If(soSortOrder = SortOrder.Ascending, hits1.CompareTo(hits2), hits2.CompareTo(hits1))
             Else
                 ' Compare them.
                 If Double.TryParse(strFirstString, dbl1) And Double.TryParse(strSecondString, dbl2) Then

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -39,4 +39,52 @@
             End If
         End Function
     End Class
+
+    ' Implements a comparer for ListView columns.
+    Class IgnoredWordsAndPhrasesListViewComparer
+        Implements IComparer
+
+        Private intColumnNumber As Integer
+        Private soSortOrder As SortOrder
+
+        Public Sub New(ByVal intInputColumnNumber As Integer, ByVal soInputSortOrder As SortOrder)
+            intColumnNumber = intInputColumnNumber
+            soSortOrder = soInputSortOrder
+        End Sub
+
+        ' Compare the items in the appropriate column
+        ' for objects x and y.
+        Public Function Compare(lvInputFirstListView As Object, lvInputSecondListView As Object) As Integer Implements IComparer.Compare
+            Dim dbl1, dbl2 As Double
+            Dim long1, long2 As Long
+            Dim date1, date2 As Date
+            Dim strFirstString, strSecondString As String
+            Dim lvFirstListView As ListViewItem = lvInputFirstListView
+            Dim lvSecondListView As ListViewItem = lvInputSecondListView
+            Dim lvFirstListViewType As Type = lvFirstListView.GetType
+            Dim lvSecondListViewType As Type = lvSecondListView.GetType
+
+            ' Get the sub-item values.
+            strFirstString = If(lvFirstListView.SubItems.Count <= intColumnNumber, "", lvFirstListView.SubItems(intColumnNumber).Text)
+            strSecondString = If(lvSecondListView.SubItems.Count <= intColumnNumber, "", lvSecondListView.SubItems(intColumnNumber).Text)
+
+            If intColumnNumber = 8 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
+                Dim timeSpan1 As TimeSpan = DirectCast(lvFirstListView, MyIgnoredListViewItem).timeSpanOfLastOccurrence
+                Dim timeSpan2 As TimeSpan = DirectCast(lvSecondListView, MyIgnoredListViewItem).timeSpanOfLastOccurrence
+
+                Return If(soSortOrder = SortOrder.Ascending, timeSpan1.CompareTo(timeSpan2), timeSpan2.CompareTo(timeSpan1))
+            Else
+                ' Compare them.
+                If Double.TryParse(strFirstString, dbl1) And Double.TryParse(strSecondString, dbl2) Then
+                    Return If(soSortOrder = SortOrder.Ascending, dbl1.CompareTo(dbl2), dbl2.CompareTo(dbl1))
+                ElseIf Date.TryParse(strFirstString, date1) And Date.TryParse(strSecondString, date2) Then
+                    Return If(soSortOrder = SortOrder.Ascending, date1.CompareTo(date2), date2.CompareTo(date1))
+                ElseIf Long.TryParse(strFirstString, long1) And Long.TryParse(strSecondString, long2) Then
+                    Return If(soSortOrder = SortOrder.Ascending, long1.CompareTo(long2), long2.CompareTo(long1))
+                Else
+                    Return If(soSortOrder = SortOrder.Ascending, String.Compare(strFirstString, strSecondString), String.Compare(strSecondString, strFirstString))
+                End If
+            End If
+        End Function
+    End Class
 End Namespace

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -100,6 +100,35 @@
                 Dim timeSpan2 As TimeSpan = item2.timeSpanOfLastOccurrence
 
                 Return If(soSortOrder = SortOrder.Ascending, timeSpan1.CompareTo(timeSpan2), timeSpan2.CompareTo(timeSpan1))
+            ElseIf intColumnNumber = 7 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
+                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+
+                Dim enabled1 As Boolean = item1.BoolEnabled
+                Dim enabled2 As Boolean = item2.BoolEnabled
+
+                ' Always keep enabled items above disabled items (independent of sort order)
+                If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
+                If Not enabled1 AndAlso enabled2 Then Return 1      ' item2 first
+
+                ' If both disabled, don't change their relative order
+                If Not enabled1 AndAlso Not enabled2 Then Return 0
+
+                ' --- Now compare ENABLED items by hits first ---
+                Dim hits1 As Long = Long.Parse(item1.SubItems(4).Text)
+                Dim hits2 As Long = Long.Parse(item2.SubItems(4).Text)
+
+                Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
+
+                ' Enabled items with hits > 0 should sort ahead of hits = 0
+                If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
+                If hits1 <> 0 AndAlso hits2 = 0 Then Return -1   ' item1 goes above
+
+                ' If both have zero hits, do not reorder them
+                If bothZeroHits Then Return 0
+
+                ' If both are enabled, sort by dateOfLastOccurrence
+                Return If(soSortOrder = SortOrder.Ascending, item1.dateOfLastOccurrence.CompareTo(item2.dateOfLastOccurrence), item2.dateOfLastOccurrence.CompareTo(item1.dateOfLastOccurrence))
             Else
                 ' Compare them.
                 If Double.TryParse(strFirstString, dbl1) And Double.TryParse(strSecondString, dbl2) Then

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -83,8 +83,9 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1 As Long = Long.Parse(item1.SubItems(4).Text)
-                Dim hits2 As Long = Long.Parse(item2.SubItems(4).Text)
+                Dim hits1, hits2 As Long
+                If Not Long.TryParse(item1.SubItems(4).Text, hits1) Then hits1 = 0
+                If Not Long.TryParse(item2.SubItems(4).Text, hits2) Then hits2 = 0
 
                 Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
 
@@ -115,8 +116,9 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1 As Long = Long.Parse(item1.SubItems(4).Text)
-                Dim hits2 As Long = Long.Parse(item2.SubItems(4).Text)
+                Dim hits1, hits2 As Long
+                If Not Long.TryParse(item1.SubItems(4).Text, hits1) Then hits1 = 0
+                If Not Long.TryParse(item2.SubItems(4).Text, hits2) Then hits2 = 0
 
                 Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
 
@@ -144,8 +146,9 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1 As Long = Long.Parse(item1.SubItems(4).Text)
-                Dim hits2 As Long = Long.Parse(item2.SubItems(4).Text)
+                Dim hits1, hits2 As Long
+                If Not Long.TryParse(item1.SubItems(4).Text, hits1) Then hits1 = 0
+                If Not Long.TryParse(item2.SubItems(4).Text, hits2) Then hits2 = 0
 
                 Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
 

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -86,7 +86,7 @@
                 Dim hits1 As Integer = item1.intHits
                 Dim hits2 As Integer = item2.intHits
 
-                Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
+                Dim bothZeroHits As Boolean = hits1 = 0 AndAlso hits2 = 0
 
                 ' Enabled items with hits > 0 should sort ahead of hits = 0
                 If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
@@ -118,7 +118,7 @@
                 Dim hits1 As Integer = item1.intHits
                 Dim hits2 As Integer = item2.intHits
 
-                Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
+                Dim bothZeroHits As Boolean = hits1 = 0 AndAlso hits2 = 0
 
                 ' Enabled items with hits > 0 should sort ahead of hits = 0
                 If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
@@ -147,7 +147,7 @@
                 Dim hits1 As Integer = item1.intHits
                 Dim hits2 As Integer = item2.intHits
 
-                Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
+                Dim bothZeroHits As Boolean = hits1 = 0 AndAlso hits2 = 0
 
                 ' Enabled items with hits > 0 should sort ahead of hits = 0
                 If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -69,8 +69,35 @@
             strSecondString = If(lvSecondListView.SubItems.Count <= intColumnNumber, "", lvSecondListView.SubItems(intColumnNumber).Text)
 
             If intColumnNumber = 8 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
-                Dim timeSpan1 As TimeSpan = DirectCast(lvFirstListView, MyIgnoredListViewItem).timeSpanOfLastOccurrence
-                Dim timeSpan2 As TimeSpan = DirectCast(lvSecondListView, MyIgnoredListViewItem).timeSpanOfLastOccurrence
+                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+
+                Dim enabled1 As Boolean = item1.BoolEnabled
+                Dim enabled2 As Boolean = item2.BoolEnabled
+
+                ' Always keep enabled items above disabled items (independent of sort order)
+                If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
+                If Not enabled1 AndAlso enabled2 Then Return 1      ' item2 first
+
+                ' If both disabled, don't change their relative order
+                If Not enabled1 AndAlso Not enabled2 Then Return 0
+
+                ' --- Now compare ENABLED items by hits first ---
+                Dim hits1 As Long = Long.Parse(item1.SubItems(4).Text)
+                Dim hits2 As Long = Long.Parse(item2.SubItems(4).Text)
+
+                Dim bothZeroHits As Boolean = (hits1 = 0 AndAlso hits2 = 0)
+
+                ' Enabled items with hits > 0 should sort ahead of hits = 0
+                If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
+                If hits1 <> 0 AndAlso hits2 = 0 Then Return -1   ' item1 goes above
+
+                ' If both have zero hits, do not reorder them
+                If bothZeroHits Then Return 0
+
+                ' If both are enabled, sort by timeSpanOfLastOccurrence
+                Dim timeSpan1 As TimeSpan = item1.timeSpanOfLastOccurrence
+                Dim timeSpan2 As TimeSpan = item2.timeSpanOfLastOccurrence
 
                 Return If(soSortOrder = SortOrder.Ascending, timeSpan1.CompareTo(timeSpan2), timeSpan2.CompareTo(timeSpan1))
             Else

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -76,6 +76,7 @@ Partial Class Alerts
         '
         'AlertsListView
         '
+        Me.AlertsListView.AllowColumnReorder = True
         Me.AlertsListView.AllowDrop = True
         Me.AlertsListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -309,7 +309,18 @@ Public Class Alerts
 
             My.Settings.alerts = tempAlerts
             My.Settings.Save()
-        Catch
+        Catch ex As Exception
+            SyncLock SupportCode.ParentForm.dataGridLockObject
+                SupportCode.ParentForm.Logs.Rows.Add(
+                    SyslogParser.MakeLocalDataGridRowEntry(
+                        $"Unable to save user preferences on ""Alerts"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        SupportCode.ParentForm.Logs
+                    )
+                )
+
+                If SupportCode.ParentForm.ChkEnableAutoScroll.Checked Then SupportCode.ParentForm.Logs.FirstDisplayedScrollingRowIndex = SupportCode.ParentForm.Logs.Rows.Count - 1
+                SupportCode.ParentForm.NumberOfLogs.Text = $"Number of Log Entries: {SupportCode.ParentForm.Logs.Rows.Count:N0}"
+            End SyncLock
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -6,6 +6,7 @@ Public Class Alerts
     Private boolEditMode As Boolean = False
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
+    Private boolColumnOrderChanged As Boolean = False
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles AlertsListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -66,7 +67,12 @@ Public Class Alerts
                                                                     End Function)
     End Function
 
+    Private Sub AlertsListView_ColumnReordered(sender As Object, e As ColumnReorderedEventArgs) Handles AlertsListView.ColumnReordered
+        boolColumnOrderChanged = True
+    End Sub
+
     Private Sub Alerts_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        LoadColumnOrders(AlertsListView.Columns, My.Settings.alertsColumnOrder)
         BtnCancel.Visible = False
         Location = VerifyWindowLocation(My.Settings.alertsLocation, Me)
         Dim MyIgnoredListViewItem As New List(Of AlertsListViewItem)
@@ -278,6 +284,11 @@ Public Class Alerts
     End Sub
 
     Private Sub Alerts_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
+        If boolColumnOrderChanged Then
+            My.Settings.alertsColumnOrder = SaveColumnOrders(AlertsListView.Columns)
+            My.Settings.Save()
+        End If
+
         If Not boolChanged Then Exit Sub
 
         Dim newAlertsList As New ThreadSafetyLists.ThreadSafeAlertsList

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -287,7 +287,16 @@ Public Class Alerts
                 Dim AlertsClass As AlertsClass
 
                 For Each item As AlertsListViewItem In AlertsListView.Items
-                    AlertsClass = New AlertsClass() With {.StrLogText = item.StrLogText, .StrAlertText = item.StrAlertText, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .alertType = item.AlertType, .BoolEnabled = item.BoolEnabled, .BoolLimited = item.BoolLimited}
+                    AlertsClass = New AlertsClass() With {
+                        .StrLogText = item.StrLogText,
+                        .StrAlertText = item.StrAlertText,
+                        .BoolCaseSensitive = item.BoolCaseSensitive,
+                        .BoolRegex = item.BoolRegex,
+                        .alertType = item.AlertType,
+                        .BoolEnabled = item.BoolEnabled,
+                        .BoolLimited = item.BoolLimited
+                    }
+
                     If AlertsClass.BoolEnabled Then newAlertsList.Add(AlertsClass)
                     tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
                 Next

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -279,21 +279,31 @@ Public Class Alerts
 
     Private Sub Alerts_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         If boolChanged Then
-            alertsList.Clear()
-
-            Dim AlertsClass As AlertsClass
+            Dim newAlertsList As New ThreadSafetyLists.ThreadSafeAlertsList
             Dim tempAlerts As New Specialized.StringCollection()
+            Dim boolSuccess As Boolean = False
 
-            For Each item As AlertsListViewItem In AlertsListView.Items
-                AlertsClass = New AlertsClass() With {.StrLogText = item.StrLogText, .StrAlertText = item.StrAlertText, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .alertType = item.AlertType, .BoolEnabled = item.BoolEnabled, .boolLimited = item.BoolLimited}
-                If AlertsClass.BoolEnabled Then alertsList.Add(AlertsClass)
-                tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
-            Next
+            Try
+                Dim AlertsClass As AlertsClass
 
-            alertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+                For Each item As AlertsListViewItem In AlertsListView.Items
+                    AlertsClass = New AlertsClass() With {.StrLogText = item.StrLogText, .StrAlertText = item.StrAlertText, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .alertType = item.AlertType, .BoolEnabled = item.BoolEnabled, .BoolLimited = item.BoolLimited}
+                    If AlertsClass.BoolEnabled Then newAlertsList.Add(AlertsClass)
+                    tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
+                Next
 
-            My.Settings.alerts = tempAlerts
-            My.Settings.Save()
+                newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+                boolSuccess = True
+            Catch
+            Finally
+                If boolSuccess Then
+                    alertsList.Clear()
+                    alertsList.Merge(newAlertsList)
+
+                    My.Settings.alerts = tempAlerts
+                    My.Settings.Save()
+                End If
+            End Try
         End If
     End Sub
 

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -305,7 +305,7 @@ Public Class Alerts
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             alertsList.Clear()
-            alertsList.Merge(newAlertsList)
+            alertsList.Merge(newAlertsList.GetSnapshot())
 
             My.Settings.alerts = tempAlerts
             My.Settings.Save()

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -278,42 +278,42 @@ Public Class Alerts
     End Sub
 
     Private Sub Alerts_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
-        If boolChanged Then
-            Dim newAlertsList As New ThreadSafetyLists.ThreadSafeAlertsList
-            Dim tempAlerts As New Specialized.StringCollection()
-            Dim boolSuccess As Boolean = False
+        If Not boolChanged Then Exit Sub
 
-            Try
-                Dim AlertsClass As AlertsClass
+        Dim newAlertsList As New ThreadSafetyLists.ThreadSafeAlertsList
+        Dim tempAlerts As New Specialized.StringCollection()
+        Dim boolSuccess As Boolean = False
 
-                For Each item As AlertsListViewItem In AlertsListView.Items
-                    AlertsClass = New AlertsClass() With {
-                        .StrLogText = item.StrLogText,
-                        .StrAlertText = item.StrAlertText,
-                        .BoolCaseSensitive = item.BoolCaseSensitive,
-                        .BoolRegex = item.BoolRegex,
-                        .alertType = item.AlertType,
-                        .BoolEnabled = item.BoolEnabled,
-                        .BoolLimited = item.BoolLimited
-                    }
+        Try
+            Dim AlertsClass As AlertsClass
 
-                    If AlertsClass.BoolEnabled Then newAlertsList.Add(AlertsClass)
-                    tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
-                Next
+            For Each item As AlertsListViewItem In AlertsListView.Items
+                AlertsClass = New AlertsClass() With {
+                    .StrLogText = item.StrLogText,
+                    .StrAlertText = item.StrAlertText,
+                    .BoolCaseSensitive = item.BoolCaseSensitive,
+                    .BoolRegex = item.BoolRegex,
+                    .alertType = item.AlertType,
+                    .BoolEnabled = item.BoolEnabled,
+                    .BoolLimited = item.BoolLimited
+                }
 
-                newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-                boolSuccess = True
-            Catch
-            Finally
-                If boolSuccess Then
-                    alertsList.Clear()
-                    alertsList.Merge(newAlertsList)
+                If AlertsClass.BoolEnabled Then newAlertsList.Add(AlertsClass)
+                tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
+            Next
 
-                    My.Settings.alerts = tempAlerts
-                    My.Settings.Save()
-                End If
-            End Try
-        End If
+            newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            boolSuccess = True
+        Catch
+        Finally
+            If boolSuccess Then
+                alertsList.Clear()
+                alertsList.Merge(newAlertsList)
+
+                My.Settings.alerts = tempAlerts
+                My.Settings.Save()
+            End If
+        End Try
     End Sub
 
     Private Sub ListViewMenu_Opening(sender As Object, e As ComponentModel.CancelEventArgs) Handles ListViewMenu.Opening

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -282,7 +282,6 @@ Public Class Alerts
 
         Dim newAlertsList As New ThreadSafetyLists.ThreadSafeAlertsList
         Dim tempAlerts As New Specialized.StringCollection()
-        Dim boolSuccess As Boolean = False
 
         Try
             Dim AlertsClass As AlertsClass
@@ -303,16 +302,14 @@ Public Class Alerts
             Next
 
             newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            boolSuccess = True
-        Catch
-        Finally
-            If boolSuccess Then
-                alertsList.Clear()
-                alertsList.Merge(newAlertsList)
 
-                My.Settings.alerts = tempAlerts
-                My.Settings.Save()
-            End If
+            ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
+            alertsList.Clear()
+            alertsList.Merge(newAlertsList)
+
+            My.Settings.alerts = tempAlerts
+            My.Settings.Save()
+        Catch
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -171,7 +171,6 @@ Public Class ConfigureSysLogMirrorClients
     Private Sub ConfigureSysLogMirrorServers_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         Dim newServerList As New ThreadSafetyLists.ThreadSafeProxyServerList
         Dim tempServer As New Specialized.StringCollection()
-        Dim boolSuccess As Boolean = False
 
         Try
             Dim SysLogProxyServer As SysLogProxyServer
@@ -188,16 +187,13 @@ Public Class ConfigureSysLogMirrorClients
                 tempServer.Add(Newtonsoft.Json.JsonConvert.SerializeObject(SysLogProxyServer))
             Next
 
-            boolSuccess = True
-        Catch
-        Finally
-            If boolSuccess Then
-                serversList.Clear()
-                serversList.Merge(newServerList)
+            ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
+            serversList.Clear()
+            serversList.Merge(newServerList)
 
-                My.Settings.ServersToSendTo = tempServer
-                My.Settings.Save()
-            End If
+            My.Settings.ServersToSendTo = tempServer
+            My.Settings.Save()
+        Catch
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -193,7 +193,18 @@ Public Class ConfigureSysLogMirrorClients
 
             My.Settings.ServersToSendTo = tempServer
             My.Settings.Save()
-        Catch
+        Catch ex As Exception
+            SyncLock SupportCode.ParentForm.dataGridLockObject
+                SupportCode.ParentForm.Logs.Rows.Add(
+                    SyslogParser.MakeLocalDataGridRowEntry(
+                        $"Unable to save user preferences on ""Configure Syslog Mirror Servers"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        SupportCode.ParentForm.Logs
+                    )
+                )
+
+                If SupportCode.ParentForm.ChkEnableAutoScroll.Checked Then SupportCode.ParentForm.Logs.FirstDisplayedScrollingRowIndex = SupportCode.ParentForm.Logs.Rows.Count - 1
+                SupportCode.ParentForm.NumberOfLogs.Text = $"Number of Log Entries: {SupportCode.ParentForm.Logs.Rows.Count:N0}"
+            End SyncLock
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -189,7 +189,7 @@ Public Class ConfigureSysLogMirrorClients
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             serversList.Clear()
-            serversList.Merge(newServerList)
+            serversList.Merge(newServerList.GetSnapshot())
 
             My.Settings.ServersToSendTo = tempServer
             My.Settings.Save()

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -177,7 +177,13 @@ Public Class ConfigureSysLogMirrorClients
             Dim SysLogProxyServer As SysLogProxyServer
 
             For Each item As ServerListViewItem In servers.Items
-                SysLogProxyServer = New SysLogProxyServer() With {.ip = item.SubItems(0).Text, .port = Integer.Parse(item.SubItems(1).Text), .boolEnabled = item.BoolEnabled, .name = item.SubItems(3).Text}
+                SysLogProxyServer = New SysLogProxyServer() With {
+                    .ip = item.SubItems(0).Text,
+                    .port = Integer.Parse(item.SubItems(1).Text),
+                    .boolEnabled = item.BoolEnabled,
+                    .name = item.SubItems(3).Text
+                }
+
                 If SysLogProxyServer.boolEnabled Then newServerList.Add(SysLogProxyServer)
                 tempServer.Add(Newtonsoft.Json.JsonConvert.SerializeObject(SysLogProxyServer))
             Next

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -169,19 +169,30 @@ Public Class ConfigureSysLogMirrorClients
     End Sub
 
     Private Sub ConfigureSysLogMirrorServers_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
-        serversList.Clear()
-
-        Dim SysLogProxyServer As SysLogProxyServer
+        Dim newServerList As New ThreadSafetyLists.ThreadSafeProxyServerList
         Dim tempServer As New Specialized.StringCollection()
+        Dim boolSuccess As Boolean = False
 
-        For Each item As ServerListViewItem In servers.Items
-            SysLogProxyServer = New SysLogProxyServer() With {.ip = item.SubItems(0).Text, .port = Integer.Parse(item.SubItems(1).Text), .boolEnabled = item.BoolEnabled, .name = item.SubItems(3).Text}
-            If SysLogProxyServer.boolEnabled Then serversList.Add(SysLogProxyServer)
-            tempServer.Add(Newtonsoft.Json.JsonConvert.SerializeObject(SysLogProxyServer))
-        Next
+        Try
+            Dim SysLogProxyServer As SysLogProxyServer
 
-        My.Settings.ServersToSendTo = tempServer
-        My.Settings.Save()
+            For Each item As ServerListViewItem In servers.Items
+                SysLogProxyServer = New SysLogProxyServer() With {.ip = item.SubItems(0).Text, .port = Integer.Parse(item.SubItems(1).Text), .boolEnabled = item.BoolEnabled, .name = item.SubItems(3).Text}
+                If SysLogProxyServer.boolEnabled Then newServerList.Add(SysLogProxyServer)
+                tempServer.Add(Newtonsoft.Json.JsonConvert.SerializeObject(SysLogProxyServer))
+            Next
+
+            boolSuccess = True
+        Catch
+        Finally
+            If boolSuccess Then
+                serversList.Clear()
+                serversList.Merge(newServerList)
+
+                My.Settings.ServersToSendTo = tempServer
+                My.Settings.Save()
+            End If
+        End Try
     End Sub
 
     Private Sub ContextMenuStrip1_Opening(sender As Object, e As CancelEventArgs) Handles ContextMenuStrip1.Opening

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -73,9 +73,7 @@ Public Class Form1
             SelectLatestLogEntry()
             BtnSaveLogsToDisk.Enabled = True
 
-            SyncLock recentUniqueObjectsLock
-                recentUniqueObjects.Clear()
-            End SyncLock
+            recentUniqueObjects.Clear()
 
             NumberOfLogs.Text = $"Number of Log Entries: {Logs.Rows.Count:N0}"
         End SyncLock
@@ -400,32 +398,30 @@ Public Class Form1
 
         Dim sortedList As List(Of String)
 
-        SyncLock recentUniqueObjectsLock
-            If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                sortedList = recentUniqueObjects.logTypes.ToList()
-                sortedList.Sort()
+        If boxLimitBy.Text.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+            sortedList = recentUniqueObjects.logTypes.ToList()
+            sortedList.Sort()
 
-                boxLimiter.Items.AddRange(sortedList.ToArray)
-            ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                sortedList = recentUniqueObjects.processes.ToList()
-                sortedList.Sort()
+            boxLimiter.Items.AddRange(sortedList.ToArray)
+        ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+            sortedList = recentUniqueObjects.processes.ToList()
+            sortedList.Sort()
 
-                boxLimiter.Items.AddRange(sortedList.ToArray)
-            ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-                sortedList = recentUniqueObjects.hostNames.ToList()
-                sortedList.Sort()
+            boxLimiter.Items.AddRange(sortedList.ToArray)
+        ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+            sortedList = recentUniqueObjects.hostNames.ToList()
+            sortedList.Sort()
 
-                boxLimiter.Items.AddRange(sortedList.ToArray)
-            ElseIf boxLimitBy.Text.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-                sortedList = recentUniqueObjects.ipAddresses.ToList()
-                sortedList.Sort()
+            boxLimiter.Items.AddRange(sortedList.ToArray)
+        ElseIf boxLimitBy.Text.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+            sortedList = recentUniqueObjects.ipAddresses.ToList()
+            sortedList.Sort()
 
-                boxLimiter.Items.AddRange(sortedList.ToArray)
-            Else
-                boxLimiter.Text = "(Not Specified)"
-                boxLimiter.Enabled = False
-            End If
-        End SyncLock
+            boxLimiter.Items.AddRange(sortedList.ToArray)
+        Else
+            boxLimiter.Text = "(Not Specified)"
+            boxLimiter.Enabled = False
+        End If
     End Sub
 
     Private Function FormatSecondsToReadableTime(input As Integer) As String

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1223,6 +1223,7 @@ Public Class Form1
     End Sub
 
     Private Sub ZerooutIgnoredLogsCounterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ZerooutIgnoredLogsCounterToolStripMenuItem.Click
+        IgnoredLastEvent.Clear()
         IgnoredHits.Clear()
         longNumberOfIgnoredLogs = 0
         LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -14,7 +14,6 @@ Imports Free_SysLog.SyslogTcpServer.SyslogTcpServer
 Public Class Form1
     Private boolMaximizedBeforeMinimize As Boolean
     Private boolDoneLoading As Boolean = False
-    Public longNumberOfIgnoredLogs As Long = 0
     Public IgnoredLogs As New List(Of MyDataGridViewRow)
     Public IgnoredLogsLockingObject As New Object
     Public intSortColumnIndex As Integer = 0 ' Define intColumnNumber at class level

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1062,9 +1062,6 @@ Public Class Form1
 
     Private Sub Logs_ColumnHeaderMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles Logs.ColumnHeaderMouseClick
         If e.Button = MouseButtons.Left Then
-            ' Disable user sorting
-            Logs.AllowUserToOrderColumns = False
-
             Dim column As DataGridViewColumn = Logs.Columns(e.ColumnIndex)
             intSortColumnIndex = e.ColumnIndex
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -130,8 +130,52 @@ Public Class Form1
         End Select
     End Function
 
+    Public Sub WriteLogsToDisk()
+        SyncLock dataGridLockObject
+            Dim collectionOfSavedData As New List(Of SavedData)
+            Dim myItem As MyDataGridViewRow
+
+            Try
+                For Each item As DataGridViewRow In Logs.Rows
+                    If Not String.IsNullOrWhiteSpace(item.Cells(ColumnIndex_ComputedTime).Value) Then
+                        myItem = DirectCast(item, MyDataGridViewRow)
+
+                        collectionOfSavedData.Add(New SavedData With {
+                                                .time = myItem.Cells(ColumnIndex_ComputedTime).Value,
+                                                .logType = myItem.Cells(ColumnIndex_LogType).Value,
+                                                .ip = myItem.Cells(ColumnIndex_IPAddress).Value,
+                                                .appName = myItem.Cells(ColumnIndex_RemoteProcess).Value,
+                                                .log = myItem.Cells(ColumnIndex_LogText).Value,
+                                                .hostname = myItem.Cells(ColumnIndex_Hostname).Value,
+                                                .DateObject = myItem.DateObject,
+                                                .BoolAlerted = myItem.BoolAlerted,
+                                                .ServerDate = myItem.ServerDate,
+                                                .rawLogData = myItem.RawLogData,
+                                                .alertText = myItem.AlertText,
+                                                .alertType = myItem.alertType
+                                              })
+                    End If
+                Next
+
+                Using fileStream As New StreamWriter(strPathToDataFile & ".new")
+                    fileStream.Write(Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
+                End Using
+
+                File.Delete(strPathToDataFile)
+                File.Move(strPathToDataFile & ".new", strPathToDataFile)
+            Catch ex As Exception
+                MsgBox("A critical error occurred while writing log data to disk. The old data had been saved to prevent data corruption and loss.", MsgBoxStyle.Critical, Text)
+                Process.GetCurrentProcess.Kill()
+            End Try
+
+            LblLogFileSize.Text = $"Log File Size: {FileSizeToHumanSize(New FileInfo(strPathToDataFile).Length)}"
+
+            BtnSaveLogsToDisk.Enabled = False
+        End SyncLock
+    End Sub
+
     Private Sub MakeLogBackup()
-        DataHandling.WriteLogsToDisk()
+        WriteLogsToDisk()
         File.Copy(strPathToDataFile, GetUniqueFileName(Path.Combine(strPathToDataBackupFolder, $"{GetDateStringBasedOnUserPreference(Now.AddDays(-1))} Backup.json")))
     End Sub
 
@@ -208,7 +252,7 @@ Public Class Form1
     End Sub
 
     Private Sub SaveTimer_Tick(sender As Object, e As EventArgs) Handles SaveTimer.Tick
-        DataHandling.WriteLogsToDisk()
+        WriteLogsToDisk()
         LblAutoSaved.Text = $"Last Auto-Saved At: {Date.Now:h:mm:ss tt}"
     End Sub
 
@@ -876,7 +920,7 @@ Public Class Form1
     End Sub
 
     Public Sub SaveLogsToDiskSub()
-        DataHandling.WriteLogsToDisk()
+        WriteLogsToDisk()
         LblAutoSaved.Text = $"Last Saved At: {Date.Now:h:mm:ss tt}"
         SaveTimer.Enabled = False
         SaveTimer.Enabled = True
@@ -923,7 +967,7 @@ Public Class Form1
         If My.Settings.saveIgnoredLogCount Then My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
         My.Settings.logsColumnOrder = SaveColumnOrders(Logs.Columns)
         My.Settings.Save()
-        DataHandling.WriteLogsToDisk()
+        WriteLogsToDisk()
 
         If boolDoWeOwnTheMutex Then
             SendMessageToSysLogServer(strTerminate, My.Settings.sysLogPort)
@@ -1832,7 +1876,7 @@ Public Class Form1
                 Logs.DefaultCellStyle.Font = My.Settings.font
                 Logs.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
 
-                DataHandling.WriteLogsToDisk()
+                WriteLogsToDisk()
 
                 SyncLock dataGridLockObject
                     Threading.Tasks.Task.Run(Sub() LoadDataFile(False))

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -114,15 +114,26 @@ Public Class Hostnames
 
     Private Sub Hostnames_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         Dim tempHostnames As New Specialized.StringCollection()
-        SupportCode.hostnames.Clear()
+        Dim newHostNames As New Concurrent.ConcurrentDictionary(Of String, String)
+        Dim boolSuccess As Boolean = False
 
-        For Each item As ListViewItem In ListHostnames.Items
-            tempHostnames.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}))
-            SupportCode.hostnames(item.SubItems(0).Text) = item.SubItems(1).Text
-        Next
+        Try
+            For Each item As ListViewItem In ListHostnames.Items
+                tempHostnames.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}))
+                newHostNames(item.SubItems(0).Text) = item.SubItems(1).Text
+            Next
 
-        My.Settings.hostnames = tempHostnames
-        My.Settings.Save()
+            boolSuccess = True
+        Catch
+        Finally
+            If boolSuccess Then
+                SupportCode.hostnames.Clear()
+                SupportCode.hostnames = newHostNames
+
+                My.Settings.hostnames = tempHostnames
+                My.Settings.Save()
+            End If
+        End Try
     End Sub
 
     Private Sub BtnDelete_Click(sender As Object, e As EventArgs) Handles BtnDelete.Click

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -118,8 +118,11 @@ Public Class Hostnames
         Dim boolSuccess As Boolean = False
 
         Try
+            Dim hostName As CustomHostname
+
             For Each item As ListViewItem In ListHostnames.Items
-                tempHostnames.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}))
+                hostName = New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}
+                tempHostnames.Add(Newtonsoft.Json.JsonConvert.SerializeObject(hostName))
                 newHostNames(item.SubItems(0).Text) = item.SubItems(1).Text
             Next
 

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -135,7 +135,18 @@ Public Class Hostnames
 
             My.Settings.hostnames = tempHostnames
             My.Settings.Save()
-        Catch
+        Catch ex As Exception
+            SyncLock SupportCode.ParentForm.dataGridLockObject
+                SupportCode.ParentForm.Logs.Rows.Add(
+                    SyslogParser.MakeLocalDataGridRowEntry(
+                        $"Unable to save user preferences on ""Hostnames"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        SupportCode.ParentForm.Logs
+                    )
+                )
+
+                If SupportCode.ParentForm.ChkEnableAutoScroll.Checked Then SupportCode.ParentForm.Logs.FirstDisplayedScrollingRowIndex = SupportCode.ParentForm.Logs.Rows.Count - 1
+                SupportCode.ParentForm.NumberOfLogs.Text = $"Number of Log Entries: {SupportCode.ParentForm.Logs.Rows.Count:N0}"
+            End SyncLock
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -115,7 +115,6 @@ Public Class Hostnames
     Private Sub Hostnames_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         Dim tempHostnames As New Specialized.StringCollection()
         Dim newHostNames As New Concurrent.ConcurrentDictionary(Of String, String)
-        Dim boolSuccess As Boolean = False
 
         Try
             Dim hostName As CustomHostname
@@ -130,16 +129,13 @@ Public Class Hostnames
                 newHostNames(item.SubItems(0).Text) = item.SubItems(1).Text
             Next
 
-            boolSuccess = True
-        Catch
-        Finally
-            If boolSuccess Then
-                SupportCode.hostnames.Clear()
-                SupportCode.hostnames = newHostNames
+            ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
+            SupportCode.hostnames.Clear()
+            SupportCode.hostnames = newHostNames
 
-                My.Settings.hostnames = tempHostnames
-                My.Settings.Save()
-            End If
+            My.Settings.hostnames = tempHostnames
+            My.Settings.Save()
+        Catch
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -121,7 +121,11 @@ Public Class Hostnames
             Dim hostName As CustomHostname
 
             For Each item As ListViewItem In ListHostnames.Items
-                hostName = New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}
+                hostName = New CustomHostname() With {
+                    .ip = item.SubItems(0).Text,
+                    .deviceName = item.SubItems(1).Text
+                }
+
                 tempHostnames.Add(Newtonsoft.Json.JsonConvert.SerializeObject(hostName))
                 newHostNames(item.SubItems(0).Text) = item.SubItems(1).Text
             Next

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -57,6 +57,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.txtComment = New System.Windows.Forms.TextBox()
         Me.lblCommentLabel = New System.Windows.Forms.Label()
         Me.lblTotalHits = New System.Windows.Forms.Label()
+        Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -87,7 +88,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -368,6 +369,11 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblTotalHits.TabIndex = 51
         Me.lblTotalHits.Text = "Total Ignored Hits: 0"
         '
+        'colDateOfLastEvent
+        '
+        Me.colDateOfLastEvent.Text = "Date of Last Event"
+        Me.colDateOfLastEvent.Width = 240
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -440,4 +446,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents lblCommentLabel As Label
     Friend WithEvents ResetHitsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents lblTotalHits As Label
+    Friend WithEvents colDateOfLastEvent As ColumnHeader
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -59,6 +59,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblTotalHits = New System.Windows.Forms.Label()
         Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.btnUpdateHits = New System.Windows.Forms.Button()
+        Me.colSecondsAgo = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -89,7 +90,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent, Me.colSecondsAgo})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -385,6 +386,11 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnUpdateHits.Text = "Update Hits and Last Events"
         Me.btnUpdateHits.UseVisualStyleBackColor = True
         '
+        'colSecondsAgo
+        '
+        Me.colSecondsAgo.Text = "Seconds Ago"
+        Me.colSecondsAgo.Width = 80
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -460,4 +466,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents lblTotalHits As Label
     Friend WithEvents colDateOfLastEvent As ColumnHeader
     Friend WithEvents btnUpdateHits As Button
+    Friend WithEvents colSecondsAgo As ColumnHeader
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -86,6 +86,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         'IgnoredListView
         '
+        Me.IgnoredListView.AllowColumnReorder = True
         Me.IgnoredListView.AllowDrop = True
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -390,7 +390,7 @@ Partial Class IgnoredWordsAndPhrases
         'colSinceLastEvent
         '
         Me.colSinceLastEvent.Text = "Since Last Event"
-        Me.colSinceLastEvent.Width = 80
+        Me.colSinceLastEvent.Width = 100
         '
         'IgnoredWordsAndPhrases
         '

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -58,6 +58,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblCommentLabel = New System.Windows.Forms.Label()
         Me.lblTotalHits = New System.Windows.Forms.Label()
         Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.btnUpdateHits = New System.Windows.Forms.Button()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -363,7 +364,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.lblTotalHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblTotalHits.AutoSize = True
-        Me.lblTotalHits.Location = New System.Drawing.Point(407, 256)
+        Me.lblTotalHits.Location = New System.Drawing.Point(583, 256)
         Me.lblTotalHits.Name = "lblTotalHits"
         Me.lblTotalHits.Size = New System.Drawing.Size(103, 13)
         Me.lblTotalHits.TabIndex = 51
@@ -374,11 +375,22 @@ Partial Class IgnoredWordsAndPhrases
         Me.colDateOfLastEvent.Text = "Date of Last Event"
         Me.colDateOfLastEvent.Width = 240
         '
+        'btnUpdateHits
+        '
+        Me.btnUpdateHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnUpdateHits.Location = New System.Drawing.Point(407, 251)
+        Me.btnUpdateHits.Name = "btnUpdateHits"
+        Me.btnUpdateHits.Size = New System.Drawing.Size(170, 23)
+        Me.btnUpdateHits.TabIndex = 52
+        Me.btnUpdateHits.Text = "Update Hits and Last Events"
+        Me.btnUpdateHits.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1004, 437)
+        Me.Controls.Add(Me.btnUpdateHits)
         Me.Controls.Add(Me.lblTotalHits)
         Me.Controls.Add(Me.ChkRemoteProcess)
         Me.Controls.Add(Me.btnDeleteDuringEditing)
@@ -447,4 +459,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents ResetHitsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents lblTotalHits As Label
     Friend WithEvents colDateOfLastEvent As ColumnHeader
+    Friend WithEvents btnUpdateHits As Button
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -59,7 +59,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblTotalHits = New System.Windows.Forms.Label()
         Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.btnUpdateHits = New System.Windows.Forms.Button()
-        Me.colSecondsAgo = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.colSinceLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -91,7 +91,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent, Me.colSecondsAgo})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent, Me.colSinceLastEvent})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -387,10 +387,10 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnUpdateHits.Text = "Update Hits and Last Events"
         Me.btnUpdateHits.UseVisualStyleBackColor = True
         '
-        'colSecondsAgo
+        'colSinceLastEvent
         '
-        Me.colSecondsAgo.Text = "Seconds Ago"
-        Me.colSecondsAgo.Width = 80
+        Me.colSinceLastEvent.Text = "Since Last Event"
+        Me.colSinceLastEvent.Width = 80
         '
         'IgnoredWordsAndPhrases
         '
@@ -467,5 +467,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents lblTotalHits As Label
     Friend WithEvents colDateOfLastEvent As ColumnHeader
     Friend WithEvents btnUpdateHits As Button
-    Friend WithEvents colSecondsAgo As ColumnHeader
+    Friend WithEvents colSinceLastEvent As ColumnHeader
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -366,7 +366,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.lblTotalHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblTotalHits.AutoSize = True
-        Me.lblTotalHits.Location = New System.Drawing.Point(583, 256)
+        Me.lblTotalHits.Location = New System.Drawing.Point(592, 256)
         Me.lblTotalHits.Name = "lblTotalHits"
         Me.lblTotalHits.Size = New System.Drawing.Size(103, 13)
         Me.lblTotalHits.TabIndex = 51
@@ -382,9 +382,9 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnUpdateHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.btnUpdateHits.Location = New System.Drawing.Point(407, 251)
         Me.btnUpdateHits.Name = "btnUpdateHits"
-        Me.btnUpdateHits.Size = New System.Drawing.Size(170, 23)
+        Me.btnUpdateHits.Size = New System.Drawing.Size(179, 23)
         Me.btnUpdateHits.TabIndex = 52
-        Me.btnUpdateHits.Text = "Update Hits and Last Events"
+        Me.btnUpdateHits.Text = "Update Hits and Last Events (F5)"
         Me.btnUpdateHits.UseVisualStyleBackColor = True
         '
         'colSinceLastEvent

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -56,6 +56,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnResetHits = New System.Windows.Forms.Button()
         Me.txtComment = New System.Windows.Forms.TextBox()
         Me.lblCommentLabel = New System.Windows.Forms.Label()
+        Me.lblTotalHits = New System.Windows.Forms.Label()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -357,11 +358,22 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblCommentLabel.TabIndex = 50
         Me.lblCommentLabel.Text = "Comment"
         '
+        'lblTotalHits
+        '
+        Me.lblTotalHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.lblTotalHits.AutoSize = True
+        Me.lblTotalHits.Location = New System.Drawing.Point(407, 256)
+        Me.lblTotalHits.Name = "lblTotalHits"
+        Me.lblTotalHits.Size = New System.Drawing.Size(103, 13)
+        Me.lblTotalHits.TabIndex = 51
+        Me.lblTotalHits.Text = "Total Ignored Hits: 0"
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1004, 437)
+        Me.Controls.Add(Me.lblTotalHits)
         Me.Controls.Add(Me.ChkRemoteProcess)
         Me.Controls.Add(Me.btnDeleteDuringEditing)
         Me.Controls.Add(Me.BtnCancel)
@@ -427,4 +439,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents txtComment As TextBox
     Friend WithEvents lblCommentLabel As Label
     Friend WithEvents ResetHitsToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents lblTotalHits As Label
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -537,6 +537,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub btnUpdateHits_Click(sender As Object, e As EventArgs) Handles btnUpdateHits.Click
         Dim longTotalHits As Long = 0
+        Dim intSecondsSinceLastEvent As Integer
 
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
             Dim longHits As Long = 0
@@ -549,7 +550,9 @@ Public Class IgnoredWordsAndPhrases
 
             If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
                 dateOfLastEvent = dateOfLastEvent.ToLocalTime
-                item.SubItems(7).Text = dateOfLastEvent.ToLongDateString & " " & dateOfLastEvent.ToLongTimeString
+                intSecondsSinceLastEvent = (Now.ToLocalTime - dateOfLastEvent).TotalSeconds
+                item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
+                item.SubItems(8).Text = intSecondsSinceLastEvent.ToString("N0")
             End If
         Next
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -129,7 +129,16 @@ Public Class IgnoredWordsAndPhrases
                 Dim ignoredClass As IgnoredClass
 
                 For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment}
+                    ignoredClass = New IgnoredClass() With {
+                        .StrIgnore = item.SubItems(0).Text,
+                        .BoolCaseSensitive = item.BoolCaseSensitive,
+                        .BoolRegex = item.BoolRegex,
+                        .BoolEnabled = item.BoolEnabled,
+                        .IgnoreType = item.IgnoreType,
+                        .dateCreated = item.dateCreated,
+                        .strComment = item.strComment
+                    }
+
                     If ignoredClass.BoolEnabled Then newIgnoredList.Add(ignoredClass)
                     tempIgnoredRules.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
                 Next

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -172,11 +172,15 @@ Public Class IgnoredWordsAndPhrases
         Location = VerifyWindowLocation(My.Settings.ignoredWordsLocation, Me)
         Dim MyIgnoredListViewItem As New List(Of MyIgnoredListViewItem)
 
+        Dim longTotalHits As Long = 0
+
         If My.Settings.ignored2 IsNot Nothing AndAlso My.Settings.ignored2.Count > 0 Then
             For Each strJSONString As String In My.Settings.ignored2
-                MyIgnoredListViewItem.Add(Newtonsoft.Json.JsonConvert.DeserializeObject(Of IgnoredClass)(strJSONString, JSONDecoderSettingsForSettingsFiles).ToListViewItem())
+                MyIgnoredListViewItem.Add(Newtonsoft.Json.JsonConvert.DeserializeObject(Of IgnoredClass)(strJSONString, JSONDecoderSettingsForSettingsFiles).ToListViewItem(longTotalHits))
             Next
         End If
+
+        lblTotalHits.Text = $"Total Ignored Hits: {longTotalHits:N0}"
 
         IgnoredListView.Items.AddRange(MyIgnoredListViewItem.ToArray())
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -602,6 +602,7 @@ Public Class IgnoredWordsAndPhrases
                 dateOfLastEvent = dateOfLastEvent.ToLocalTime
                 sinceLastEvent = Now.ToLocalTime - dateOfLastEvent
                 item.timeSpanOfLastOccurrence = sinceLastEvent
+                item.dateOfLastOccurrence = dateOfLastEvent
                 item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
                 item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
             End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -610,5 +610,7 @@ Public Class IgnoredWordsAndPhrases
         Next
 
         lblTotalHits.Text = $"Total Ignored Hits: {longTotalHits:N0}"
+
+        If IgnoredListView.ListViewItemSorter IsNot Nothing Then IgnoredListView.Sort()
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -3,6 +3,7 @@
 Public Class IgnoredWordsAndPhrases
     Private boolDoneLoading As Boolean = False
     Public boolChanged As Boolean = False
+    Private boolColumnOrderChanged As Boolean = False
     Private boolEditMode As Boolean = False
     Public strIgnoredPattern As String = Nothing
     Private draggedItem As ListViewItem
@@ -119,7 +120,16 @@ Public Class IgnoredWordsAndPhrases
         End If
     End Sub
 
+    Private Sub IgnoredListView_ColumnReordered(sender As Object, e As ColumnReorderedEventArgs) Handles IgnoredListView.ColumnReordered
+        boolColumnOrderChanged = True
+    End Sub
+
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
+        If boolColumnOrderChanged Then
+            My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveListViewColumnOrder(IgnoredListView)
+            My.Settings.Save()
+        End If
+
         If Not boolChanged Then Exit Sub
 
         Dim newIgnoredList As New ThreadSafetyLists.ThreadSafeIgnoredList
@@ -167,6 +177,8 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
+        LoadSavedListViewColumnOrder(IgnoredListView, My.Settings.IgnoredWordsAndPhrasesColumnOrder)
+
         BtnCancel.Visible = False
         btnDeleteDuringEditing.Visible = False
         Location = VerifyWindowLocation(My.Settings.ignoredWordsLocation, Me)

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -126,7 +126,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         If boolColumnOrderChanged Then
-            My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveListViewColumnOrder(IgnoredListView.Columns)
+            My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveColumnOrders(IgnoredListView.Columns)
             My.Settings.Save()
         End If
 
@@ -177,7 +177,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
-        LoadSavedListViewColumnOrder(IgnoredListView.Columns, My.Settings.IgnoredWordsAndPhrasesColumnOrder)
+        LoadColumnOrders(IgnoredListView.Columns, My.Settings.IgnoredWordsAndPhrasesColumnOrder)
 
         BtnCancel.Visible = False
         btnDeleteDuringEditing.Visible = False

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -189,6 +189,7 @@ Public Class IgnoredWordsAndPhrases
         CaseSensitive.Width = My.Settings.colIgnoredCaseSensitive
         ColEnabled.Width = My.Settings.colIgnoredEnabled
         colDateCreated.Width = My.Settings.colIgnoredDateCreated
+        colDateOfLastEvent.Width = My.Settings.DateOfLastEventColumnWidth
 
         Size = My.Settings.ConfigureIgnoredSize
 
@@ -359,6 +360,7 @@ Public Class IgnoredWordsAndPhrases
             My.Settings.colIgnoredCaseSensitive = CaseSensitive.Width
             My.Settings.colIgnoredEnabled = ColEnabled.Width
             My.Settings.colIgnoredDateCreated = colDateCreated.Width
+            My.Settings.DateOfLastEventColumnWidth = colDateOfLastEvent.Width
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -202,6 +202,7 @@ Public Class IgnoredWordsAndPhrases
         ColEnabled.Width = My.Settings.colIgnoredEnabled
         colDateCreated.Width = My.Settings.colIgnoredDateCreated
         colDateOfLastEvent.Width = My.Settings.DateOfLastEventColumnWidth
+        colSinceLastEvent.Width = My.Settings.ColSinceLastEventWidth
 
         Size = My.Settings.ConfigureIgnoredSize
 
@@ -373,6 +374,7 @@ Public Class IgnoredWordsAndPhrases
             My.Settings.colIgnoredEnabled = ColEnabled.Width
             My.Settings.colIgnoredDateCreated = colDateCreated.Width
             My.Settings.DateOfLastEventColumnWidth = colDateOfLastEvent.Width
+            My.Settings.ColSinceLastEventWidth = colSinceLastEvent.Width
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -124,7 +124,6 @@ Public Class IgnoredWordsAndPhrases
 
         Dim newIgnoredList As New ThreadSafetyLists.ThreadSafeIgnoredList
         Dim tempIgnoredRules As New Specialized.StringCollection()
-        Dim boolSuccess As Boolean = False
 
         Try
             Dim ignoredClass As IgnoredClass
@@ -145,16 +144,14 @@ Public Class IgnoredWordsAndPhrases
             Next
 
             newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            boolSuccess = True
-        Catch
-        Finally
-            If boolSuccess Then
-                ignoredList.Clear()
-                ignoredList.Merge(newIgnoredList)
 
-                My.Settings.ignored2 = tempIgnoredRules
-                My.Settings.Save()
-            End If
+            ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
+            ignoredList.Clear()
+            ignoredList.Merge(newIgnoredList)
+
+            My.Settings.ignored2 = tempIgnoredRules
+            My.Settings.Save()
+        Catch
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -147,7 +147,7 @@ Public Class IgnoredWordsAndPhrases
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             ignoredList.Clear()
-            ignoredList.Merge(newIgnoredList)
+            ignoredList.Merge(newIgnoredList.GetSnapshot())
 
             My.Settings.ignored2 = tempIgnoredRules
             My.Settings.Save()

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -121,21 +121,31 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         If boolChanged Then
-            ignoredList.Clear()
+            Dim newIgnoredList As New ThreadSafetyLists.ThreadSafeIgnoredList
+            Dim tempIgnoredRules As New Specialized.StringCollection()
+            Dim boolSuccess As Boolean = False
 
-            Dim ignoredClass As IgnoredClass
-            Dim listOfIgnoredRulesToBeSavedToSettings As New Specialized.StringCollection()
+            Try
+                Dim ignoredClass As IgnoredClass
 
-            For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment}
-                If ignoredClass.BoolEnabled Then ignoredList.Add(ignoredClass)
-                listOfIgnoredRulesToBeSavedToSettings.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
-            Next
+                For Each item As MyIgnoredListViewItem In IgnoredListView.Items
+                    ignoredClass = New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment}
+                    If ignoredClass.BoolEnabled Then newIgnoredList.Add(ignoredClass)
+                    tempIgnoredRules.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
+                Next
 
-            ignoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
+                newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
+                boolSuccess = True
+            Catch
+            Finally
+                If boolSuccess Then
+                    ignoredList.Clear()
+                    ignoredList.Merge(newIgnoredList)
 
-            My.Settings.ignored2 = listOfIgnoredRulesToBeSavedToSettings
-            My.Settings.Save()
+                    My.Settings.ignored2 = tempIgnoredRules
+                    My.Settings.Save()
+                End If
+            End Try
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -126,7 +126,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         If boolColumnOrderChanged Then
-            My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveListViewColumnOrder(IgnoredListView)
+            My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveListViewColumnOrder(IgnoredListView.Columns)
             My.Settings.Save()
         End If
 
@@ -177,7 +177,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
-        LoadSavedListViewColumnOrder(IgnoredListView, My.Settings.IgnoredWordsAndPhrasesColumnOrder)
+        LoadSavedListViewColumnOrder(IgnoredListView.Columns, My.Settings.IgnoredWordsAndPhrasesColumnOrder)
 
         BtnCancel.Visible = False
         btnDeleteDuringEditing.Visible = False

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -446,7 +446,11 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
-        If e.KeyCode = Keys.Escape Then Close()
+        If e.KeyCode = Keys.Escape Then
+            Close()
+        ElseIf e.KeyCode = Keys.F5 Then
+            btnUpdateHits.PerformClick()
+        End If
     End Sub
 
     Private Sub btnDeleteAll_Click(sender As Object, e As EventArgs) Handles btnDeleteAll.Click

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -518,7 +518,45 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredListView_ColumnClick(sender As Object, e As ColumnClickEventArgs) Handles IgnoredListView.ColumnClick
-        SortByClickedColumn(IgnoredListView, e.Column, m_SortingColumn)
+        SortByClickedColumnForIgnoredList(IgnoredListView, e.Column, m_SortingColumn)
+    End Sub
+
+    Private Sub SortByClickedColumnForIgnoredList(ByRef ListView As ListView, intColumn As Integer, ByRef m_SortingColumn As ColumnHeader)
+        ' Get the new sorting column.
+        Dim new_sorting_column As ColumnHeader = ListView.Columns(intColumn)
+
+        ' Figure out the new sorting order.
+        Dim sort_order As SortOrder
+        If m_SortingColumn Is Nothing Then
+            ' New column. Sort ascending.
+            sort_order = SortOrder.Ascending
+        Else
+            ' See if this is the same column.
+            If new_sorting_column.Equals(m_SortingColumn) Then
+                ' Same column. Switch the sort order.
+                If m_SortingColumn.Text.StartsWith("> ") Then
+                    sort_order = SortOrder.Descending
+                Else
+                    sort_order = SortOrder.Ascending
+                End If
+            Else
+                ' New column. Sort ascending.
+                sort_order = SortOrder.Ascending
+            End If
+
+            ' Remove the old sort indicator.
+            m_SortingColumn.Text = m_SortingColumn.Text.Substring(2)
+        End If
+
+        ' Display the new sort order.
+        m_SortingColumn = new_sorting_column
+        m_SortingColumn.Text = If(sort_order = SortOrder.Ascending, "> " & m_SortingColumn.Text, "< " & m_SortingColumn.Text)
+
+        ' Create a comparer.
+        ListView.ListViewItemSorter = New listViewSorter.IgnoredWordsAndPhrasesListViewComparer(intColumn, sort_order)
+
+        ' Sort.
+        ListView.Sort()
     End Sub
 
     Private Sub btnResetHits_Click(sender As Object, e As EventArgs) Handles btnResetHits.Click
@@ -563,6 +601,7 @@ Public Class IgnoredWordsAndPhrases
             If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
                 dateOfLastEvent = dateOfLastEvent.ToLocalTime
                 sinceLastEvent = Now.ToLocalTime - dateOfLastEvent
+                item.timeSpanOfLastOccurrence = sinceLastEvent
                 item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
                 item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
             End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -151,7 +151,18 @@ Public Class IgnoredWordsAndPhrases
 
             My.Settings.ignored2 = tempIgnoredRules
             My.Settings.Save()
-        Catch
+        Catch ex As Exception
+            SyncLock SupportCode.ParentForm.dataGridLockObject
+                SupportCode.ParentForm.Logs.Rows.Add(
+                    SyslogParser.MakeLocalDataGridRowEntry(
+                        $"Unable to save user preferences on ""Ignored Words and Phrases"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        SupportCode.ParentForm.Logs
+                    )
+                )
+
+                If SupportCode.ParentForm.ChkEnableAutoScroll.Checked Then SupportCode.ParentForm.Logs.FirstDisplayedScrollingRowIndex = SupportCode.ParentForm.Logs.Rows.Count - 1
+                SupportCode.ParentForm.NumberOfLogs.Text = $"Number of Log Entries: {SupportCode.ParentForm.Logs.Rows.Count:N0}"
+            End SyncLock
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -590,12 +590,12 @@ Public Class IgnoredWordsAndPhrases
         Dim sinceLastEvent As TimeSpan
 
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-            Dim longHits As Long = 0
+            Dim intHits As Integer = 0
             Dim dateOfLastEvent As Date = Date.MinValue
 
-            If IgnoredHits.TryGetValue(item.SubItems(0).Text, longHits) Then
-                item.SubItems(4).Text = longHits.ToString("N0")
-                longTotalHits += longHits
+            If IgnoredHits.TryGetValue(item.SubItems(0).Text, intHits) Then
+                item.SubItems(4).Text = intHits.ToString("N0")
+                longTotalHits += intHits
             End If
 
             If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
@@ -605,6 +605,7 @@ Public Class IgnoredWordsAndPhrases
                 item.dateOfLastOccurrence = dateOfLastEvent
                 item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
                 item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
+                item.intHits = intHits
             End If
         Next
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -534,4 +534,25 @@ Public Class IgnoredWordsAndPhrases
             Next
         End If
     End Sub
+
+    Private Sub btnUpdateHits_Click(sender As Object, e As EventArgs) Handles btnUpdateHits.Click
+        Dim longTotalHits As Long = 0
+
+        For Each item As MyIgnoredListViewItem In IgnoredListView.Items
+            Dim longHits As Long = 0
+            Dim dateOfLastEvent As Date = Date.MinValue
+
+            If IgnoredHits.TryGetValue(item.SubItems(0).Text, longHits) Then
+                item.SubItems(4).Text = longHits.ToString("N0")
+                longTotalHits += longHits
+            End If
+
+            If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
+                dateOfLastEvent = dateOfLastEvent.ToLocalTime
+                item.SubItems(7).Text = dateOfLastEvent.ToLongDateString & " " & dateOfLastEvent.ToLongTimeString
+            End If
+        Next
+
+        lblTotalHits.Text = $"Total Ignored Hits: {longTotalHits:N0}"
+    End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -120,42 +120,42 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
-        If boolChanged Then
-            Dim newIgnoredList As New ThreadSafetyLists.ThreadSafeIgnoredList
-            Dim tempIgnoredRules As New Specialized.StringCollection()
-            Dim boolSuccess As Boolean = False
+        If Not boolChanged Then Exit Sub
 
-            Try
-                Dim ignoredClass As IgnoredClass
+        Dim newIgnoredList As New ThreadSafetyLists.ThreadSafeIgnoredList
+        Dim tempIgnoredRules As New Specialized.StringCollection()
+        Dim boolSuccess As Boolean = False
 
-                For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                    ignoredClass = New IgnoredClass() With {
-                        .StrIgnore = item.SubItems(0).Text,
-                        .BoolCaseSensitive = item.BoolCaseSensitive,
-                        .BoolRegex = item.BoolRegex,
-                        .BoolEnabled = item.BoolEnabled,
-                        .IgnoreType = item.IgnoreType,
-                        .dateCreated = item.dateCreated,
-                        .strComment = item.strComment
-                    }
+        Try
+            Dim ignoredClass As IgnoredClass
 
-                    If ignoredClass.BoolEnabled Then newIgnoredList.Add(ignoredClass)
-                    tempIgnoredRules.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
-                Next
+            For Each item As MyIgnoredListViewItem In IgnoredListView.Items
+                ignoredClass = New IgnoredClass() With {
+                    .StrIgnore = item.SubItems(0).Text,
+                    .BoolCaseSensitive = item.BoolCaseSensitive,
+                    .BoolRegex = item.BoolRegex,
+                    .BoolEnabled = item.BoolEnabled,
+                    .IgnoreType = item.IgnoreType,
+                    .dateCreated = item.dateCreated,
+                    .strComment = item.strComment
+                }
 
-                newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
-                boolSuccess = True
-            Catch
-            Finally
-                If boolSuccess Then
-                    ignoredList.Clear()
-                    ignoredList.Merge(newIgnoredList)
+                If ignoredClass.BoolEnabled Then newIgnoredList.Add(ignoredClass)
+                tempIgnoredRules.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
+            Next
 
-                    My.Settings.ignored2 = tempIgnoredRules
-                    My.Settings.Save()
-                End If
-            End Try
-        End If
+            newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            boolSuccess = True
+        Catch
+        Finally
+            If boolSuccess Then
+                ignoredList.Clear()
+                ignoredList.Merge(newIgnoredList)
+
+                My.Settings.ignored2 = tempIgnoredRules
+                My.Settings.Save()
+            End If
+        End Try
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -549,7 +549,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub btnUpdateHits_Click(sender As Object, e As EventArgs) Handles btnUpdateHits.Click
         Dim longTotalHits As Long = 0
-        Dim intSecondsSinceLastEvent As Integer
+        Dim sinceLastEvent As TimeSpan
 
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
             Dim longHits As Long = 0
@@ -562,9 +562,9 @@ Public Class IgnoredWordsAndPhrases
 
             If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
                 dateOfLastEvent = dateOfLastEvent.ToLocalTime
-                intSecondsSinceLastEvent = (Now.ToLocalTime - dateOfLastEvent).TotalSeconds
+                sinceLastEvent = Now.ToLocalTime - dateOfLastEvent
                 item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
-                item.SubItems(8).Text = intSecondsSinceLastEvent.ToString("N0")
+                item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
             End If
         Next
 

--- a/Free SysLog/Windows/Replacements.Designer.vb
+++ b/Free SysLog/Windows/Replacements.Designer.vb
@@ -55,6 +55,7 @@ Partial Class Replacements
         '
         'ReplacementsListView
         '
+        Me.ReplacementsListView.AllowColumnReorder = True
         Me.ReplacementsListView.AllowDrop = True
         Me.ReplacementsListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -146,40 +146,40 @@ Public Class Replacements
     End Sub
 
     Private Sub Replacements_Closing(sender As Object, e As ComponentModel.CancelEventArgs) Handles Me.Closing
-        If boolChanged Then
-            Dim newReplacementsList As New ThreadSafetyLists.ThreadSafeReplacementsList
-            Dim tempReplacements As New Specialized.StringCollection()
-            Dim boolSuccess As Boolean = False
+        If Not boolChanged Then Exit Sub
 
-            Try
-                Dim replacementsClass As ReplacementsClass
+        Dim newReplacementsList As New ThreadSafetyLists.ThreadSafeReplacementsList
+        Dim tempReplacements As New Specialized.StringCollection()
+        Dim boolSuccess As Boolean = False
 
-                For Each item As MyReplacementsListViewItem In ReplacementsListView.Items
-                    replacementsClass = New ReplacementsClass With {
-                        .BoolRegex = item.BoolRegex,
-                        .StrReplace = item.SubItems(0).Text,
-                        .StrReplaceWith = item.SubItems(1).Text,
-                        .BoolCaseSensitive = item.BoolCaseSensitive,
-                        .BoolEnabled = item.BoolEnabled
-                    }
+        Try
+            Dim replacementsClass As ReplacementsClass
 
-                    If replacementsClass.BoolEnabled Then newReplacementsList.Add(replacementsClass)
-                    tempReplacements.Add(Newtonsoft.Json.JsonConvert.SerializeObject(replacementsClass))
-                Next
+            For Each item As MyReplacementsListViewItem In ReplacementsListView.Items
+                replacementsClass = New ReplacementsClass With {
+                    .BoolRegex = item.BoolRegex,
+                    .StrReplace = item.SubItems(0).Text,
+                    .StrReplaceWith = item.SubItems(1).Text,
+                    .BoolCaseSensitive = item.BoolCaseSensitive,
+                    .BoolEnabled = item.BoolEnabled
+                }
 
-                newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-                boolSuccess = True
-            Catch
-            Finally
-                If boolSuccess Then
-                    replacementsList.Clear()
-                    replacementsList.Merge(newReplacementsList)
+                If replacementsClass.BoolEnabled Then newReplacementsList.Add(replacementsClass)
+                tempReplacements.Add(Newtonsoft.Json.JsonConvert.SerializeObject(replacementsClass))
+            Next
 
-                    My.Settings.replacements = tempReplacements
-                    My.Settings.Save()
-                End If
-            End Try
-        End If
+            newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            boolSuccess = True
+        Catch
+        Finally
+            If boolSuccess Then
+                replacementsList.Clear()
+                replacementsList.Merge(newReplacementsList)
+
+                My.Settings.replacements = tempReplacements
+                My.Settings.Save()
+            End If
+        End Try
     End Sub
 
     Private Sub ReplacementsListView_KeyUp(sender As Object, e As KeyEventArgs) Handles ReplacementsListView.KeyUp

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -171,7 +171,7 @@ Public Class Replacements
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             replacementsList.Clear()
-            replacementsList.Merge(newReplacementsList)
+            replacementsList.Merge(newReplacementsList.GetSnapshot())
 
             My.Settings.replacements = tempReplacements
             My.Settings.Save()

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -175,7 +175,18 @@ Public Class Replacements
 
             My.Settings.replacements = tempReplacements
             My.Settings.Save()
-        Catch
+        Catch ex As Exception
+            SyncLock SupportCode.ParentForm.dataGridLockObject
+                SupportCode.ParentForm.Logs.Rows.Add(
+                    SyslogParser.MakeLocalDataGridRowEntry(
+                        $"Unable to save user preferences on ""Replacements"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        SupportCode.ParentForm.Logs
+                    )
+                )
+
+                If SupportCode.ParentForm.ChkEnableAutoScroll.Checked Then SupportCode.ParentForm.Logs.FirstDisplayedScrollingRowIndex = SupportCode.ParentForm.Logs.Rows.Count - 1
+                SupportCode.ParentForm.NumberOfLogs.Text = $"Number of Log Entries: {SupportCode.ParentForm.Logs.Rows.Count:N0}"
+            End SyncLock
         End Try
     End Sub
 

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -6,6 +6,11 @@ Public Class Replacements
     Private boolEditMode As Boolean = False
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
+    Private boolColumnOrderChanged As Boolean = False
+
+    Private Sub ReplacementsListView_ColumnReordered(sender As Object, e As ColumnReorderedEventArgs) Handles ReplacementsListView.ColumnReordered
+        boolColumnOrderChanged = True
+    End Sub
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles ReplacementsListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -122,6 +127,7 @@ Public Class Replacements
     End Sub
 
     Private Sub Replacements_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        LoadColumnOrders(ReplacementsListView.Columns, My.Settings.replacementsColumnOrder)
         BtnCancel.Visible = False
         Location = VerifyWindowLocation(My.Settings.replacementsLocation, Me)
         Dim listOfReplacementsToAdd As New List(Of MyReplacementsListViewItem)
@@ -146,6 +152,11 @@ Public Class Replacements
     End Sub
 
     Private Sub Replacements_Closing(sender As Object, e As ComponentModel.CancelEventArgs) Handles Me.Closing
+        If boolColumnOrderChanged Then
+            My.Settings.replacementsColumnOrder = SaveColumnOrders(ReplacementsListView.Columns)
+            My.Settings.Save()
+        End If
+
         If Not boolChanged Then Exit Sub
 
         Dim newReplacementsList As New ThreadSafetyLists.ThreadSafeReplacementsList

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -147,21 +147,31 @@ Public Class Replacements
 
     Private Sub Replacements_Closing(sender As Object, e As ComponentModel.CancelEventArgs) Handles Me.Closing
         If boolChanged Then
-            replacementsList.Clear()
-
-            Dim replacementsClass As ReplacementsClass
+            Dim newReplacementsList As New ThreadSafetyLists.ThreadSafeReplacementsList
             Dim tempReplacements As New Specialized.StringCollection()
+            Dim boolSuccess As Boolean = False
 
-            For Each item As MyReplacementsListViewItem In ReplacementsListView.Items
-                replacementsClass = New ReplacementsClass With {.BoolRegex = item.BoolRegex, .StrReplace = item.SubItems(0).Text, .StrReplaceWith = item.SubItems(1).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolEnabled = item.BoolEnabled}
-                If replacementsClass.BoolEnabled Then replacementsList.Add(replacementsClass)
-                tempReplacements.Add(Newtonsoft.Json.JsonConvert.SerializeObject(replacementsClass))
-            Next
+            Try
+                Dim replacementsClass As ReplacementsClass
 
-            replacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+                For Each item As MyReplacementsListViewItem In ReplacementsListView.Items
+                    replacementsClass = New ReplacementsClass With {.BoolRegex = item.BoolRegex, .StrReplace = item.SubItems(0).Text, .StrReplaceWith = item.SubItems(1).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolEnabled = item.BoolEnabled}
+                    If replacementsClass.BoolEnabled Then newReplacementsList.Add(replacementsClass)
+                    tempReplacements.Add(Newtonsoft.Json.JsonConvert.SerializeObject(replacementsClass))
+                Next
 
-            My.Settings.replacements = tempReplacements
-            My.Settings.Save()
+                newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+                boolSuccess = True
+            Catch
+            Finally
+                If boolSuccess Then
+                    replacementsList.Clear()
+                    replacementsList.Merge(newReplacementsList)
+
+                    My.Settings.replacements = tempReplacements
+                    My.Settings.Save()
+                End If
+            End Try
         End If
     End Sub
 

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -155,7 +155,14 @@ Public Class Replacements
                 Dim replacementsClass As ReplacementsClass
 
                 For Each item As MyReplacementsListViewItem In ReplacementsListView.Items
-                    replacementsClass = New ReplacementsClass With {.BoolRegex = item.BoolRegex, .StrReplace = item.SubItems(0).Text, .StrReplaceWith = item.SubItems(1).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolEnabled = item.BoolEnabled}
+                    replacementsClass = New ReplacementsClass With {
+                        .BoolRegex = item.BoolRegex,
+                        .StrReplace = item.SubItems(0).Text,
+                        .StrReplaceWith = item.SubItems(1).Text,
+                        .BoolCaseSensitive = item.BoolCaseSensitive,
+                        .BoolEnabled = item.BoolEnabled
+                    }
+
                     If replacementsClass.BoolEnabled Then newReplacementsList.Add(replacementsClass)
                     tempReplacements.Add(Newtonsoft.Json.JsonConvert.SerializeObject(replacementsClass))
                 Next

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -150,7 +150,6 @@ Public Class Replacements
 
         Dim newReplacementsList As New ThreadSafetyLists.ThreadSafeReplacementsList
         Dim tempReplacements As New Specialized.StringCollection()
-        Dim boolSuccess As Boolean = False
 
         Try
             Dim replacementsClass As ReplacementsClass
@@ -169,16 +168,14 @@ Public Class Replacements
             Next
 
             newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            boolSuccess = True
-        Catch
-        Finally
-            If boolSuccess Then
-                replacementsList.Clear()
-                replacementsList.Merge(newReplacementsList)
 
-                My.Settings.replacements = tempReplacements
-                My.Settings.Save()
-            End If
+            ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
+            replacementsList.Clear()
+            replacementsList.Merge(newReplacementsList)
+
+            My.Settings.replacements = tempReplacements
+            My.Settings.Save()
+        Catch
         End Try
     End Sub
 

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -312,6 +312,9 @@
             <setting name="OnlySaveAlertedLogs" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="DateOfLastEventColumnWidth" serializeAs="String">
+                <value>240</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -324,6 +324,9 @@
             <setting name="replacementsColumnOrder" serializeAs="String">
                 <value />
             </setting>
+            <setting name="ColSinceLastEventWidth" serializeAs="String">
+                <value>100</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -318,6 +318,9 @@
             <setting name="IgnoredWordsAndPhrasesColumnOrder" serializeAs="String">
                 <value />
             </setting>
+            <setting name="alertsColumnOrder" serializeAs="String">
+                <value />
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -315,6 +315,9 @@
             <setting name="DateOfLastEventColumnWidth" serializeAs="String">
                 <value>240</value>
             </setting>
+            <setting name="IgnoredWordsAndPhrasesColumnOrder" serializeAs="String">
+                <value />
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -321,6 +321,9 @@
             <setting name="alertsColumnOrder" serializeAs="String">
                 <value />
             </setting>
+            <setting name="replacementsColumnOrder" serializeAs="String">
+                <value />
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Added error handling when updating many of the data types that the user is allowed to change by making many of the changes atomic. In other words, it happens with no errors or it doesn't happen at all.
- Removed the synclocks around the code that handles the unique objects.
- Changed the Notification Limiter code to use Concurrent Dictionaries instead of regular dictionaries and locking objects.
- Added logging of exception data if something happens when saving user preferences on the Alerts, "Configure SysLog Mirror Clients", "Ignored Words and Phrases", and the Replacements windows.
- The total number of hits for ignored rules are now displayed under the list of rules on the "Ignored Words and Phrases" window.
- Removed an errant call to Interlocked.Increment(). This was causing the number of ignored logs displayed in the UI to be overly inflated.
- Fixed Exabyte conversion in the FileSizeToHumanSize() function.
- Added "Date of Last Event" and "Since Last Event" to ignored rules.
- Added a button to update the hists and last events on the "Ignored Words and Phrases" window.
- Updated the Newtonsoft.Json NuGet package from version 13.0.3 to 13.0.4.
- Added the ability to reorder the columns on the "Ignored Words and Phrases" window.
- Fixed a bug that prevented column reordering on the main window.
- Added the ability to reorder columns on the Alerts and Replacements windows.
- Made it so that the hit counter column value isn't filled in for disabled rules on the "Ignored Words and Phrases" window.
- Added sorting for the "Since Last Event" column on the "Ignored Words and Phrases" window.

And a whole lot more under the hood changes to the code with over 40 separate commits.