### PR TITLE
Version 4.8 Build 3

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.8.2.109")>
+<Assembly: AssemblyFileVersion("4.8.3.110")>

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -120,6 +120,12 @@ Namespace SupportCode
             Return If(parts.Count > 0, String.Join(", ", parts), "0s")
         End Function
 
+        Public Sub SetDoubleBufferingFlag(guiObject As Object)
+            Dim flags As Reflection.BindingFlags = Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance Or Reflection.BindingFlags.SetProperty
+            Dim propInfo As Reflection.PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
+            propInfo?.SetValue(guiObject, True, Nothing)
+        End Sub
+
         Public Function SaveColumnOrders(columns As DataGridViewColumnCollection) As Specialized.StringCollection
             Try
                 Dim SpecializedStringCollection As New Specialized.StringCollection

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -1,6 +1,4 @@
-﻿Imports System.Reflection
-
-Public Class Alerts_History
+﻿Public Class Alerts_History
     Public Property DataToLoad As List(Of AlertsHistory)
     Private Shadows ParentForm As Form1
     Private boolDoneLoading As Boolean = False
@@ -30,9 +28,7 @@ Public Class Alerts_History
             AlertHistoryList.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
         End If
 
-        Dim flags As BindingFlags = BindingFlags.NonPublic Or BindingFlags.Instance Or BindingFlags.SetProperty
-        Dim propInfo As PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
-        propInfo?.SetValue(AlertHistoryList, True, Nothing)
+        SupportCode.SetDoubleBufferingFlag(AlertHistoryList)
 
         AlertHistoryList.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = SupportCode.GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
         Size = My.Settings.AlertHistorySize

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -5,7 +5,6 @@ Imports System.Text
 Imports System.ComponentModel
 Imports Microsoft.Win32
 Imports System.Text.RegularExpressions
-Imports System.Reflection
 Imports System.Configuration
 Imports Free_SysLog.SupportCode
 Imports Microsoft.Toolkit.Uwp.Notifications
@@ -476,9 +475,7 @@ Public Class Form1
 
         LoadCheckboxSettings()
 
-        Dim flags As BindingFlags = BindingFlags.NonPublic Or BindingFlags.Instance Or BindingFlags.SetProperty
-        Dim propInfo As PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
-        propInfo?.SetValue(Logs, True, Nothing)
+        SetDoubleBufferingFlag(Logs)
 
         Logs.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
         Logs.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -1,6 +1,5 @@
 ﻿Imports System.ComponentModel
 Imports System.IO
-Imports System.Reflection
 Imports System.Text.RegularExpressions
 Imports System.Xml.Serialization
 Imports Free_SysLog.SupportCode
@@ -185,9 +184,7 @@ Public Class IgnoredLogsAndSearchResults
 
         ColTime.HeaderCell.SortGlyphDirection = SortOrder.Ascending
 
-        Dim flags As BindingFlags = BindingFlags.NonPublic Or BindingFlags.Instance Or BindingFlags.SetProperty
-        Dim propInfo As PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
-        propInfo?.SetValue(Logs, True, Nothing)
+        SetDoubleBufferingFlag(Logs)
 
         Logs.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor}
         Logs.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -177,6 +177,8 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
+        SetDoubleBufferingFlag(IgnoredListView)
+
         LoadColumnOrders(IgnoredListView.Columns, My.Settings.IgnoredWordsAndPhrasesColumnOrder)
 
         BtnCancel.Visible = False
@@ -595,6 +597,8 @@ Public Class IgnoredWordsAndPhrases
         Dim longTotalHits As Long = 0
         Dim sinceLastEvent As TimeSpan
 
+        IgnoredListView.BeginUpdate()
+
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
             Dim intHits As Integer = 0
             Dim dateOfLastEvent As Date = Date.MinValue
@@ -618,5 +622,7 @@ Public Class IgnoredWordsAndPhrases
         lblTotalHits.Text = $"Total Ignored Hits: {longTotalHits:N0}"
 
         If IgnoredListView.ListViewItemSorter IsNot Nothing Then IgnoredListView.Sort()
+
+        IgnoredListView.EndUpdate()
     End Sub
 End Class


### PR DESCRIPTION
- Moved the code that sets DoubleBuffering to a sub-routine to de-duplicate code.
- Added DoubleBuffering to the IgnoredListView on the "Ignored Words and Phrases" window to eliminate the flashing when updating rule usage statistics.