### PR TITLE
Version 4.9 Build 1

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -81,14 +81,8 @@ Namespace My
             allUniqueObjects = LoadUniqueLogTypesAndProcesses(True)
             recentUniqueObjects = LoadUniqueLogTypesAndProcesses(False)
 
-            If My.Settings.saveIgnoredLogCount Then
-                If IO.File.Exists(strPathToIgnoredHitsFile) Then
-                    IgnoredHits = Newtonsoft.Json.JsonConvert.DeserializeObject(Of Concurrent.ConcurrentDictionary(Of String, Integer))(IO.File.ReadAllText(strPathToIgnoredHitsFile), JSONDecoderSettingsForSettingsFiles)
-                End If
-
-                If IO.File.Exists(strPathToIgnoredLastEventFile) Then
-                    IgnoredLastEvent = Newtonsoft.Json.JsonConvert.DeserializeObject(Of Concurrent.ConcurrentDictionary(Of String, Date))(IO.File.ReadAllText(strPathToIgnoredLastEventFile), JSONDecoderSettingsForSettingsFiles)
-                End If
+            If My.Settings.saveIgnoredLogCount AndAlso IO.File.Exists(strPathToIgnoredStatsFile) Then
+                IgnoredStats = Newtonsoft.Json.JsonConvert.DeserializeObject(Of Concurrent.ConcurrentDictionary(Of String, IgnoredStatsEntry))(IO.File.ReadAllText(strPathToIgnoredStatsFile), JSONDecoderSettingsForSettingsFiles)
             End If
         End Sub
 

--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -80,6 +80,16 @@ Namespace My
 
             allUniqueObjects = LoadUniqueLogTypesAndProcesses(True)
             recentUniqueObjects = LoadUniqueLogTypesAndProcesses(False)
+
+            If My.Settings.saveIgnoredLogCount Then
+                If IO.File.Exists(strPathToIgnoredHitsFile) Then
+                    IgnoredHits = Newtonsoft.Json.JsonConvert.DeserializeObject(Of Concurrent.ConcurrentDictionary(Of String, Integer))(IO.File.ReadAllText(strPathToIgnoredHitsFile), JSONDecoderSettingsForSettingsFiles)
+                End If
+
+                If IO.File.Exists(strPathToIgnoredLastEventFile) Then
+                    IgnoredLastEvent = Newtonsoft.Json.JsonConvert.DeserializeObject(Of Concurrent.ConcurrentDictionary(Of String, Date))(IO.File.ReadAllText(strPathToIgnoredLastEventFile), JSONDecoderSettingsForSettingsFiles)
+                End If
+            End If
         End Sub
 
         Private Function LoadUniqueLogTypesAndProcesses(boolProcessAllFiles As Boolean) As uniqueObjectsClass

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.8.3.110")>
+<Assembly: AssemblyFileVersion("4.9.1.111")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1352,6 +1352,18 @@ Namespace My
                 Me("ColSinceLastEventWidth") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property AutomaticStatRefreshOnIgnoredWordsAndPhrases() As Boolean
+            Get
+                Return CType(Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases"),Boolean)
+            End Get
+            Set
+                Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1364,6 +1364,18 @@ Namespace My
                 Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases() As Boolean
+            Get
+                Return CType(Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases"),Boolean)
+            End Get
+            Set
+                Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -332,5 +332,8 @@
     <Setting Name="AutomaticStatRefreshOnIgnoredWordsAndPhrases" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -329,5 +329,8 @@
     <Setting Name="ColSinceLastEventWidth" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">100</Value>
     </Setting>
+    <Setting Name="AutomaticStatRefreshOnIgnoredWordsAndPhrases" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -127,12 +127,13 @@ Public Class IgnoredClass
         Dim intHits As Integer
         Dim dateLastEvent As Date
         Dim sinceLastEvent As TimeSpan
+        Dim currentDate As Date = Now
 
         If Not IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent) Then dateLastEvent = Date.MinValue
         If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
         longTotalHits += intHits
 
-        If dateCreated = Date.MinValue Then dateCreated = Date.Now
+        If dateCreated = Date.MinValue Then dateCreated = currentDate
 
         Dim listViewItem As New MyIgnoredListViewItem(StrIgnore)
         listViewItem.SubItems.Add(If(BoolRegex, "Yes", "No"))
@@ -143,11 +144,11 @@ Public Class IgnoredClass
         listViewItem.SubItems.Add(dateCreated.ToLongDateString)
 
         If Not dateLastEvent.Equals(Date.MinValue) Then
-            dateLastEvent = dateLastEvent.ToLocalTime()
-            sinceLastEvent = Now.ToLocalTime - dateLastEvent
+            dateLastEvent = dateLastEvent
+            sinceLastEvent = currentDate - dateLastEvent
             listViewItem.timeSpanOfLastOccurrence = sinceLastEvent
             listViewItem.dateOfLastOccurrence = dateLastEvent
-            listViewItem.SubItems.Add($"{dateLastEvent.ToLongDateString} {dateLastEvent.ToLongTimeString}")
+            listViewItem.SubItems.Add($"{dateLastEvent.ToLocalTime.ToLongDateString} {dateLastEvent.ToLocalTime.ToLongTimeString}")
             listViewItem.SubItems.Add(TimespanToHMS(sinceLastEvent))
         Else
             listViewItem.SubItems.Add("")

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -128,9 +128,16 @@ Public Class IgnoredClass
         Dim dateLastEvent As Date
         Dim sinceLastEvent As TimeSpan
         Dim currentDate As Date = Now
+        Dim IgnoredStatsEntry As IgnoredStatsEntry = Nothing
 
-        If Not IgnoredLastEvent.TryGetValue(StrIgnore, dateLastEvent) Then dateLastEvent = Date.MinValue
-        If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
+        If Not IgnoredStats.TryGetValue(StrIgnore, IgnoredStatsEntry) Then
+            dateLastEvent = Date.MinValue
+            intHits = 0
+        Else
+            dateLastEvent = IgnoredStatsEntry.LastEvent
+            intHits = IgnoredStatsEntry.Hits
+        End If
+
         longTotalHits += intHits
 
         If dateCreated = Date.MinValue Then dateCreated = currentDate
@@ -169,7 +176,9 @@ Public Class IgnoredClass
 
     Public Function ToListViewItem() As MyIgnoredListViewItem
         Dim intHits As Integer
-        If Not IgnoredHits.TryGetValue(StrIgnore, intHits) Then intHits = 0
+        Dim IgnoredStatsEntry As IgnoredStatsEntry = Nothing
+
+        intHits = If(IgnoredStats.TryGetValue(StrIgnore, IgnoredStatsEntry), IgnoredStatsEntry.Hits, 0)
 
         If dateCreated = Date.MinValue Then dateCreated = Date.Now
 

--- a/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
+++ b/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
@@ -40,6 +40,10 @@ Namespace NativeMethod
         <DllImport("iphlpapi.dll", SetLastError:=True)>
         Public Shared Function GetExtendedUdpTable(pUdpTable As IntPtr, ByRef dwOutBufLen As Integer, sort As Boolean, ipVersion As Integer, tableClass As UDP_TABLE_CLASS, reserved As Integer) As UInteger
         End Function
+
+        <DllImport("user32.dll")>
+        Public Shared Function GetForegroundWindow() As IntPtr
+        End Function
     End Class
 
     Module APIs

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -126,6 +126,8 @@ Namespace SupportCode
             If timeSpan.Minutes > 0 Then parts.Add($"{timeSpan.Minutes}m")
             If timeSpan.Seconds > 0 Then parts.Add($"{timeSpan.Seconds}s")
 
+            If parts.Count() = 0 Then parts.Add($"{timeSpan.Milliseconds}ms")
+
             Return String.Join(", ", parts)
         End Function
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -117,6 +117,7 @@ Namespace SupportCode
 
         Public Function TimespanToHMS(timeSpan As TimeSpan) As String
             If timeSpan.TotalMilliseconds < 1 Then Return "0s"
+            If timeSpan < TimeSpan.Zero Then timeSpan = timeSpan.Duration()
 
             Dim parts As New List(Of String)
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -73,6 +73,7 @@ Namespace SupportCode
         Public strPathToConfigBackupFile As String = IO.Path.Combine(strPathToDataFolder, "config_backup.json")
         Public strPathToIgnoredHitsFile As String = IO.Path.Combine(strPathToDataFolder, "IgnoredHits.json")
         Public strPathToIgnoredLastEventFile As String = IO.Path.Combine(strPathToDataFolder, "IgnoredLastEvent.json")
+        Public strPathToNumberOfIgnoredLogsFile As String = IO.Path.Combine(strPathToDataFolder, "NumberOfIgnoredLogs.json")
         Public Const strProxiedString As String = "proxied|"
         Public Const strQuote As String = Chr(34)
         Public Const strViewLog As String = "viewlog"
@@ -121,6 +122,24 @@ Namespace SupportCode
 
             Return If(parts.Count > 0, String.Join(", ", parts), "0s")
         End Function
+
+        Public Property NumberOfIgnoredLogs As Long
+            Get
+                If Not IO.File.Exists(strPathToNumberOfIgnoredLogsFile) Then Return 0
+
+                Dim strFileData As String = IO.File.ReadAllText(strPathToNumberOfIgnoredLogsFile)
+                Dim longResult As Long = 0
+
+                If Long.TryParse(strFileData, longResult) Then
+                    Return longResult
+                Else
+                    Return 0
+                End If
+            End Get
+            Set(value As Long)
+                IO.File.WriteAllText(strPathToNumberOfIgnoredLogsFile, value.ToString)
+            End Set
+        End Property
 
         Public Sub SetDoubleBufferingFlag(control As Control)
             If control Is Nothing Then Exit Sub

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -121,6 +121,7 @@ Namespace SupportCode
 
             Dim parts As New List(Of String)
 
+            If timeSpan.Days > 0 Then parts.Add($"{timeSpan.Days}d")
             If timeSpan.Hours > 0 Then parts.Add($"{timeSpan.Hours}h")
             If timeSpan.Minutes > 0 Then parts.Add($"{timeSpan.Minutes}m")
             If timeSpan.Seconds > 0 Then parts.Add($"{timeSpan.Seconds}s")

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -45,14 +45,18 @@ Namespace SupportCode
         End Sub
     End Class
 
+    Public Class IgnoredStatsEntry
+        Public Property Hits As Long
+        Public Property LastEvent As Date
+    End Class
+
     Module SupportCode
         Public ParentForm As Form1
 
         Public AlertsRegexCache As New ConcurrentDictionary(Of String, Regex)
         Public ReplacementsRegexCache As New ConcurrentDictionary(Of String, Regex)
         Public IgnoredRegexCache As New ConcurrentDictionary(Of String, Regex)
-        Public IgnoredHits As New ConcurrentDictionary(Of String, Integer)
-        Public IgnoredLastEvent As New ConcurrentDictionary(Of String, Date)
+        Public IgnoredStats As New ConcurrentDictionary(Of String, IgnoredStatsEntry)
 
         Public longNumberOfIgnoredLogs As Long = 0
         Public boolIsProgrammaticScroll As Boolean = False
@@ -72,8 +76,7 @@ Namespace SupportCode
         Public strPathToDataBackupFolder As String = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog", "Backup")
         Public strPathToDataFile As String = Path.Combine(strPathToDataFolder, "log.json")
         Public strPathToConfigBackupFile As String = Path.Combine(strPathToDataFolder, "config_backup.json")
-        Public strPathToIgnoredHitsFile As String = Path.Combine(strPathToDataFolder, "IgnoredHits.json")
-        Public strPathToIgnoredLastEventFile As String = Path.Combine(strPathToDataFolder, "IgnoredLastEvent.json")
+        Public strPathToIgnoredStatsFile As String = Path.Combine(strPathToDataFolder, "IgnoredStats.json")
         Public strPathToNumberOfIgnoredLogsFile As String = Path.Combine(strPathToDataFolder, "NumberOfIgnoredLogs.json")
         Public Const strProxiedString As String = "proxied|"
         Public Const strQuote As String = Chr(34)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -126,13 +126,23 @@ Namespace SupportCode
         Public Sub WriteFileAtomically(path As String, contents As String)
             Dim tmpPath As String = path & ".tmp"
 
-            IO.File.WriteAllText(tmpPath, contents)
+            Try
+                IO.File.WriteAllText(tmpPath, contents)
 
-            If IO.File.Exists(path) Then
-                IO.File.Replace(tmpPath, path, Nothing)
-            Else
-                IO.File.Move(tmpPath, path)
-            End If
+                If IO.File.Exists(path) Then
+                    IO.File.Replace(tmpPath, path, Nothing)
+                Else
+                    IO.File.Move(tmpPath, path)
+                End If
+            Catch
+                ' Fail silently
+            Finally
+                Try
+                    If IO.File.Exists(tmpPath) Then IO.File.Delete(tmpPath)
+                Catch
+                    ' Fail silently
+                End Try
+            End Try
         End Sub
 
         Public Property NumberOfIgnoredLogs As Long

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -123,6 +123,18 @@ Namespace SupportCode
             Return If(parts.Count > 0, String.Join(", ", parts), "0s")
         End Function
 
+        Public Sub WriteFileAtomically(path As String, contents As String)
+            Dim tmpPath As String = path & ".tmp"
+
+            IO.File.WriteAllText(tmpPath, contents)
+
+            If IO.File.Exists(path) Then
+                IO.File.Replace(tmpPath, path, Nothing)
+            Else
+                IO.File.Move(tmpPath, path)
+            End If
+        End Sub
+
         Public Property NumberOfIgnoredLogs As Long
             Get
                 If Not IO.File.Exists(strPathToNumberOfIgnoredLogsFile) Then Return 0
@@ -137,7 +149,7 @@ Namespace SupportCode
                 End If
             End Get
             Set(value As Long)
-                IO.File.WriteAllText(strPathToNumberOfIgnoredLogsFile, value.ToString)
+                WriteFileAtomically(strPathToNumberOfIgnoredLogsFile, value.ToString)
             End Set
         End Property
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -115,7 +115,7 @@ Namespace SupportCode
         Public Const boolDebugBuild As Boolean = False
 #End If
 
-        Public Function TimespanToHMS(timeSpan As TimeSpan) As String
+        Public Function TimespanToHMS(timeSpan As TimeSpan, Optional boolUseCommas As Boolean = True) As String
             If timeSpan.TotalMilliseconds < 1 Then Return "0s"
             If timeSpan < TimeSpan.Zero Then timeSpan = timeSpan.Duration()
 
@@ -128,7 +128,11 @@ Namespace SupportCode
 
             If parts.Count() = 0 Then parts.Add($"{timeSpan.Milliseconds}ms")
 
-            Return String.Join(", ", parts)
+            If boolUseCommas Then
+                Return String.Join(", ", parts)
+            Else
+                Return String.Join(" ", parts)
+            End If
         End Function
 
         Public Sub WriteFileAtomically(path As String, contents As String)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -120,10 +120,11 @@ Namespace SupportCode
             Return If(parts.Count > 0, String.Join(", ", parts), "0s")
         End Function
 
-        Public Sub SetDoubleBufferingFlag(guiObject As Object)
-            Dim flags As Reflection.BindingFlags = Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance Or Reflection.BindingFlags.SetProperty
-            Dim propInfo As Reflection.PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
-            propInfo?.SetValue(guiObject, True, Nothing)
+        Public Sub SetDoubleBufferingFlag(control As Control)
+            If control Is Nothing Then Exit Sub
+            Dim flags As Reflection.BindingFlags = Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance
+            Dim propInfo As Reflection.PropertyInfo = control.GetType().GetProperty("DoubleBuffered", flags)
+            propInfo?.SetValue(control, True, Nothing)
         End Sub
 
         Public Function SaveColumnOrders(columns As DataGridViewColumnCollection) As Specialized.StringCollection

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -6,6 +6,7 @@ Imports System.Text
 Imports System.Text.RegularExpressions
 Imports Microsoft.Toolkit.Uwp.Notifications
 Imports System.Runtime.InteropServices
+Imports System.IO
 
 Namespace SupportCode
     Public Enum IgnoreOrSearchWindowDisplayMode As Byte
@@ -67,13 +68,13 @@ Namespace SupportCode
         Public boolDoWeOwnTheMutex As Boolean = False
         Public JSONDecoderSettingsForLogFiles As New Newtonsoft.Json.JsonSerializerSettings With {.MissingMemberHandling = Newtonsoft.Json.MissingMemberHandling.Ignore}
         Public JSONDecoderSettingsForSettingsFiles As New Newtonsoft.Json.JsonSerializerSettings With {.MissingMemberHandling = Newtonsoft.Json.MissingMemberHandling.Error}
-        Public strPathToDataFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog")
-        Public strPathToDataBackupFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog", "Backup")
-        Public strPathToDataFile As String = IO.Path.Combine(strPathToDataFolder, "log.json")
-        Public strPathToConfigBackupFile As String = IO.Path.Combine(strPathToDataFolder, "config_backup.json")
-        Public strPathToIgnoredHitsFile As String = IO.Path.Combine(strPathToDataFolder, "IgnoredHits.json")
-        Public strPathToIgnoredLastEventFile As String = IO.Path.Combine(strPathToDataFolder, "IgnoredLastEvent.json")
-        Public strPathToNumberOfIgnoredLogsFile As String = IO.Path.Combine(strPathToDataFolder, "NumberOfIgnoredLogs.json")
+        Public strPathToDataFolder As String = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog")
+        Public strPathToDataBackupFolder As String = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog", "Backup")
+        Public strPathToDataFile As String = Path.Combine(strPathToDataFolder, "log.json")
+        Public strPathToConfigBackupFile As String = Path.Combine(strPathToDataFolder, "config_backup.json")
+        Public strPathToIgnoredHitsFile As String = Path.Combine(strPathToDataFolder, "IgnoredHits.json")
+        Public strPathToIgnoredLastEventFile As String = Path.Combine(strPathToDataFolder, "IgnoredLastEvent.json")
+        Public strPathToNumberOfIgnoredLogsFile As String = Path.Combine(strPathToDataFolder, "NumberOfIgnoredLogs.json")
         Public Const strProxiedString As String = "proxied|"
         Public Const strQuote As String = Chr(34)
         Public Const strViewLog As String = "viewlog"
@@ -127,18 +128,18 @@ Namespace SupportCode
             Dim tmpPath As String = path & ".tmp"
 
             Try
-                IO.File.WriteAllText(tmpPath, contents)
+                File.WriteAllText(tmpPath, contents)
 
-                If IO.File.Exists(path) Then
-                    IO.File.Replace(tmpPath, path, Nothing)
+                If File.Exists(path) Then
+                    File.Replace(tmpPath, path, Nothing)
                 Else
-                    IO.File.Move(tmpPath, path)
+                    File.Move(tmpPath, path)
                 End If
             Catch
                 ' Fail silently
             Finally
                 Try
-                    If IO.File.Exists(tmpPath) Then IO.File.Delete(tmpPath)
+                    If File.Exists(tmpPath) Then File.Delete(tmpPath)
                 Catch
                     ' Fail silently
                 End Try
@@ -147,9 +148,9 @@ Namespace SupportCode
 
         Public Property NumberOfIgnoredLogs As Long
             Get
-                If Not IO.File.Exists(strPathToNumberOfIgnoredLogsFile) Then Return 0
+                If Not File.Exists(strPathToNumberOfIgnoredLogsFile) Then Return 0
 
-                Dim strFileData As String = IO.File.ReadAllText(strPathToNumberOfIgnoredLogsFile)
+                Dim strFileData As String = File.ReadAllText(strPathToNumberOfIgnoredLogsFile)
                 Dim longResult As Long = 0
 
                 If Long.TryParse(strFileData, longResult) Then
@@ -406,11 +407,11 @@ Namespace SupportCode
             notification.SetToastDuration(If(My.Settings.NotificationLength = 0, ToastDuration.Short, ToastDuration.Long))
 
             If tipIcon = ToolTipIcon.Error Then
-                strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png")
+                strIconPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "error.png")
             ElseIf tipIcon = ToolTipIcon.Warning Then
-                strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png")
+                strIconPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "warning.png")
             ElseIf tipIcon = ToolTipIcon.Info Then
-                strIconPath = IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
+                strIconPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "info.png")
             End If
 
             If My.Settings.IncludeButtonsOnNotifications Then
@@ -423,7 +424,7 @@ Namespace SupportCode
                 notification.AddArgument("action", strOpenSysLog)
             End If
 
-            If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso IO.File.Exists(strIconPath) Then notification.AddAppLogoOverride(New Uri(strIconPath), ToastGenericAppLogoCrop.Circle)
+            If Not String.IsNullOrWhiteSpace(strIconPath) AndAlso File.Exists(strIconPath) Then notification.AddAppLogoOverride(New Uri(strIconPath), ToastGenericAppLogoCrop.Circle)
 
             notification.Show()
         End Sub
@@ -631,7 +632,7 @@ Namespace SupportCode
         End Function
 
         Public Sub SelectFileInWindowsExplorer(strFullPath As String)
-            If Not String.IsNullOrEmpty(strFullPath) AndAlso IO.File.Exists(strFullPath) Then
+            If Not String.IsNullOrEmpty(strFullPath) AndAlso File.Exists(strFullPath) Then
                 Dim pidlList As IntPtr = NativeMethod.NativeMethods.ILCreateFromPathW(strFullPath)
 
                 If Not pidlList.Equals(IntPtr.Zero) Then

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -126,7 +126,7 @@ Namespace SupportCode
             If timeSpan.Minutes > 0 Then parts.Add($"{timeSpan.Minutes}m")
             If timeSpan.Seconds > 0 Then parts.Add($"{timeSpan.Seconds}s")
 
-            Return If(parts.Count > 0, String.Join(", ", parts), "0s")
+            Return String.Join(", ", parts)
         End Function
 
         Public Sub WriteFileAtomically(path As String, contents As String)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -71,6 +71,8 @@ Namespace SupportCode
         Public strPathToDataBackupFolder As String = IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Free SysLog", "Backup")
         Public strPathToDataFile As String = IO.Path.Combine(strPathToDataFolder, "log.json")
         Public strPathToConfigBackupFile As String = IO.Path.Combine(strPathToDataFolder, "config_backup.json")
+        Public strPathToIgnoredHitsFile As String = IO.Path.Combine(strPathToDataFolder, "IgnoredHits.json")
+        Public strPathToIgnoredLastEventFile As String = IO.Path.Combine(strPathToDataFolder, "IgnoredLastEvent.json")
         Public Const strProxiedString As String = "proxied|"
         Public Const strQuote As String = Chr(34)
         Public Const strViewLog As String = "viewlog"

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -492,22 +492,22 @@ Namespace SyslogParser
                                                                                  )
                         NewIgnoredItem.IgnoredPattern = strIgnoredPattern
 
-                            If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
+                        If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
                                 ParentForm.IgnoredLogs.Add(NewIgnoredItem)
                             Else
                                 While ParentForm.IgnoredLogs.Count >= My.Settings.LimitNumberOfIgnoredLogs
-                                    ParentForm.IgnoredLogs.RemoveAt(0)
+                                    ParentForm.IgnoredLogs.TryRemoveAt(0)
                                 End While
 
                                 ParentForm.IgnoredLogs.Add(NewIgnoredItem)
                             End If
 
-                            If My.Settings.recordIgnoredLogs Then
-                                ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.IgnoredLogs.Count:N0}"
-                            Else
-                                ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
-                                ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
-                            End If
+                        If My.Settings.recordIgnoredLogs Then
+                            ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {ParentForm.IgnoredLogs.Count:N0}"
+                        Else
+                            ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
+                            ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
+                        End If
 
                         SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
                             If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -407,8 +407,13 @@ Namespace SyslogParser
                                                                                            If Not matchFound Then
                                                                                                _strIgnoredPattern = strRegexPattern
                                                                                                matchFound = True
-                                                                                               IgnoredHits.AddOrUpdate(strRegexPattern, 1, Function(key As String, oldValue As Integer) oldValue + 1)
-                                                                                               IgnoredLastEvent.AddOrUpdate(strRegexPattern, Date.Now, Function(key As String, oldValue As Date) Date.Now)
+
+                                                                                               IgnoredStats.AddOrUpdate(strRegexPattern, Function(key As String) New IgnoredStatsEntry With {.Hits = 1, .LastEvent = Now}, Function(key As String, oldValue As IgnoredStatsEntry)
+                                                                                                                                                                                                                               oldValue.Hits += 1
+                                                                                                                                                                                                                               oldValue.LastEvent = Now
+                                                                                                                                                                                                                               Return oldValue
+                                                                                                                                                                                                                           End Function)
+
                                                                                                state.Stop()
                                                                                                If ParentForm IsNot Nothing Then ParentForm.Invoke(Sub() Interlocked.Increment(longNumberOfIgnoredLogs))
                                                                                            End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -492,7 +492,6 @@ Namespace SyslogParser
                                                                                  )
                         NewIgnoredItem.IgnoredPattern = strIgnoredPattern
 
-                        SyncLock ParentForm.IgnoredLogsLockingObject
                             If ParentForm.IgnoredLogs.Count < My.Settings.LimitNumberOfIgnoredLogs Then
                                 ParentForm.IgnoredLogs.Add(NewIgnoredItem)
                             Else
@@ -509,7 +508,6 @@ Namespace SyslogParser
                                 ParentForm.ZerooutIgnoredLogsCounterToolStripMenuItem.Enabled = True
                                 ParentForm.LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
                             End If
-                        End SyncLock
 
                         SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
                             If IgnoredLogsAndSearchResultsInstance IsNot Nothing Then IgnoredLogsAndSearchResultsInstance.AddIgnoredDatagrid(NewIgnoredItem)

--- a/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
+++ b/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
@@ -124,6 +124,18 @@ Namespace ThreadSafetyLists
         Private ReadOnly _list As New List(Of T)
         Private ReadOnly _lock As New Object()
 
+        Public Function Count() As Integer
+            SyncLock _lock
+                Return _list.Count
+            End SyncLock
+        End Function
+
+        Public Function Any() As Boolean
+            SyncLock _lock
+                Return _list.Any()
+            End SyncLock
+        End Function
+
         Public Sub Add(item As T)
             SyncLock _lock
                 _list.Add(item)

--- a/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
+++ b/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
@@ -136,6 +136,14 @@ Namespace ThreadSafetyLists
             End SyncLock
         End Function
 
+        Public Function TryRemoveAt(index As Integer) As Boolean
+            SyncLock _lock
+                If index < 0 OrElse index >= _list.Count Then Return False
+                _list.RemoveAt(index)
+                Return True
+            End SyncLock
+        End Function
+
         Public Sub Add(item As T)
             SyncLock _lock
                 _list.Add(item)

--- a/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
+++ b/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
@@ -130,11 +130,13 @@ Namespace ThreadSafetyLists
             End SyncLock
         End Sub
 
-        Public Sub Merge(items As IEnumerable(Of T))
+		Public Sub Merge(items As IEnumerable(Of T))
+            Dim snapshot As List(Of T) = items.ToList()
+
             SyncLock _lock
-                _list.AddRange(items)
-            End SyncLock
-        End Sub
+				_list.AddRange(snapshot)
+			End SyncLock
+		End Sub
 
         Public Sub Clear()
             SyncLock _lock

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -159,6 +159,19 @@
                 ' If both are enabled, sort by dateOfLastOccurrence
                 Return If(soSortOrder = SortOrder.Ascending, hits1.CompareTo(hits2), hits2.CompareTo(hits1))
             Else
+                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+
+                Dim enabled1 As Boolean = item1.BoolEnabled
+                Dim enabled2 As Boolean = item2.BoolEnabled
+
+                ' Always keep enabled items above disabled items (independent of sort order)
+                If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
+                If Not enabled1 AndAlso enabled2 Then Return 1      ' item2 first
+
+                ' If both disabled, don't change their relative order
+                If Not enabled1 AndAlso Not enabled2 Then Return 0
+
                 ' Compare them.
                 If Double.TryParse(strFirstString, dbl1) And Double.TryParse(strSecondString, dbl2) Then
                     Return If(soSortOrder = SortOrder.Ascending, dbl1.CompareTo(dbl2), dbl2.CompareTo(dbl1))

--- a/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
+++ b/Free SysLog/Support Code/Namespace Code/listViewSorter.vb
@@ -63,17 +63,20 @@
             Dim lvSecondListView As ListViewItem = lvInputSecondListView
             Dim lvFirstListViewType As Type = lvFirstListView.GetType
             Dim lvSecondListViewType As Type = lvSecondListView.GetType
+            Dim enabled1, enabled2, bothZeroHits As Boolean
+            Dim hits1, hits2 As Integer
+            Dim item1, item2 As MyIgnoredListViewItem
 
             ' Get the sub-item values.
             strFirstString = If(lvFirstListView.SubItems.Count <= intColumnNumber, "", lvFirstListView.SubItems(intColumnNumber).Text)
             strSecondString = If(lvSecondListView.SubItems.Count <= intColumnNumber, "", lvSecondListView.SubItems(intColumnNumber).Text)
 
             If intColumnNumber = 8 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
-                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
-                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+                item1 = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                item2 = DirectCast(lvSecondListView, MyIgnoredListViewItem)
 
-                Dim enabled1 As Boolean = item1.BoolEnabled
-                Dim enabled2 As Boolean = item2.BoolEnabled
+                enabled1 = item1.BoolEnabled
+                enabled2 = item2.BoolEnabled
 
                 ' Always keep enabled items above disabled items (independent of sort order)
                 If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
@@ -83,10 +86,10 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1 As Integer = item1.intHits
-                Dim hits2 As Integer = item2.intHits
+                hits1 = item1.intHits
+                hits2 = item2.intHits
 
-                Dim bothZeroHits As Boolean = hits1 = 0 AndAlso hits2 = 0
+                bothZeroHits = hits1 = 0 AndAlso hits2 = 0
 
                 ' Enabled items with hits > 0 should sort ahead of hits = 0
                 If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
@@ -101,11 +104,11 @@
 
                 Return If(soSortOrder = SortOrder.Ascending, timeSpan1.CompareTo(timeSpan2), timeSpan2.CompareTo(timeSpan1))
             ElseIf intColumnNumber = 7 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
-                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
-                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+                item1 = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                item2 = DirectCast(lvSecondListView, MyIgnoredListViewItem)
 
-                Dim enabled1 As Boolean = item1.BoolEnabled
-                Dim enabled2 As Boolean = item2.BoolEnabled
+                enabled1 = item1.BoolEnabled
+                enabled2 = item2.BoolEnabled
 
                 ' Always keep enabled items above disabled items (independent of sort order)
                 If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
@@ -115,10 +118,10 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1 As Integer = item1.intHits
-                Dim hits2 As Integer = item2.intHits
+                hits1 = item1.intHits
+                hits2 = item2.intHits
 
-                Dim bothZeroHits As Boolean = hits1 = 0 AndAlso hits2 = 0
+                bothZeroHits = hits1 = 0 AndAlso hits2 = 0
 
                 ' Enabled items with hits > 0 should sort ahead of hits = 0
                 If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
@@ -130,11 +133,11 @@
                 ' If both are enabled, sort by dateOfLastOccurrence
                 Return If(soSortOrder = SortOrder.Ascending, item1.dateOfLastOccurrence.CompareTo(item2.dateOfLastOccurrence), item2.dateOfLastOccurrence.CompareTo(item1.dateOfLastOccurrence))
             ElseIf intColumnNumber = 4 AndAlso TypeOf lvFirstListView Is MyIgnoredListViewItem AndAlso TypeOf lvSecondListView Is MyIgnoredListViewItem Then
-                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
-                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+                item1 = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                item2 = DirectCast(lvSecondListView, MyIgnoredListViewItem)
 
-                Dim enabled1 As Boolean = item1.BoolEnabled
-                Dim enabled2 As Boolean = item2.BoolEnabled
+                enabled1 = item1.BoolEnabled
+                enabled2 = item2.BoolEnabled
 
                 ' Always keep enabled items above disabled items (independent of sort order)
                 If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first
@@ -144,10 +147,10 @@
                 If Not enabled1 AndAlso Not enabled2 Then Return 0
 
                 ' --- Now compare ENABLED items by hits first ---
-                Dim hits1 As Integer = item1.intHits
-                Dim hits2 As Integer = item2.intHits
+                hits1 = item1.intHits
+                hits2 = item2.intHits
 
-                Dim bothZeroHits As Boolean = hits1 = 0 AndAlso hits2 = 0
+                bothZeroHits = hits1 = 0 AndAlso hits2 = 0
 
                 ' Enabled items with hits > 0 should sort ahead of hits = 0
                 If hits1 = 0 AndAlso hits2 <> 0 Then Return 1    ' item1 goes below
@@ -159,11 +162,11 @@
                 ' If both are enabled, sort by dateOfLastOccurrence
                 Return If(soSortOrder = SortOrder.Ascending, hits1.CompareTo(hits2), hits2.CompareTo(hits1))
             Else
-                Dim item1 As MyIgnoredListViewItem = DirectCast(lvFirstListView, MyIgnoredListViewItem)
-                Dim item2 As MyIgnoredListViewItem = DirectCast(lvSecondListView, MyIgnoredListViewItem)
+                item1 = DirectCast(lvFirstListView, MyIgnoredListViewItem)
+                item2 = DirectCast(lvSecondListView, MyIgnoredListViewItem)
 
-                Dim enabled1 As Boolean = item1.BoolEnabled
-                Dim enabled2 As Boolean = item2.BoolEnabled
+                enabled1 = item1.BoolEnabled
+                enabled2 = item2.BoolEnabled
 
                 ' Always keep enabled items above disabled items (independent of sort order)
                 If enabled1 AndAlso Not enabled2 Then Return -1     ' item1 first

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -402,7 +402,7 @@ Public Class Alerts
                 listOfAlertsClass.Add(New AlertsClass() With {.StrLogText = item.StrLogText, .StrAlertText = item.StrAlertText, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .alertType = item.AlertType, .BoolEnabled = item.BoolEnabled, .BoolLimited = item.BoolLimited})
             Next
 
-            IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -2,7 +2,7 @@
 
 Public Class Alerts
     Private boolDoneLoading As Boolean = False
-    Public boolChanged As Boolean = False
+    Private boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
@@ -320,6 +320,8 @@ Public Class Alerts
 
             My.Settings.alerts = tempAlerts
             My.Settings.Save()
+
+            AlertsRegexCache.Clear()
         Catch ex As Exception
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -247,7 +247,7 @@ Public Class ConfigureSysLogMirrorClients
                 listOfSysLogProxyServer.Add(New SysLogProxyServer() With {.ip = item.SubItems(0).Text, .port = Integer.Parse(item.SubItems(1).Text), .boolEnabled = item.BoolEnabled, .name = item.SubItems(3).Text})
             Next
 
-            IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfSysLogProxyServer, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfSysLogProxyServer, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -3,7 +3,7 @@ Imports System.Net
 Imports Free_SysLog.SupportCode
 
 Public Class ConfigureSysLogMirrorClients
-    Public boolSuccess As Boolean = False
+    Private boolSuccess As Boolean = False
     Private boolEditMode As Boolean = False
     Private boolDoneLoading As Boolean = False
     Private draggedItem As ListViewItem
@@ -193,6 +193,8 @@ Public Class ConfigureSysLogMirrorClients
 
             My.Settings.ServersToSendTo = tempServer
             My.Settings.Save()
+
+            MsgBox("Done", MsgBoxStyle.Information, "Free SysLog Server")
         Catch ex As Exception
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -142,6 +142,7 @@ Partial Class Form1
         Me.ReOpenToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
+        Me.lblProcessUptime = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.colDelete = New System.Windows.Forms.DataGridViewCheckBoxColumn()
         Me.StatusStrip.SuspendLayout()
@@ -241,7 +242,7 @@ Partial Class Form1
         '
         'StatusStrip
         '
-        Me.StatusStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.NumberOfLogs, Me.LblItemsSelected, Me.LblAutoSaved, Me.LblLogFileSize, Me.LblNumberOfIgnoredIncomingLogs, Me.LblAutoScrollStatus})
+        Me.StatusStrip.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.NumberOfLogs, Me.LblItemsSelected, Me.LblAutoSaved, Me.LblLogFileSize, Me.LblNumberOfIgnoredIncomingLogs, Me.LblAutoScrollStatus, Me.lblProcessUptime})
         Me.StatusStrip.Location = New System.Drawing.Point(0, 424)
         Me.StatusStrip.Name = "StatusStrip"
         Me.StatusStrip.Size = New System.Drawing.Size(1175, 22)
@@ -286,6 +287,7 @@ Partial Class Form1
         '
         'LblAutoScrollStatus
         '
+        Me.LblAutoScrollStatus.Margin = New System.Windows.Forms.Padding(0, 3, 25, 2)
         Me.LblAutoScrollStatus.Name = "LblAutoScrollStatus"
         Me.LblAutoScrollStatus.Size = New System.Drawing.Size(200, 17)
         Me.LblAutoScrollStatus.Text = "Auto Scroll Status: Disabled"
@@ -979,6 +981,12 @@ Partial Class Form1
         Me.boxLimiter.Sorted = True
         Me.boxLimiter.TabIndex = 44
         '
+        'lblProcessUptime
+        '
+        Me.lblProcessUptime.Name = "lblProcessUptime"
+        Me.lblProcessUptime.Size = New System.Drawing.Size(92, 17)
+        Me.lblProcessUptime.Text = "Process Uptime:"
+        '
         'boxLimitBy
         '
         Me.boxLimitBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
@@ -1152,4 +1160,5 @@ Partial Class Form1
     Friend WithEvents lblLimitBy As Label
     Friend WithEvents btnShowLimit As Button
     Friend WithEvents colDelete As DataGridViewCheckBoxColumn
+    Friend WithEvents lblProcessUptime As ToolStripStatusLabel
 End Class

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -913,9 +913,9 @@ Partial Class Form1
         Me.SaveIgnoredLogCount.Name = "SaveIgnoredLogCount"
         Me.SaveIgnoredLogCount.Size = New System.Drawing.Size(319, 22)
         Me.SaveIgnoredLogCount.Text = "Save Ignored Log Count"
-        Me.SaveIgnoredLogCount.ToolTipText = "In case you want to reach a very high number without having" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "to keep the program " &
-    "running for a very long time. This is" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "more for the funzies, if you know what I " &
-    "mean."
+        Me.SaveIgnoredLogCount.ToolTipText = "Saves the ignored log count and ignored rule stat data to disk for historical ana" &
+    "lysis." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Before it was for the funzies, now this can be an incredible tool to hel" &
+    "p you fine tune rules."
         '
         'CreateIgnoredLogToolStripMenuItem
         '

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -985,7 +985,7 @@ Partial Class Form1
         '
         Me.lblProcessUptime.Name = "lblProcessUptime"
         Me.lblProcessUptime.Size = New System.Drawing.Size(92, 17)
-        Me.lblProcessUptime.Text = "Process Uptime:"
+        Me.lblProcessUptime.Text = "Program Uptime:"
         '
         'boxLimitBy
         '

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -522,7 +522,7 @@ Public Class Form1
         LblAutoScrollStatus.Text = $"Auto Scroll Status: {If(ChkEnableAutoScroll.Checked, "Enabled", "Disabled")}"
 
         If My.Settings.saveIgnoredLogCount Then
-            longNumberOfIgnoredLogs = My.Settings.ignoredLogCount
+            longNumberOfIgnoredLogs = NumberOfIgnoredLogs
             LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
         End If
 
@@ -981,7 +981,7 @@ Public Class Form1
         processUptimeTimer.Dispose()
 
         If My.Settings.saveIgnoredLogCount Then
-            My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
+            NumberOfIgnoredLogs = longNumberOfIgnoredLogs
             File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
             File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
         End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -973,7 +973,7 @@ Public Class Form1
         My.Settings.logsColumnOrder = SaveColumnOrders(Logs.Columns)
         My.Settings.Save()
         WriteLogsToDisk()
-        processUptimeTimer.Dispose()
+        processUptimeTimer?.Dispose()
 
         If My.Settings.saveIgnoredLogCount Then
             NumberOfIgnoredLogs = longNumberOfIgnoredLogs

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -486,7 +486,7 @@ Public Class Form1
         LoadCheckboxSettings()
 
         processUptimeTimer = New Timer() With {.Interval = 1000, .Enabled = True}
-        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Process Uptime: {TimespanToDHM(Now.ToLocalTime - dateProcessStarted.ToLocalTime)}"
+        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToDHM(Now.ToLocalTime - dateProcessStarted.ToLocalTime)}"
 
         SetDoubleBufferingFlag(Logs)
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -28,6 +28,12 @@ Public Class Form1
     Private processUptimeTimer As Timer
     Private dateProcessStarted As Date = Process.GetCurrentProcess.StartTime.ToLocalTime
 
+    Private HostNamesInstance As Hostnames
+    Private IgnoredWordsAndPhrasesOrAlertsInstance As IgnoredWordsAndPhrases
+    Private ReplacementsInstance As Replacements
+    Private AlertsInstance As Alerts
+    Private ConfigureSysLogMirrorClientsInstance As ConfigureSysLogMirrorClients
+
 #Region "--== Midnight Timer Code ==--"
     ' This implementation is based on code found at https://www.codeproject.com/Articles/18201/Midnight-Timer-A-Way-to-Detect-When-it-is-Midnight.
     ' I have rewritten the code to ensure that I fully understand it and to avoid blatantly copying someone else's work.
@@ -1113,20 +1119,29 @@ Public Class Form1
     End Sub
 
     Private Sub IgnoredWordsAndPhrasesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Click
-        Dim IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-        IgnoredWordsAndPhrasesOrAlertsInstance.Show()
+        If IgnoredWordsAndPhrasesOrAlertsInstance IsNot Nothing AndAlso Not IgnoredWordsAndPhrasesOrAlertsInstance.IsDisposed Then
+            IgnoredWordsAndPhrasesOrAlertsInstance.WindowState = FormWindowState.Normal
+            IgnoredWordsAndPhrasesOrAlertsInstance.BringToFront()
+        Else
+            IgnoredWordsAndPhrasesOrAlertsInstance = New IgnoredWordsAndPhrases() With {.Icon = Icon}
+            IgnoredWordsAndPhrasesOrAlertsInstance.Show()
+        End If
     End Sub
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
         SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
-            If IgnoredLogsAndSearchResultsInstance Is Nothing Then
-                IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.MainProgramForm = Me, .Icon = Icon, .LogsToBeDisplayed = IgnoredLogs, .Text = "Ignored Logs"}
-                IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
-                IgnoredLogsAndSearchResultsInstance.Show()
-            Else
-                IgnoredLogsAndSearchResultsInstance.WindowState = FormWindowState.Normal
+            If IgnoredLogsAndSearchResultsInstance IsNot Nothing AndAlso Not IgnoredLogsAndSearchResultsInstance.IsDisposed Then
+                IgnoredWordsAndPhrasesOrAlertsInstance.WindowState = FormWindowState.Normal
                 IgnoredLogsAndSearchResultsInstance.BringToFront()
+            Else
+                IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.Icon = Icon}
+                IgnoredLogsAndSearchResultsInstance.Show()
             End If
+
+            IgnoredLogsAndSearchResultsInstance.MainProgramForm = Me
+            IgnoredLogsAndSearchResultsInstance.Text = "Ignored Logs"
+            IgnoredLogsAndSearchResultsInstance.LogsToBeDisplayed = IgnoredLogs
+            IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
         End SyncLock
     End Sub
 
@@ -1238,8 +1253,13 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click
-        Dim ReplacementsInstance As New Replacements With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-        ReplacementsInstance.Show()
+        If ReplacementsInstance IsNot Nothing AndAlso Not ReplacementsInstance.IsDisposed Then
+            ReplacementsInstance.WindowState = FormWindowState.Normal
+            ReplacementsInstance.BringToFront()
+        Else
+            ReplacementsInstance = New Replacements() With {.Icon = Icon}
+            ReplacementsInstance.Show()
+        End If
     End Sub
 
     Private Sub ConfigureAlternatingColorToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChangeAlternatingColorToolStripMenuItem.Click
@@ -1559,8 +1579,13 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureAlertsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureAlertsToolStripMenuItem.Click
-        Dim Alerts As New Alerts With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-        Alerts.Show()
+        If AlertsInstance IsNot Nothing AndAlso Not AlertsInstance.IsDisposed Then
+            AlertsInstance.WindowState = FormWindowState.Normal
+            AlertsInstance.BringToFront()
+        Else
+            AlertsInstance = New Alerts() With {.Icon = Icon}
+            AlertsInstance.Show()
+        End If
     End Sub
 
     Private Sub OpenWindowsExplorerToAppConfigFile_Click(sender As Object, e As EventArgs) Handles OpenWindowsExplorerToAppConfigFile.Click
@@ -1569,10 +1594,15 @@ Public Class Form1
     End Sub
 
     Private Sub CreateAlertToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateAlertToolStripMenuItem.Click
-        Using Alerts As New Alerts With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-            Alerts.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
-            Alerts.Show()
-        End Using
+        If AlertsInstance IsNot Nothing AndAlso Not AlertsInstance.IsDisposed Then
+            AlertsInstance.WindowState = FormWindowState.Normal
+            AlertsInstance.BringToFront()
+        Else
+            AlertsInstance = New Alerts With {.Icon = Icon}
+            AlertsInstance.Show()
+        End If
+
+        AlertsInstance.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
     End Sub
 
     Private Sub ChangeSyslogServerPortToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChangeSyslogServerPortToolStripMenuItem.Click
@@ -1634,22 +1664,29 @@ Public Class Form1
 
     Private Sub CreateIgnoredLogToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateIgnoredLogToolStripMenuItem.Click
         If Logs.SelectedRows.Count > 0 Then
-            Using Ignored As New IgnoredWordsAndPhrases With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-                Dim myItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+            If IgnoredWordsAndPhrasesOrAlertsInstance IsNot Nothing AndAlso Not IgnoredWordsAndPhrasesOrAlertsInstance.IsDisposed Then
+                IgnoredWordsAndPhrasesOrAlertsInstance.WindowState = FormWindowState.Normal
+                IgnoredWordsAndPhrasesOrAlertsInstance.BringToFront()
+            Else
+                IgnoredWordsAndPhrasesOrAlertsInstance = New IgnoredWordsAndPhrases() With {.Icon = Icon}
+                IgnoredWordsAndPhrasesOrAlertsInstance.Show()
+            End If
 
-                If myItem IsNot Nothing Then
-                    Ignored.TxtIgnored.Text = myItem.RawLogData
-                    Ignored.ShowDialog(Me)
-                End If
-            End Using
+            Dim myItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+            If myItem IsNot Nothing Then IgnoredWordsAndPhrasesOrAlertsInstance.TxtIgnored.Text = myItem.RawLogData
         End If
     End Sub
 
     Private Sub CreateReplacementToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateReplacementToolStripMenuItem.Click
-        Using Replacements As New Replacements With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-            Replacements.TxtReplace.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
-            Replacements.ShowDialog(Me)
-        End Using
+        If ReplacementsInstance IsNot Nothing AndAlso Not ReplacementsInstance.IsDisposed Then
+            ReplacementsInstance.WindowState = FormWindowState.Normal
+            ReplacementsInstance.BringToFront()
+        Else
+            ReplacementsInstance = New Replacements With {.Icon = Icon}
+            ReplacementsInstance.Show()
+        End If
+
+        ReplacementsInstance.TxtReplace.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
     End Sub
 
     Private Sub Logs_SelectionChanged(sender As Object, e As EventArgs) Handles Logs.SelectionChanged
@@ -1666,8 +1703,13 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureSysLogMirrorServers_Click(sender As Object, e As EventArgs) Handles ConfigureSysLogMirrorServers.Click
-        Dim ConfigureSysLogMirrorClients As New ConfigureSysLogMirrorClients With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-        ConfigureSysLogMirrorClients.Show()
+        If ConfigureSysLogMirrorClientsInstance IsNot Nothing AndAlso Not ConfigureSysLogMirrorClientsInstance.IsDisposed Then
+            ConfigureSysLogMirrorClientsInstance.WindowState = FormWindowState.Normal
+            ConfigureSysLogMirrorClientsInstance.BringToFront()
+        Else
+            ConfigureSysLogMirrorClientsInstance = New ConfigureSysLogMirrorClients() With {.Icon = Icon}
+            ConfigureSysLogMirrorClientsInstance.Show()
+        End If
     End Sub
 
     Private Sub ChkShowAlertedColumn_Click(sender As Object, e As EventArgs) Handles ChkShowAlertedColumn.Click
@@ -1853,8 +1895,13 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureHostnames_Click(sender As Object, e As EventArgs) Handles ConfigureHostnames.Click
-        Dim hostnames As New Hostnames() With {.Icon = Icon}
-        hostnames.Show()
+        If HostNamesInstance IsNot Nothing AndAlso Not HostNamesInstance.IsDisposed Then
+            HostNamesInstance.WindowState = FormWindowState.Normal
+            HostNamesInstance.BringToFront()
+        Else
+            HostNamesInstance = New Hostnames() With {.Icon = Icon}
+            HostNamesInstance.Show()
+        End If
     End Sub
 
     Private Sub ChangeFont_Click(sender As Object, e As EventArgs) Handles ChangeFont.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1072,7 +1072,7 @@ Public Class Form1
     End Sub
 
     Private Sub Logs_ColumnHeaderMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles Logs.ColumnHeaderMouseClick
-        If e.Button = MouseButtons.Left Then
+        If e.Button = MouseButtons.Left And e.ColumnIndex <> colDelete.Index Then
             Dim column As DataGridViewColumn = Logs.Columns(e.ColumnIndex)
             intSortColumnIndex = e.ColumnIndex
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -982,8 +982,8 @@ Public Class Form1
 
         If My.Settings.saveIgnoredLogCount Then
             NumberOfIgnoredLogs = longNumberOfIgnoredLogs
-            File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
-            File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
         End If
 
         If boolDoWeOwnTheMutex Then

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -161,12 +161,7 @@ Public Class Form1
                     End If
                 Next
 
-                Using fileStream As New StreamWriter(strPathToDataFile & ".new")
-                    fileStream.Write(Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
-                End Using
-
-                File.Delete(strPathToDataFile)
-                File.Move(strPathToDataFile & ".new", strPathToDataFile)
+                WriteFileAtomically(strPathToDataFile, Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
             Catch ex As Exception
                 MsgBox("A critical error occurred while writing log data to disk. The old data had been saved to prevent data corruption and loss.", MsgBoxStyle.Critical, Text)
                 Process.GetCurrentProcess.Kill()
@@ -699,7 +694,7 @@ Public Class Form1
             File.Copy(strPathToDataFile, $"{strPathToDataFile}.bad")
         End If
 
-        File.WriteAllText(strPathToDataFile, "[]")
+        WriteFileAtomically(strPathToDataFile, "[]")
         LblLogFileSize.Text = $"Log File Size: {FileSizeToHumanSize(New FileInfo(strPathToDataFile).Length)}"
 
         SyncLock dataGridLockObject

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -977,8 +977,7 @@ Public Class Form1
 
         If My.Settings.saveIgnoredLogCount Then
             NumberOfIgnoredLogs = longNumberOfIgnoredLogs
-            WriteFileAtomically(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
-            WriteFileAtomically(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
         End If
 
         If boolDoWeOwnTheMutex Then
@@ -1251,8 +1250,7 @@ Public Class Form1
     End Sub
 
     Private Sub ZerooutIgnoredLogsCounterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ZerooutIgnoredLogsCounterToolStripMenuItem.Click
-        IgnoredLastEvent.Clear()
-        IgnoredHits.Clear()
+        IgnoredStats.Clear()
         longNumberOfIgnoredLogs = 0
         LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
     End Sub

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1118,25 +1118,35 @@ Public Class Form1
         Logs.ResumeLayout()
     End Sub
 
-    Private Sub IgnoredWordsAndPhrasesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Click
-        If IgnoredWordsAndPhrasesOrAlertsInstance IsNot Nothing AndAlso Not IgnoredWordsAndPhrasesOrAlertsInstance.IsDisposed Then
-            IgnoredWordsAndPhrasesOrAlertsInstance.WindowState = FormWindowState.Normal
-            IgnoredWordsAndPhrasesOrAlertsInstance.BringToFront()
+    Public Sub ShowSingleInstanceWindow(Of T As {Form, New})(ByRef instance As T, ownerIcon As Icon)
+        If instance IsNot Nothing AndAlso Not instance.IsDisposed Then
+            instance.WindowState = FormWindowState.Normal
+            instance.BringToFront()
+            instance.Activate()
         Else
-            IgnoredWordsAndPhrasesOrAlertsInstance = New IgnoredWordsAndPhrases() With {.Icon = Icon}
-            IgnoredWordsAndPhrasesOrAlertsInstance.Show()
+            instance = New T() With {.Icon = ownerIcon}
+            instance.Show()
         End If
+    End Sub
+
+    Public Sub ShowSingleInstanceWindow(Of T As Form)(ByRef instance As T, createForm As Func(Of T))
+        If instance IsNot Nothing AndAlso Not instance.IsDisposed Then
+            instance.WindowState = FormWindowState.Normal
+            instance.BringToFront()
+            instance.Activate()
+        Else
+            instance = createForm()
+            instance.Show()
+        End If
+    End Sub
+
+    Private Sub IgnoredWordsAndPhrasesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Click
+        ShowSingleInstanceWindow(Of IgnoredWordsAndPhrases)(IgnoredWordsAndPhrasesOrAlertsInstance, Me.Icon)
     End Sub
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
         SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
-            If IgnoredLogsAndSearchResultsInstance IsNot Nothing AndAlso Not IgnoredLogsAndSearchResultsInstance.IsDisposed Then
-                IgnoredWordsAndPhrasesOrAlertsInstance.WindowState = FormWindowState.Normal
-                IgnoredLogsAndSearchResultsInstance.BringToFront()
-            Else
-                IgnoredLogsAndSearchResultsInstance = New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.Icon = Icon}
-                IgnoredLogsAndSearchResultsInstance.Show()
-            End If
+            ShowSingleInstanceWindow(IgnoredLogsAndSearchResultsInstance, Function() New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.Icon = Icon})
 
             IgnoredLogsAndSearchResultsInstance.MainProgramForm = Me
             IgnoredLogsAndSearchResultsInstance.Text = "Ignored Logs"
@@ -1253,13 +1263,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click
-        If ReplacementsInstance IsNot Nothing AndAlso Not ReplacementsInstance.IsDisposed Then
-            ReplacementsInstance.WindowState = FormWindowState.Normal
-            ReplacementsInstance.BringToFront()
-        Else
-            ReplacementsInstance = New Replacements() With {.Icon = Icon}
-            ReplacementsInstance.Show()
-        End If
+        ShowSingleInstanceWindow(Of Replacements)(ReplacementsInstance, Icon)
     End Sub
 
     Private Sub ConfigureAlternatingColorToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChangeAlternatingColorToolStripMenuItem.Click
@@ -1579,13 +1583,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureAlertsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureAlertsToolStripMenuItem.Click
-        If AlertsInstance IsNot Nothing AndAlso Not AlertsInstance.IsDisposed Then
-            AlertsInstance.WindowState = FormWindowState.Normal
-            AlertsInstance.BringToFront()
-        Else
-            AlertsInstance = New Alerts() With {.Icon = Icon}
-            AlertsInstance.Show()
-        End If
+        ShowSingleInstanceWindow(Of Alerts)(AlertsInstance, Icon)
     End Sub
 
     Private Sub OpenWindowsExplorerToAppConfigFile_Click(sender As Object, e As EventArgs) Handles OpenWindowsExplorerToAppConfigFile.Click
@@ -1594,14 +1592,7 @@ Public Class Form1
     End Sub
 
     Private Sub CreateAlertToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateAlertToolStripMenuItem.Click
-        If AlertsInstance IsNot Nothing AndAlso Not AlertsInstance.IsDisposed Then
-            AlertsInstance.WindowState = FormWindowState.Normal
-            AlertsInstance.BringToFront()
-        Else
-            AlertsInstance = New Alerts With {.Icon = Icon}
-            AlertsInstance.Show()
-        End If
-
+        ShowSingleInstanceWindow(Of Alerts)(AlertsInstance, Icon)
         AlertsInstance.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
     End Sub
 
@@ -1664,13 +1655,7 @@ Public Class Form1
 
     Private Sub CreateIgnoredLogToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateIgnoredLogToolStripMenuItem.Click
         If Logs.SelectedRows.Count > 0 Then
-            If IgnoredWordsAndPhrasesOrAlertsInstance IsNot Nothing AndAlso Not IgnoredWordsAndPhrasesOrAlertsInstance.IsDisposed Then
-                IgnoredWordsAndPhrasesOrAlertsInstance.WindowState = FormWindowState.Normal
-                IgnoredWordsAndPhrasesOrAlertsInstance.BringToFront()
-            Else
-                IgnoredWordsAndPhrasesOrAlertsInstance = New IgnoredWordsAndPhrases() With {.Icon = Icon}
-                IgnoredWordsAndPhrasesOrAlertsInstance.Show()
-            End If
+            ShowSingleInstanceWindow(Of IgnoredWordsAndPhrases)(IgnoredWordsAndPhrasesOrAlertsInstance, Icon)
 
             Dim myItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
             If myItem IsNot Nothing Then IgnoredWordsAndPhrasesOrAlertsInstance.TxtIgnored.Text = myItem.RawLogData
@@ -1678,14 +1663,7 @@ Public Class Form1
     End Sub
 
     Private Sub CreateReplacementToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateReplacementToolStripMenuItem.Click
-        If ReplacementsInstance IsNot Nothing AndAlso Not ReplacementsInstance.IsDisposed Then
-            ReplacementsInstance.WindowState = FormWindowState.Normal
-            ReplacementsInstance.BringToFront()
-        Else
-            ReplacementsInstance = New Replacements With {.Icon = Icon}
-            ReplacementsInstance.Show()
-        End If
-
+        ShowSingleInstanceWindow(Of Replacements)(ReplacementsInstance, Icon)
         ReplacementsInstance.TxtReplace.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
     End Sub
 
@@ -1703,13 +1681,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureSysLogMirrorServers_Click(sender As Object, e As EventArgs) Handles ConfigureSysLogMirrorServers.Click
-        If ConfigureSysLogMirrorClientsInstance IsNot Nothing AndAlso Not ConfigureSysLogMirrorClientsInstance.IsDisposed Then
-            ConfigureSysLogMirrorClientsInstance.WindowState = FormWindowState.Normal
-            ConfigureSysLogMirrorClientsInstance.BringToFront()
-        Else
-            ConfigureSysLogMirrorClientsInstance = New ConfigureSysLogMirrorClients() With {.Icon = Icon}
-            ConfigureSysLogMirrorClientsInstance.Show()
-        End If
+        ShowSingleInstanceWindow(Of ConfigureSysLogMirrorClients)(ConfigureSysLogMirrorClientsInstance, Icon)
     End Sub
 
     Private Sub ChkShowAlertedColumn_Click(sender As Object, e As EventArgs) Handles ChkShowAlertedColumn.Click
@@ -1895,13 +1867,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureHostnames_Click(sender As Object, e As EventArgs) Handles ConfigureHostnames.Click
-        If HostNamesInstance IsNot Nothing AndAlso Not HostNamesInstance.IsDisposed Then
-            HostNamesInstance.WindowState = FormWindowState.Normal
-            HostNamesInstance.BringToFront()
-        Else
-            HostNamesInstance = New Hostnames() With {.Icon = Icon}
-            HostNamesInstance.Show()
-        End If
+        ShowSingleInstanceWindow(Of Hostnames)(HostNamesInstance, Icon)
     End Sub
 
     Private Sub ChangeFont_Click(sender As Object, e As EventArgs) Handles ChangeFont.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -975,6 +975,11 @@ Public Class Form1
         WriteLogsToDisk()
         processUptimeTimer.Dispose()
 
+        If My.Settings.saveIgnoredLogCount Then
+            File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
+            File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
+        End If
+
         If boolDoWeOwnTheMutex Then
             SendMessageToSysLogServer(strTerminate, My.Settings.sysLogPort)
             If My.Settings.EnableTCPServer Then SendMessageToTCPSysLogServer(strTerminate, My.Settings.sysLogPort)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -2128,6 +2128,20 @@ Public Class Form1
         My.Settings.OnlySaveAlertedLogs = OnlySaveAlertedLogs.Checked
     End Sub
 
+    Private Sub Logs_CellContentClick(sender As Object, e As DataGridViewCellEventArgs) Handles Logs.CellContentClick
+        If e.ColumnIndex = colDelete.Index AndAlso e.RowIndex >= 0 Then
+            Dim intNumberOfCheckedLogs As Integer = Logs.Rows.Cast(Of DataGridViewRow).Count(Function(row) CBool(row.Cells(colDelete.Index).Value))
+
+            If intNumberOfCheckedLogs = 0 Then
+                LblItemsSelected.Visible = False
+                LblItemsSelected.Text = Nothing
+            Else
+                LblItemsSelected.Visible = True
+                LblItemsSelected.Text = $"Checked Logs: {intNumberOfCheckedLogs:N0}"
+            End If
+        End If
+    End Sub
+
 #Region "-- SysLog Server Code --"
     Sub SysLogThread()
         Try

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -9,12 +9,12 @@ Imports System.Configuration
 Imports Free_SysLog.SupportCode
 Imports Microsoft.Toolkit.Uwp.Notifications
 Imports Free_SysLog.SyslogTcpServer.SyslogTcpServer
+Imports Free_SysLog.ThreadSafetyLists
 
 Public Class Form1
     Private boolMaximizedBeforeMinimize As Boolean
     Private boolDoneLoading As Boolean = False
-    Public IgnoredLogs As New List(Of MyDataGridViewRow)
-    Public IgnoredLogsLockingObject As New Object
+    Public IgnoredLogs As New ThreadSafeList(Of MyDataGridViewRow)
     Public intSortColumnIndex As Integer = 0 ' Define intColumnNumber at class level
     Public sortOrder As SortOrder = SortOrder.Ascending ' Define soSortOrder at class level
     Public ReadOnly dataGridLockObject As New Object
@@ -1147,13 +1147,11 @@ Public Class Form1
     Private Sub ClearIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ClearIgnoredLogsToolStripMenuItem.Click
         If MsgBox("Are you sure you want to clear the ignored logs stored in system memory?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then
             SyncLock IgnoredLogsLockObject
-                For Each item As MyDataGridViewRow In IgnoredLogs
+                For Each item As MyDataGridViewRow In IgnoredLogs.GetSnapshot()
                     item.Dispose()
                 Next
 
-                SyncLock IgnoredLogsLockingObject
                     IgnoredLogs.Clear()
-                End SyncLock
 
                 GC.Collect()
                 GC.WaitForPendingFinalizers()
@@ -1189,9 +1187,7 @@ Public Class Form1
         longNumberOfIgnoredLogs = 0
 
         If Not ChkEnableRecordingOfIgnoredLogs.Checked Then
-            SyncLock IgnoredLogsLockingObject
                 IgnoredLogs.Clear()
-            End SyncLock
 
             LblNumberOfIgnoredIncomingLogs.Text = "Number of ignored incoming logs: 0"
         End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1139,7 +1139,7 @@ Public Class Form1
 
             IgnoredLogsAndSearchResultsInstance.MainProgramForm = Me
             IgnoredLogsAndSearchResultsInstance.Text = "Ignored Logs"
-            IgnoredLogsAndSearchResultsInstance.LogsToBeDisplayed = IgnoredLogs
+            IgnoredLogsAndSearchResultsInstance.LogsToBeDisplayed = IgnoredLogs.GetSnapshot()
             IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
         End SyncLock
     End Sub
@@ -1151,7 +1151,7 @@ Public Class Form1
                     item.Dispose()
                 Next
 
-                    IgnoredLogs.Clear()
+                IgnoredLogs.Clear()
 
                 GC.Collect()
                 GC.WaitForPendingFinalizers()
@@ -1187,7 +1187,7 @@ Public Class Form1
         longNumberOfIgnoredLogs = 0
 
         If Not ChkEnableRecordingOfIgnoredLogs.Checked Then
-                IgnoredLogs.Clear()
+            IgnoredLogs.Clear()
 
             LblNumberOfIgnoredIncomingLogs.Text = "Number of ignored incoming logs: 0"
         End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -26,7 +26,7 @@ Public Class Form1
     Private boolTCPServerRunning As Boolean = False
     Private lastFirstDisplayedRowIndex As Integer = -1
     Private processUptimeTimer As Timer
-    Private dateProcessStarted As Date = Process.GetCurrentProcess.StartTime.ToLocalTime
+    Private dateProcessStarted As Date = Process.GetCurrentProcess.StartTime
 
     Private HostNamesInstance As Hostnames
     Private IgnoredWordsAndPhrasesOrAlertsInstance As IgnoredWordsAndPhrases
@@ -482,7 +482,7 @@ Public Class Form1
         LoadCheckboxSettings()
 
         processUptimeTimer = New Timer() With {.Interval = 1000, .Enabled = True}
-        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now.ToLocalTime - dateProcessStarted.ToLocalTime)}"
+        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now - dateProcessStarted)}"
 
         SetDoubleBufferingFlag(Logs)
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -452,14 +452,6 @@ Public Class Form1
         End If
     End Sub
 
-    Private Function TimespanToDHM(ts As TimeSpan) As String
-        Dim days As Integer = ts.Days
-        Dim hours As Integer = ts.Hours
-        Dim minutes As Integer = ts.Minutes
-        Dim seconds As Integer = ts.Seconds
-        Return $"{days}d {hours}h {minutes}m {seconds}s"
-    End Function
-
     Private Sub AutoStatSaveTimer_Tick(sender As Object, e As EventArgs)
         NumberOfIgnoredLogs = longNumberOfIgnoredLogs
         WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
@@ -492,7 +484,7 @@ Public Class Form1
         LoadCheckboxSettings()
 
         processUptimeTimer = New Timer() With {.Interval = 1000, .Enabled = True}
-        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToDHM(Now.ToLocalTime - dateProcessStarted.ToLocalTime)}"
+        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now.ToLocalTime - dateProcessStarted.ToLocalTime)}"
 
         SetDoubleBufferingFlag(Logs)
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1094,13 +1094,8 @@ Public Class Form1
     End Sub
 
     Private Sub IgnoredWordsAndPhrasesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Click
-        Using IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-            IgnoredWordsAndPhrasesOrAlertsInstance.ShowDialog(Me)
-
-            If IgnoredWordsAndPhrasesOrAlertsInstance.boolChanged Then
-                IgnoredRegexCache.Clear()
-            End If
-        End Using
+        Dim IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
+        IgnoredWordsAndPhrasesOrAlertsInstance.Show()
     End Sub
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
@@ -1224,13 +1219,8 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click
-        Using ReplacementsInstance As New Replacements With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-            ReplacementsInstance.ShowDialog(Me)
-
-            If ReplacementsInstance.boolChanged Then
-                ReplacementsRegexCache.Clear()
-            End If
-        End Using
+        Dim ReplacementsInstance As New Replacements With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
+        ReplacementsInstance.Show()
     End Sub
 
     Private Sub ConfigureAlternatingColorToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChangeAlternatingColorToolStripMenuItem.Click
@@ -1550,13 +1540,8 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureAlertsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureAlertsToolStripMenuItem.Click
-        Using Alerts As New Alerts With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-            Alerts.ShowDialog(Me)
-
-            If Alerts.boolChanged Then
-                AlertsRegexCache.Clear()
-            End If
-        End Using
+        Dim Alerts As New Alerts With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
+        Alerts.Show()
     End Sub
 
     Private Sub OpenWindowsExplorerToAppConfigFile_Click(sender As Object, e As EventArgs) Handles OpenWindowsExplorerToAppConfigFile.Click
@@ -1567,7 +1552,7 @@ Public Class Form1
     Private Sub CreateAlertToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateAlertToolStripMenuItem.Click
         Using Alerts As New Alerts With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
             Alerts.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
-            Alerts.ShowDialog(Me)
+            Alerts.Show()
         End Using
     End Sub
 
@@ -1662,10 +1647,8 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureSysLogMirrorServers_Click(sender As Object, e As EventArgs) Handles ConfigureSysLogMirrorServers.Click
-        Using ConfigureSysLogMirrorClients As New ConfigureSysLogMirrorClients With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-            ConfigureSysLogMirrorClients.ShowDialog(Me)
-            If ConfigureSysLogMirrorClients.boolSuccess Then MsgBox("Done", MsgBoxStyle.Information, Text)
-        End Using
+        Dim ConfigureSysLogMirrorClients As New ConfigureSysLogMirrorClients With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+        ConfigureSysLogMirrorClients.Show()
     End Sub
 
     Private Sub ChkShowAlertedColumn_Click(sender As Object, e As EventArgs) Handles ChkShowAlertedColumn.Click
@@ -1851,9 +1834,8 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureHostnames_Click(sender As Object, e As EventArgs) Handles ConfigureHostnames.Click
-        Using hostnames As New Hostnames() With {.Icon = Icon}
-            hostnames.ShowDialog()
-        End Using
+        Dim hostnames As New Hostnames() With {.Icon = Icon}
+        hostnames.Show()
     End Sub
 
     Private Sub ChangeFont_Click(sender As Object, e As EventArgs) Handles ChangeFont.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -975,13 +975,13 @@ Public Class Form1
             End SyncLock
         End If
 
-        If My.Settings.saveIgnoredLogCount Then My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
         My.Settings.logsColumnOrder = SaveColumnOrders(Logs.Columns)
         My.Settings.Save()
         WriteLogsToDisk()
         processUptimeTimer.Dispose()
 
         If My.Settings.saveIgnoredLogCount Then
+            My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
             File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
             File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
         End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -482,7 +482,7 @@ Public Class Form1
         LoadCheckboxSettings()
 
         processUptimeTimer = New Timer() With {.Interval = 1000, .Enabled = True}
-        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now - dateProcessStarted)}"
+        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now - dateProcessStarted, False)}"
 
         SetDoubleBufferingFlag(Logs)
 

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -203,7 +203,7 @@ Public Class Hostnames
                 stringCollection.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}))
             Next
 
-            IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -203,7 +203,7 @@ Public Class Hostnames
                 stringCollection.Add(Newtonsoft.Json.JsonConvert.SerializeObject(New CustomHostname() With {.ip = item.SubItems(0).Text, .deviceName = item.SubItems(1).Text}))
             Next
 
-            WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
+            SupportCode.WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -526,10 +526,9 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub CreateAlertToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateAlertToolStripMenuItem.Click
-        Using Alerts As New Alerts With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
-            Alerts.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
-            Alerts.ShowDialog(Me)
-        End Using
+        Dim Alerts As New Alerts With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+        Alerts.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
+        Alerts.Show()
     End Sub
 
     Private Sub Ignored_Logs_and_Search_Results_Closing(sender As Object, e As CancelEventArgs) Handles Me.Closing
@@ -631,14 +630,9 @@ Public Class IgnoredLogsAndSearchResults
             Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
             Dim strIgnoredPattern As String = selectedRow.IgnoredPattern
 
-            Using IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-                IgnoredWordsAndPhrasesOrAlertsInstance.strIgnoredPattern = strIgnoredPattern
-                IgnoredWordsAndPhrasesOrAlertsInstance.ShowDialog(Me)
-
-                If IgnoredWordsAndPhrasesOrAlertsInstance.boolChanged Then
-                    IgnoredRegexCache.Clear()
-                End If
-            End Using
+            Dim IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
+            IgnoredWordsAndPhrasesOrAlertsInstance.strIgnoredPattern = strIgnoredPattern
+            IgnoredWordsAndPhrasesOrAlertsInstance.Show()
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -33,6 +33,8 @@ Partial Class IgnoredWordsAndPhrases
         Me.colHits = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.colTarget = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.colDateCreated = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.colSinceLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.EnableDisableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ResetHitsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -57,11 +59,10 @@ Partial Class IgnoredWordsAndPhrases
         Me.txtComment = New System.Windows.Forms.TextBox()
         Me.lblCommentLabel = New System.Windows.Forms.Label()
         Me.lblTotalHits = New System.Windows.Forms.Label()
-        Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.btnUpdateHits = New System.Windows.Forms.Button()
         Me.ChkAutoRefresh = New System.Windows.Forms.CheckBox()
-        Me.colSinceLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
+        Me.ChkRefreshOnlyIfActive = New System.Windows.Forms.CheckBox()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -137,6 +138,16 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.colDateCreated.Text = "Date Created"
         Me.colDateCreated.Width = 180
+        '
+        'colDateOfLastEvent
+        '
+        Me.colDateOfLastEvent.Text = "Date of Last Event"
+        Me.colDateOfLastEvent.Width = 240
+        '
+        'colSinceLastEvent
+        '
+        Me.colSinceLastEvent.Text = "Since Last Event"
+        Me.colSinceLastEvent.Width = 100
         '
         'ListViewMenu
         '
@@ -368,16 +379,11 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.lblTotalHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblTotalHits.AutoSize = True
-        Me.lblTotalHits.Location = New System.Drawing.Point(691, 256)
+        Me.lblTotalHits.Location = New System.Drawing.Point(823, 256)
         Me.lblTotalHits.Name = "lblTotalHits"
         Me.lblTotalHits.Size = New System.Drawing.Size(103, 13)
         Me.lblTotalHits.TabIndex = 51
         Me.lblTotalHits.Text = "Total Ignored Hits: 0"
-        '
-        'colDateOfLastEvent
-        '
-        Me.colDateOfLastEvent.Text = "Date of Last Event"
-        Me.colDateOfLastEvent.Width = 240
         '
         'btnUpdateHits
         '
@@ -388,11 +394,6 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnUpdateHits.TabIndex = 52
         Me.btnUpdateHits.Text = "Update Hits and Last Events (F5)"
         Me.btnUpdateHits.UseVisualStyleBackColor = True
-        '
-        'colSinceLastEvent
-        '
-        Me.colSinceLastEvent.Text = "Since Last Event"
-        Me.colSinceLastEvent.Width = 100
         '
         'ChkAutoRefresh
         '
@@ -406,11 +407,23 @@ Partial Class IgnoredWordsAndPhrases
         Me.ToolTip.SetToolTip(Me.ChkAutoRefresh, "Enabling this makes it so that the data is refreshed every five seconds.")
         Me.ChkAutoRefresh.UseVisualStyleBackColor = True
         '
+        'ChkRefreshOnlyIfActive
+        '
+        Me.ChkRefreshOnlyIfActive.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkRefreshOnlyIfActive.AutoSize = True
+        Me.ChkRefreshOnlyIfActive.Location = New System.Drawing.Point(686, 255)
+        Me.ChkRefreshOnlyIfActive.Name = "ChkRefreshOnlyIfActive"
+        Me.ChkRefreshOnlyIfActive.Size = New System.Drawing.Size(131, 17)
+        Me.ChkRefreshOnlyIfActive.TabIndex = 54
+        Me.ChkRefreshOnlyIfActive.Text = "Only If Active Window"
+        Me.ChkRefreshOnlyIfActive.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1118, 437)
+        Me.Controls.Add(Me.ChkRefreshOnlyIfActive)
         Me.Controls.Add(Me.ChkAutoRefresh)
         Me.Controls.Add(Me.btnUpdateHits)
         Me.Controls.Add(Me.lblTotalHits)
@@ -485,4 +498,5 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents colSinceLastEvent As ColumnHeader
     Friend WithEvents ChkAutoRefresh As CheckBox
     Friend WithEvents ToolTip As ToolTip
+    Friend WithEvents ChkRefreshOnlyIfActive As CheckBox
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -404,7 +404,9 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkAutoRefresh.Size = New System.Drawing.Size(88, 17)
         Me.ChkAutoRefresh.TabIndex = 53
         Me.ChkAutoRefresh.Text = "Auto Refresh"
-        Me.ToolTip.SetToolTip(Me.ChkAutoRefresh, "Enabling this makes it so that the data is refreshed every five seconds.")
+        Me.ToolTip.SetToolTip(Me.ChkAutoRefresh, "Enabling this makes it so that the data is refreshed every five seconds." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Holding" &
+        " down the F1 key on the keyboard disables auto-refresh for as long as the key is" &
+        " pressed down.")
         Me.ChkAutoRefresh.UseVisualStyleBackColor = True
         '
         'ChkRefreshOnlyIfActive

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -59,7 +59,9 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblTotalHits = New System.Windows.Forms.Label()
         Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.btnUpdateHits = New System.Windows.Forms.Button()
+        Me.ChkAutoRefresh = New System.Windows.Forms.CheckBox()
         Me.colSinceLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -366,7 +368,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.lblTotalHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblTotalHits.AutoSize = True
-        Me.lblTotalHits.Location = New System.Drawing.Point(592, 256)
+        Me.lblTotalHits.Location = New System.Drawing.Point(701, 256)
         Me.lblTotalHits.Name = "lblTotalHits"
         Me.lblTotalHits.Size = New System.Drawing.Size(103, 13)
         Me.lblTotalHits.TabIndex = 51
@@ -392,11 +394,24 @@ Partial Class IgnoredWordsAndPhrases
         Me.colSinceLastEvent.Text = "Since Last Event"
         Me.colSinceLastEvent.Width = 100
         '
+        'ChkAutoRefresh
+        '
+        Me.ChkAutoRefresh.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkAutoRefresh.AutoSize = True
+        Me.ChkAutoRefresh.Location = New System.Drawing.Point(592, 255)
+        Me.ChkAutoRefresh.Name = "ChkAutoRefresh"
+        Me.ChkAutoRefresh.Size = New System.Drawing.Size(88, 17)
+        Me.ChkAutoRefresh.TabIndex = 53
+        Me.ChkAutoRefresh.Text = "Auto Refresh"
+        Me.ToolTip.SetToolTip(Me.ChkAutoRefresh, "Enabling this makes it so that the data is refreshed every five seconds.")
+        Me.ChkAutoRefresh.UseVisualStyleBackColor = True
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1004, 437)
+        Me.Controls.Add(Me.ChkAutoRefresh)
         Me.Controls.Add(Me.btnUpdateHits)
         Me.Controls.Add(Me.lblTotalHits)
         Me.Controls.Add(Me.ChkRemoteProcess)
@@ -468,4 +483,6 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents colDateOfLastEvent As ColumnHeader
     Friend WithEvents btnUpdateHits As Button
     Friend WithEvents colSinceLastEvent As ColumnHeader
+    Friend WithEvents ChkAutoRefresh As CheckBox
+    Friend WithEvents ToolTip As ToolTip
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -99,7 +99,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.HideSelection = False
         Me.IgnoredListView.Location = New System.Drawing.Point(12, 12)
         Me.IgnoredListView.Name = "IgnoredListView"
-        Me.IgnoredListView.Size = New System.Drawing.Size(950, 233)
+        Me.IgnoredListView.Size = New System.Drawing.Size(1064, 233)
         Me.IgnoredListView.TabIndex = 5
         Me.IgnoredListView.UseCompatibleStateImageBehavior = False
         Me.IgnoredListView.View = System.Windows.Forms.View.Details
@@ -181,7 +181,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnImport
         '
         Me.BtnImport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnImport.Location = New System.Drawing.Point(917, 251)
+        Me.BtnImport.Location = New System.Drawing.Point(1031, 251)
         Me.BtnImport.Name = "BtnImport"
         Me.BtnImport.Size = New System.Drawing.Size(75, 23)
         Me.BtnImport.TabIndex = 11
@@ -191,7 +191,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnExport
         '
         Me.BtnExport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnExport.Location = New System.Drawing.Point(836, 251)
+        Me.BtnExport.Location = New System.Drawing.Point(950, 251)
         Me.BtnExport.Name = "BtnExport"
         Me.BtnExport.Size = New System.Drawing.Size(75, 23)
         Me.BtnExport.TabIndex = 12
@@ -211,7 +211,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnDown
         '
         Me.BtnDown.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnDown.Location = New System.Drawing.Point(969, 222)
+        Me.BtnDown.Location = New System.Drawing.Point(1083, 222)
         Me.BtnDown.Name = "BtnDown"
         Me.BtnDown.Size = New System.Drawing.Size(24, 23)
         Me.BtnDown.TabIndex = 19
@@ -221,7 +221,7 @@ Partial Class IgnoredWordsAndPhrases
         'BtnUp
         '
         Me.BtnUp.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnUp.Location = New System.Drawing.Point(968, 12)
+        Me.BtnUp.Location = New System.Drawing.Point(1082, 12)
         Me.BtnUp.Name = "BtnUp"
         Me.BtnUp.Size = New System.Drawing.Size(24, 23)
         Me.BtnUp.TabIndex = 18
@@ -235,7 +235,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.SeparatingLine.BackColor = System.Drawing.Color.Black
         Me.SeparatingLine.Location = New System.Drawing.Point(-1, 286)
         Me.SeparatingLine.Name = "SeparatingLine"
-        Me.SeparatingLine.Size = New System.Drawing.Size(1010, 1)
+        Me.SeparatingLine.Size = New System.Drawing.Size(1124, 1)
         Me.SeparatingLine.TabIndex = 26
         '
         'Label4
@@ -290,7 +290,7 @@ Partial Class IgnoredWordsAndPhrases
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.TxtIgnored.Location = New System.Drawing.Point(61, 325)
         Me.TxtIgnored.Name = "TxtIgnored"
-        Me.TxtIgnored.Size = New System.Drawing.Size(932, 20)
+        Me.TxtIgnored.Size = New System.Drawing.Size(1046, 20)
         Me.TxtIgnored.TabIndex = 41
         '
         'Label1
@@ -351,7 +351,7 @@ Partial Class IgnoredWordsAndPhrases
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.txtComment.Location = New System.Drawing.Point(73, 374)
         Me.txtComment.Name = "txtComment"
-        Me.txtComment.Size = New System.Drawing.Size(919, 20)
+        Me.txtComment.Size = New System.Drawing.Size(1033, 20)
         Me.txtComment.TabIndex = 49
         '
         'lblCommentLabel
@@ -368,7 +368,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.lblTotalHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblTotalHits.AutoSize = True
-        Me.lblTotalHits.Location = New System.Drawing.Point(701, 256)
+        Me.lblTotalHits.Location = New System.Drawing.Point(691, 256)
         Me.lblTotalHits.Name = "lblTotalHits"
         Me.lblTotalHits.Size = New System.Drawing.Size(103, 13)
         Me.lblTotalHits.TabIndex = 51
@@ -410,7 +410,7 @@ Partial Class IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(1004, 437)
+        Me.ClientSize = New System.Drawing.Size(1118, 437)
         Me.Controls.Add(Me.ChkAutoRefresh)
         Me.Controls.Add(Me.btnUpdateHits)
         Me.Controls.Add(Me.lblTotalHits)
@@ -438,7 +438,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.Controls.Add(Me.lblCommentLabel)
         Me.Controls.Add(Me.txtComment)
         Me.KeyPreview = True
-        Me.MinimumSize = New System.Drawing.Size(815, 417)
+        Me.MinimumSize = New System.Drawing.Size(1134, 476)
         Me.Name = "IgnoredWordsAndPhrases"
         Me.Text = "Ignored Words and Phrases"
         Me.ListViewMenu.ResumeLayout(False)

--- a/Free SysLog/Windows/Ignored Words and Phrases.resx
+++ b/Free SysLog/Windows/Ignored Words and Phrases.resx
@@ -120,4 +120,7 @@
   <metadata name="ListViewMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>145, 17</value>
+  </metadata>
 </root>

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -639,6 +639,7 @@ Public Class IgnoredWordsAndPhrases
         Dim sinceLastEvent As TimeSpan
         Dim intHits As Integer
         Dim dateOfLastEvent As Date
+        Dim currentDate As Date = Now
 
         IgnoredListView.BeginUpdate()
 
@@ -653,11 +654,11 @@ Public Class IgnoredWordsAndPhrases
                 End If
 
                 If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
-                    dateOfLastEvent = dateOfLastEvent.ToLocalTime
-                    sinceLastEvent = Now.ToLocalTime - dateOfLastEvent
+                    dateOfLastEvent = dateOfLastEvent
+                    sinceLastEvent = currentDate - dateOfLastEvent
                     item.timeSpanOfLastOccurrence = sinceLastEvent
                     item.dateOfLastOccurrence = dateOfLastEvent
-                    item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
+                    item.SubItems(7).Text = $"{dateOfLastEvent.ToLocalTime.ToLongDateString} {dateOfLastEvent.ToLocalTime.ToLongTimeString}"
                     item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
                     item.intHits = intHits
                 End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -200,9 +200,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub AutoStatSaveTimer_Tick(sender As Object, e As EventArgs)
-        My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
-        My.Settings.Save()
-
+        NumberOfIgnoredLogs = longNumberOfIgnoredLogs
         IO.File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
         IO.File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
     End Sub

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -11,6 +11,7 @@ Public Class IgnoredWordsAndPhrases
     Private m_SortingColumn As ColumnHeader
     Private AutoRefreshTimer As Timer
     Private boolCurrentlyEditing As Boolean = False
+    Private boolF1KeyDown As Boolean = False
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -198,7 +199,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
-        If boolCurrentlyEditing OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
+        If boolCurrentlyEditing Or boolF1KeyDown OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
         btnUpdateHits.PerformClick()
     End Sub
 
@@ -511,11 +512,21 @@ Public Class IgnoredWordsAndPhrases
         End If
     End Sub
 
+    Private Sub IgnoredWordsAndPhrases_KeyDown(sender As Object, e As KeyEventArgs) Handles Me.KeyDown
+        If e.KeyCode = Keys.F1 Then
+            boolF1KeyDown = True
+            ChkAutoRefresh.Enabled = False
+        End If
+    End Sub
+
     Private Sub IgnoredWordsAndPhrases_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
         If e.KeyCode = Keys.Escape Then
             Close()
         ElseIf e.KeyCode = Keys.F5 Then
             btnUpdateHits.PerformClick()
+        ElseIf e.KeyCode = Keys.F1 Then
+            boolF1KeyDown = False
+            ChkAutoRefresh.Enabled = True
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -13,6 +13,7 @@ Public Class IgnoredWordsAndPhrases
     Private boolCurrentlyEditing As Boolean = False
     Private boolF1KeyDown As Boolean = False
     Private Const strWindowTitle As String = "Ignored Words and Phrases"
+    Private strOldRuleText As String
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -86,6 +87,17 @@ Public Class IgnoredWordsAndPhrases
                         .dateCreated = Date.Now
                         .SubItems(colDateCreated.Index).Text = Date.Now.ToLongDateString
                     End If
+
+	                If Not strOldRuleText.Equals(TxtIgnored.Text, StringComparison.OrdinalIgnoreCase) Then
+                        IgnoredStats.TryRemove(.SubItems(Ignored.Index).Text, Nothing)
+                        .intHits = 0
+                		.dateOfLastOccurrence = Date.MinValue
+                		.timeSpanOfLastOccurrence = TimeSpan.MinValue
+                		.SubItems(colHits.Index).Text = "0"
+                		.SubItems(colDateOfLastEvent.Index).Text = ""
+                		.SubItems(colSinceLastEvent.Index).Text = ""
+                		.intHits = 0
+	                End If
                 End With
 
                 IgnoredListView.Enabled = True
@@ -123,6 +135,7 @@ Public Class IgnoredWordsAndPhrases
             ChkRegex.Checked = False
             ChkEnabled.Checked = True
             ChkRemoteProcess.Checked = False
+            strOldRuleText = Nothing
 
             Text = $"{strWindowTitle} — Auto Refresh Enabled"
         End If
@@ -330,6 +343,8 @@ Public Class IgnoredWordsAndPhrases
             ChkCaseSensitive.Checked = selectedItemObject.BoolCaseSensitive
             ChkEnabled.Checked = selectedItemObject.BoolEnabled
             txtComment.Text = selectedItemObject.strComment
+
+            strOldRuleText = selectedItemObject.SubItems(Ignored.Index).Text
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -645,12 +645,14 @@ Public Class IgnoredWordsAndPhrases
     Private Sub btnUpdateHits_Click(sender As Object, e As EventArgs) Handles btnUpdateHits.Click
         Dim longTotalHits As Long = 0
         Dim sinceLastEvent As TimeSpan
+        Dim intHits As Integer
+        Dim dateOfLastEvent As Date
 
         IgnoredListView.BeginUpdate()
 
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-            Dim intHits As Integer = 0
-            Dim dateOfLastEvent As Date = Date.MinValue
+            intHits = 0
+            dateOfLastEvent = Date.MinValue
 
             If IgnoredHits.TryGetValue(item.SubItems(0).Text, intHits) Then
                 item.SubItems(4).Text = intHits.ToString("N0")

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -187,7 +187,9 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
-        If boolCurrentlyEditing OrElse Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle Then Exit Sub
+        If boolCurrentlyEditing OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
+
+        Debug.WriteLine("Ignored Words and Phrases Auto-Refresh Triggered")
 
         ' Prevent re-entry if refresh takes longer than the interval
         AutoRefreshTimer.Stop()
@@ -230,6 +232,8 @@ Public Class IgnoredWordsAndPhrases
         colSinceLastEvent.Width = My.Settings.ColSinceLastEventWidth
 
         ChkAutoRefresh.Checked = My.Settings.AutomaticStatRefreshOnIgnoredWordsAndPhrases
+        ChkRefreshOnlyIfActive.Checked = My.Settings.AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases
+        ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
 
         InitializeAutoRefreshTimer()
 
@@ -674,5 +678,10 @@ Public Class IgnoredWordsAndPhrases
     Private Sub ChkAutoRefresh_Click(sender As Object, e As EventArgs) Handles ChkAutoRefresh.Click
         My.Settings.AutomaticStatRefreshOnIgnoredWordsAndPhrases = ChkAutoRefresh.Checked
         AutoRefreshTimer.Enabled = ChkAutoRefresh.Checked
+        ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
+    End Sub
+
+    Private Sub ChkRefreshOnlyIfActive_Click(sender As Object, e As EventArgs) Handles ChkRefreshOnlyIfActive.Click
+        My.Settings.AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases = ChkRefreshOnlyIfActive.Checked
     End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -169,8 +169,8 @@ Public Class IgnoredWordsAndPhrases
             My.Settings.Save()
 
             If My.Settings.saveIgnoredLogCount Then
-                IO.File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
-                IO.File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
+                WriteFileAtomically(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
+                WriteFileAtomically(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
             End If
 
             IgnoredRegexCache.Clear()
@@ -201,8 +201,8 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub AutoStatSaveTimer_Tick(sender As Object, e As EventArgs)
         NumberOfIgnoredLogs = longNumberOfIgnoredLogs
-        IO.File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
-        IO.File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
+        WriteFileAtomically(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
+        WriteFileAtomically(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
@@ -446,7 +446,7 @@ Public Class IgnoredWordsAndPhrases
                 listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment})
             Next
 
-            IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -651,22 +651,24 @@ Public Class IgnoredWordsAndPhrases
         IgnoredListView.BeginUpdate()
 
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-            intHits = 0
-            dateOfLastEvent = Date.MinValue
+            If item.BoolEnabled Then
+                intHits = 0
+                dateOfLastEvent = Date.MinValue
 
-            If IgnoredHits.TryGetValue(item.SubItems(0).Text, intHits) Then
-                item.SubItems(4).Text = intHits.ToString("N0")
-                longTotalHits += intHits
-            End If
+                If IgnoredHits.TryGetValue(item.SubItems(0).Text, intHits) Then
+                    item.SubItems(4).Text = intHits.ToString("N0")
+                    longTotalHits += intHits
+                End If
 
-            If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
-                dateOfLastEvent = dateOfLastEvent.ToLocalTime
-                sinceLastEvent = Now.ToLocalTime - dateOfLastEvent
-                item.timeSpanOfLastOccurrence = sinceLastEvent
-                item.dateOfLastOccurrence = dateOfLastEvent
-                item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
-                item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
-                item.intHits = intHits
+                If IgnoredLastEvent.TryGetValue(item.SubItems(0).Text, dateOfLastEvent) Then
+                    dateOfLastEvent = dateOfLastEvent.ToLocalTime
+                    sinceLastEvent = Now.ToLocalTime - dateOfLastEvent
+                    item.timeSpanOfLastOccurrence = sinceLastEvent
+                    item.dateOfLastOccurrence = dateOfLastEvent
+                    item.SubItems(7).Text = $"{dateOfLastEvent.ToLongDateString} {dateOfLastEvent.ToLongTimeString}"
+                    item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
+                    item.intHits = intHits
+                End If
             End If
         Next
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -8,7 +8,7 @@ Public Class IgnoredWordsAndPhrases
     Public strIgnoredPattern As String = Nothing
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
-    Private AutoRefreshTimer As Timer
+    Private AutoRefreshTimer, AutoStatSaveTimer As Timer
     Private boolCurrentlyEditing As Boolean = False
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
@@ -128,7 +128,8 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
-        AutoRefreshTimer.Dispose()
+        AutoRefreshTimer?.Dispose()
+        AutoStatSaveTimer?.Dispose()
 
         If boolColumnOrderChanged Then
             My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveColumnOrders(IgnoredListView.Columns)
@@ -188,9 +189,22 @@ Public Class IgnoredWordsAndPhrases
         End Try
     End Sub
 
-    Private Sub InitializeAutoRefreshTimer()
+    Private Sub InitializeTimers()
         AutoRefreshTimer = New Timer() With {.Interval = 5000, .Enabled = ChkAutoRefresh.Checked}
         AddHandler AutoRefreshTimer.Tick, AddressOf AutoRefreshTimer_Tick
+
+        If My.Settings.saveIgnoredLogCount Then
+            AutoStatSaveTimer = New Timer() With {.Interval = 60000 * 5, .Enabled = True}
+            AddHandler AutoStatSaveTimer.Tick, AddressOf AutoStatSaveTimer_Tick
+        End If
+    End Sub
+
+    Private Sub AutoStatSaveTimer_Tick(sender As Object, e As EventArgs)
+        My.Settings.ignoredLogCount = longNumberOfIgnoredLogs
+        My.Settings.Save()
+
+        IO.File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
+        IO.File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
@@ -232,7 +246,7 @@ Public Class IgnoredWordsAndPhrases
         ChkRefreshOnlyIfActive.Checked = My.Settings.AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases
         ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
 
-        InitializeAutoRefreshTimer()
+        InitializeTimers()
 
         Size = My.Settings.ConfigureIgnoredSize
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -630,15 +630,20 @@ Public Class IgnoredWordsAndPhrases
     Private Sub btnResetHits_Click(sender As Object, e As EventArgs) Handles btnResetHits.Click
         If IgnoredListView.SelectedItems.Count > 0 Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
-                If IgnoredHits.TryRemove(item.SubItems(0).Text, Nothing) Then
+                If IgnoredHits.TryRemove(item.SubItems(0).Text, Nothing) And IgnoredLastEvent.TryRemove(item.SubItems(0).Text, Nothing) Then
                     item.SubItems(4).Text = "0"
+                    item.SubItems(7).Text = ""
+                    item.SubItems(8).Text = ""
                 End If
             Next
         Else
             IgnoredHits.Clear()
+            IgnoredLastEvent.Clear()
 
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
                 item.SubItems(4).Text = "0"
+                item.SubItems(7).Text = ""
+                item.SubItems(8).Text = ""
             Next
         End If
     End Sub
@@ -646,8 +651,10 @@ Public Class IgnoredWordsAndPhrases
     Private Sub ResetHitsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ResetHitsToolStripMenuItem.Click
         If IgnoredListView.SelectedItems.Count > 0 Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
-                If IgnoredHits.TryRemove(item.SubItems(0).Text, Nothing) Then
+                If IgnoredHits.TryRemove(item.SubItems(0).Text, Nothing) And IgnoredLastEvent.TryRemove(item.SubItems(0).Text, Nothing) Then
                     item.SubItems(4).Text = "0"
+                    item.SubItems(7).Text = ""
+                    item.SubItems(8).Text = ""
                 End If
             Next
         End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -136,6 +136,13 @@ Public Class IgnoredWordsAndPhrases
             My.Settings.Save()
         End If
 
+        Try
+            If My.Settings.saveIgnoredLogCount Then
+                WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+            End If
+        Catch ' Silently fail
+        End Try
+
         If Not boolChanged Then Exit Sub
 
         Dim newIgnoredList As New ThreadSafetyLists.ThreadSafeIgnoredList
@@ -167,10 +174,6 @@ Public Class IgnoredWordsAndPhrases
 
             My.Settings.ignored2 = tempIgnoredRules
             My.Settings.Save()
-
-            If My.Settings.saveIgnoredLogCount Then
-                WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
-            End If
 
             IgnoredRegexCache.Clear()
         Catch ex As Exception

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -128,6 +128,8 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
+        AutoRefreshTimer.Dispose()
+
         If boolColumnOrderChanged Then
             My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveColumnOrders(IgnoredListView.Columns)
             My.Settings.Save()
@@ -185,7 +187,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
-        If boolCurrentlyEditing Then Exit Sub
+        If boolCurrentlyEditing OrElse Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle Then Exit Sub
 
         ' Prevent re-entry if refresh takes longer than the interval
         AutoRefreshTimer.Stop()

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -1,4 +1,5 @@
 ﻿Imports Free_SysLog.SupportCode
+Imports Windows.UI.Xaml.Controls.Primitives
 
 Public Class IgnoredWordsAndPhrases
     Private boolDoneLoading As Boolean = False
@@ -374,12 +375,21 @@ Public Class IgnoredWordsAndPhrases
                 selectedItem.BackColor = Color.Pink
                 selectedItem.BoolEnabled = False
                 selectedItem.SubItems(ColEnabled.Index).Text = "No"
+                selectedItem.SubItems(colHits.Index).Text = ""
+                selectedItem.SubItems(colDateOfLastEvent.Index).Text = ""
+                selectedItem.SubItems(colSinceLastEvent.Index).Text = ""
+                selectedItem.intHits = 0
+                selectedItem.dateOfLastOccurrence = Date.MinValue
+                selectedItem.timeSpanOfLastOccurrence = TimeSpan.MinValue
+                IgnoredStats.TryRemove(selectedItem.SubItems(Ignored.Index).Text, Nothing)
                 BtnEnableDisable.Text = "Enable"
             Else
                 selectedItem.BackColor = Color.LightGreen
                 selectedItem.BoolEnabled = True
                 selectedItem.SubItems(ColEnabled.Index).Text = "Yes"
                 BtnEnableDisable.Text = "Disable"
+                selectedItem.SubItems(colHits.Index).Text = "0"
+                selectedItem.intHits = 0
             End If
         Else
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
@@ -387,10 +397,19 @@ Public Class IgnoredWordsAndPhrases
                     item.BackColor = Color.Pink
                     item.BoolEnabled = False
                     item.SubItems(ColEnabled.Index).Text = "No"
+                    item.SubItems(colHits.Index).Text = ""
+                    item.SubItems(colDateOfLastEvent.Index).Text = ""
+                    item.SubItems(colSinceLastEvent.Index).Text = ""
+                    item.intHits = 0
+                    item.dateOfLastOccurrence = Date.MinValue
+                    item.timeSpanOfLastOccurrence = TimeSpan.MinValue
+                    IgnoredStats.TryRemove(item.SubItems(Ignored.Index).Text, Nothing)
                 Else
                     item.BackColor = Color.LightGreen
                     item.BoolEnabled = True
                     item.SubItems(ColEnabled.Index).Text = "Yes"
+                    item.SubItems(colHits.Index).Text = "0"
+                    item.intHits = 0
                 End If
             Next
         End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -8,7 +8,7 @@ Public Class IgnoredWordsAndPhrases
     Public strIgnoredPattern As String = Nothing
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
-    Private AutoRefreshTimer, AutoStatSaveTimer As Timer
+    Private AutoRefreshTimer As Timer
     Private boolCurrentlyEditing As Boolean = False
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
@@ -129,7 +129,6 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
         AutoRefreshTimer?.Dispose()
-        AutoStatSaveTimer?.Dispose()
 
         If boolColumnOrderChanged Then
             My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveColumnOrders(IgnoredListView.Columns)
@@ -192,19 +191,9 @@ Public Class IgnoredWordsAndPhrases
         End Try
     End Sub
 
-    Private Sub InitializeTimers()
+    Private Sub InitializeAutoRefreshTimer()
         AutoRefreshTimer = New Timer() With {.Interval = 5000, .Enabled = ChkAutoRefresh.Checked}
         AddHandler AutoRefreshTimer.Tick, AddressOf AutoRefreshTimer_Tick
-
-        If My.Settings.saveIgnoredLogCount Then
-            AutoStatSaveTimer = New Timer() With {.Interval = 60000 * 5, .Enabled = True}
-            AddHandler AutoStatSaveTimer.Tick, AddressOf AutoStatSaveTimer_Tick
-        End If
-    End Sub
-
-    Private Sub AutoStatSaveTimer_Tick(sender As Object, e As EventArgs)
-        NumberOfIgnoredLogs = longNumberOfIgnoredLogs
-        WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
@@ -246,7 +235,7 @@ Public Class IgnoredWordsAndPhrases
         ChkRefreshOnlyIfActive.Checked = My.Settings.AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases
         ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
 
-        InitializeTimers()
+        InitializeAutoRefreshTimer()
 
         Size = My.Settings.ConfigureIgnoredSize
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -138,6 +138,7 @@ Public Class IgnoredWordsAndPhrases
 
         Try
             If My.Settings.saveIgnoredLogCount Then
+                NumberOfIgnoredLogs = longNumberOfIgnoredLogs
                 WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
             End If
         Catch ' Silently fail

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -628,6 +628,8 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub btnResetHits_Click(sender As Object, e As EventArgs) Handles btnResetHits.Click
+        longNumberOfIgnoredLogs = 0
+
         If IgnoredListView.SelectedItems.Count > 0 Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
                 If IgnoredStats.TryRemove(item.SubItems(0).Text, Nothing) Then

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -98,6 +98,21 @@ Public Class IgnoredWordsAndPhrases
                 		.SubItems(colSinceLastEvent.Index).Text = ""
                 		.intHits = 0
 	                End If
+
+	                If .BoolEnabled Then
+	                    .BackColor = Color.LightGreen
+	                    .SubItems(colHits.Index).Text = "0"
+	                    .intHits = 0
+	                Else
+	                    .BackColor = Color.Pink
+	                    .SubItems(colHits.Index).Text = ""
+	                    .SubItems(colDateOfLastEvent.Index).Text = ""
+	                    .SubItems(colSinceLastEvent.Index).Text = ""
+	                    .intHits = 0
+	                    .dateOfLastOccurrence = Date.MinValue
+	                    .timeSpanOfLastOccurrence = TimeSpan.MinValue
+                        IgnoredStats.TryRemove(.SubItems(Ignored.Index).Text, Nothing)
+                    End If
                 End With
 
                 IgnoredListView.Enabled = True

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -167,6 +167,11 @@ Public Class IgnoredWordsAndPhrases
             My.Settings.ignored2 = tempIgnoredRules
             My.Settings.Save()
 
+            If My.Settings.saveIgnoredLogCount Then
+                IO.File.WriteAllText(strPathToIgnoredHitsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredHits, Newtonsoft.Json.Formatting.Indented))
+                IO.File.WriteAllText(strPathToIgnoredLastEventFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredLastEvent, Newtonsoft.Json.Formatting.Indented))
+            End If
+
             IgnoredRegexCache.Clear()
         Catch ex As Exception
             SyncLock SupportCode.ParentForm.dataGridLockObject

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -190,15 +190,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
         If boolCurrentlyEditing OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
-
-        ' Prevent re-entry if refresh takes longer than the interval
-        AutoRefreshTimer.Stop()
-
-        Try
-            btnUpdateHits.PerformClick()
-        Finally
-            AutoRefreshTimer.Start()
-        End Try
+        btnUpdateHits.PerformClick()
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -299,9 +299,11 @@ Public Class IgnoredWordsAndPhrases
 
         If IgnoredListView.SelectedItems.Count > 0 Then
             If IgnoredListView.SelectedItems.Count = 1 Then
+                IgnoredStats.TryRemove(IgnoredListView.SelectedItems(0).SubItems(Ignored.Index).Text, Nothing)
                 IgnoredListView.Items.Remove(IgnoredListView.SelectedItems(0))
             Else
                 For i As Integer = IgnoredListView.SelectedItems.Count - 1 To 0 Step -1
+                    IgnoredStats.TryRemove(IgnoredListView.SelectedItems(i).SubItems(Ignored.Index).Text, Nothing)
                     IgnoredListView.SelectedItems(i).Remove()
                 Next
             End If
@@ -632,6 +634,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub btnDeleteDuringEditing_Click(sender As Object, e As EventArgs) Handles btnDeleteDuringEditing.Click
+        IgnoredStats.TryRemove(IgnoredListView.SelectedItems(0).SubItems(Ignored.Index).Text, Nothing)
         IgnoredListView.SelectedItems(0).Remove()
         IgnoredListView.Enabled = True
         BtnAdd.Text = "Add"

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -52,7 +52,7 @@ Public Class IgnoredWordsAndPhrases
 
     Private Function CheckForExistingItem(strIgnored As String) As Boolean
         Return IgnoredListView.Items.Cast(Of MyIgnoredListViewItem).Any(Function(item As MyIgnoredListViewItem)
-                                                                            Return item.SubItems(0).Text.Equals(strIgnored, StringComparison.OrdinalIgnoreCase)
+                                                                            Return item.SubItems(Ignored.Index).Text.Equals(strIgnored, StringComparison.OrdinalIgnoreCase)
                                                                         End Function)
     End Function
 
@@ -67,11 +67,11 @@ Public Class IgnoredWordsAndPhrases
                 Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
                 With selectedItemObject
-                    .SubItems(0).Text = TxtIgnored.Text
-                    .SubItems(1).Text = If(ChkRegex.Checked, "Yes", "No")
-                    .SubItems(2).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
-                    .SubItems(3).Text = If(ChkEnabled.Checked, "Yes", "No")
-                    .SubItems(5).Text = If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text")
+                    .SubItems(Ignored.Index).Text = TxtIgnored.Text
+                    .SubItems(Regex.Index).Text = If(ChkRegex.Checked, "Yes", "No")
+                    .SubItems(CaseSensitive.Index).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
+                    .SubItems(ColEnabled.Index).Text = If(ChkEnabled.Checked, "Yes", "No")
+                    .SubItems(colTarget.Index).Text = If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text")
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolRegex = ChkRegex.Checked
@@ -81,7 +81,7 @@ Public Class IgnoredWordsAndPhrases
 
                     If .dateCreated = Date.MinValue Then ' Just in case it was never set
                         .dateCreated = Date.Now
-                        .SubItems(6).Text = Date.Now.ToLongDateString
+                        .SubItems(colDateCreated.Index).Text = Date.Now.ToLongDateString
                     End If
                 End With
 
@@ -153,7 +153,7 @@ Public Class IgnoredWordsAndPhrases
 
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
                 ignoredClass = New IgnoredClass() With {
-                    .StrIgnore = item.SubItems(0).Text,
+                    .StrIgnore = item.SubItems(Ignored.Index).Text,
                     .BoolCaseSensitive = item.BoolCaseSensitive,
                     .BoolRegex = item.BoolRegex,
                     .BoolEnabled = item.BoolEnabled,
@@ -243,7 +243,7 @@ Public Class IgnoredWordsAndPhrases
 
         If Not String.IsNullOrWhiteSpace(strIgnoredPattern) AndAlso CheckForExistingItem(strIgnoredPattern) Then
             For Each item As ListViewItem In IgnoredListView.Items
-                If item.SubItems(0).Text.Equals(strIgnoredPattern, StringComparison.OrdinalIgnoreCase) Then
+                If item.SubItems(Ignored.Index).Text.Equals(strIgnoredPattern, StringComparison.OrdinalIgnoreCase) Then
                     item.Selected = True
                     btnDeleteDuringEditing.Visible = True
                     IgnoredListView.Refresh()
@@ -316,7 +316,7 @@ Public Class IgnoredWordsAndPhrases
             Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
             ChkRemoteProcess.Checked = selectedItemObject.IgnoreType <> IgnoreType.MainLog
-            TxtIgnored.Text = selectedItemObject.SubItems(0).Text
+            TxtIgnored.Text = selectedItemObject.SubItems(Ignored.Index).Text
             ChkRegex.Checked = selectedItemObject.BoolRegex
             ChkCaseSensitive.Checked = selectedItemObject.BoolCaseSensitive
             ChkEnabled.Checked = selectedItemObject.BoolEnabled
@@ -373,12 +373,12 @@ Public Class IgnoredWordsAndPhrases
             If selectedItem.BoolEnabled Then
                 selectedItem.BackColor = Color.Pink
                 selectedItem.BoolEnabled = False
-                selectedItem.SubItems(3).Text = "No"
+                selectedItem.SubItems(ColEnabled.Index).Text = "No"
                 BtnEnableDisable.Text = "Enable"
             Else
                 selectedItem.BackColor = Color.LightGreen
                 selectedItem.BoolEnabled = True
-                selectedItem.SubItems(3).Text = "Yes"
+                selectedItem.SubItems(ColEnabled.Index).Text = "Yes"
                 BtnEnableDisable.Text = "Disable"
             End If
         Else
@@ -386,11 +386,11 @@ Public Class IgnoredWordsAndPhrases
                 If item.BoolEnabled Then
                     item.BackColor = Color.Pink
                     item.BoolEnabled = False
-                    item.SubItems(3).Text = "No"
+                    item.SubItems(ColEnabled.Index).Text = "No"
                 Else
                     item.BackColor = Color.LightGreen
                     item.BoolEnabled = True
-                    item.SubItems(3).Text = "Yes"
+                    item.SubItems(ColEnabled.Index).Text = "Yes"
                 End If
             Next
         End If
@@ -434,7 +434,7 @@ Public Class IgnoredWordsAndPhrases
 
         If saveFileDialog.ShowDialog() = DialogResult.OK Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(0).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment})
+                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(Ignored.Index).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment})
             Next
 
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
@@ -621,19 +621,19 @@ Public Class IgnoredWordsAndPhrases
 
         If IgnoredListView.SelectedItems.Count > 0 Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
-                If IgnoredStats.TryRemove(item.SubItems(0).Text, Nothing) Then
-                    item.SubItems(4).Text = "0"
-                    item.SubItems(7).Text = ""
-                    item.SubItems(8).Text = ""
+                If IgnoredStats.TryRemove(item.SubItems(Ignored.Index).Text, Nothing) Then
+                    item.SubItems(colHits.Index).Text = "0"
+                    item.SubItems(colDateOfLastEvent.Index).Text = ""
+                    item.SubItems(colSinceLastEvent.Index).Text = ""
                 End If
             Next
         Else
             IgnoredStats.Clear()
 
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                item.SubItems(4).Text = "0"
-                item.SubItems(7).Text = ""
-                item.SubItems(8).Text = ""
+                item.SubItems(colHits.Index).Text = "0"
+                item.SubItems(colDateOfLastEvent.Index).Text = ""
+                item.SubItems(colSinceLastEvent.Index).Text = ""
             Next
         End If
     End Sub
@@ -641,10 +641,10 @@ Public Class IgnoredWordsAndPhrases
     Private Sub ResetHitsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ResetHitsToolStripMenuItem.Click
         If IgnoredListView.SelectedItems.Count > 0 Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
-                If IgnoredStats.TryRemove(item.SubItems(0).Text, Nothing) Then
-                    item.SubItems(4).Text = "0"
-                    item.SubItems(7).Text = ""
-                    item.SubItems(8).Text = ""
+                If IgnoredStats.TryRemove(item.SubItems(Ignored.Index).Text, Nothing) Then
+                    item.SubItems(colHits.Index).Text = "0"
+                    item.SubItems(colDateOfLastEvent.Index).Text = ""
+                    item.SubItems(colSinceLastEvent.Index).Text = ""
                 End If
             Next
         End If
@@ -666,24 +666,24 @@ Public Class IgnoredWordsAndPhrases
                 intHits = 0
                 dateOfLastEvent = Date.MinValue
 
-                If IgnoredStats.TryGetValue(item.SubItems(0).Text, IgnoredStatsEntry) Then
+                If IgnoredStats.TryGetValue(item.SubItems(Ignored.Index).Text, IgnoredStatsEntry) Then
                     intHits = IgnoredStatsEntry.Hits
                     dateOfLastEvent = IgnoredStatsEntry.LastEvent
 
                     longTotalHits += intHits
 
-                    item.SubItems(4).Text = intHits.ToString("N0")
+                    item.SubItems(colHits.Index).Text = intHits.ToString("N0")
                     item.intHits = intHits
 
                     If dateOfLastEvent <> Date.MinValue Then
                         sinceLastEvent = currentDate - dateOfLastEvent
                         item.timeSpanOfLastOccurrence = sinceLastEvent
                         item.dateOfLastOccurrence = dateOfLastEvent
-                        item.SubItems(7).Text = $"{dateOfLastEvent.ToLocalTime.ToLongDateString} {dateOfLastEvent.ToLocalTime.ToLongTimeString}"
-                        item.SubItems(8).Text = TimespanToHMS(sinceLastEvent)
+                        item.SubItems(colDateOfLastEvent.Index).Text = $"{dateOfLastEvent.ToLocalTime.ToLongDateString} {dateOfLastEvent.ToLocalTime.ToLongTimeString}"
+                        item.SubItems(colSinceLastEvent.Index).Text = TimespanToHMS(sinceLastEvent)
                     Else
-                        item.SubItems(7).Text = ""
-                        item.SubItems(8).Text = ""
+                        item.SubItems(colDateOfLastEvent.Index).Text = ""
+                        item.SubItems(colSinceLastEvent.Index).Text = ""
                     End If
                 End If
             End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -2,7 +2,7 @@
 
 Public Class IgnoredWordsAndPhrases
     Private boolDoneLoading As Boolean = False
-    Public boolChanged As Boolean = False
+    Private boolChanged As Boolean = False
     Private boolColumnOrderChanged As Boolean = False
     Private boolEditMode As Boolean = False
     Public strIgnoredPattern As String = Nothing
@@ -166,6 +166,8 @@ Public Class IgnoredWordsAndPhrases
 
             My.Settings.ignored2 = tempIgnoredRules
             My.Settings.Save()
+
+            IgnoredRegexCache.Clear()
         Catch ex As Exception
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -191,8 +191,6 @@ Public Class IgnoredWordsAndPhrases
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
         If boolCurrentlyEditing OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
 
-        Debug.WriteLine("Ignored Words and Phrases Auto-Refresh Triggered")
-
         ' Prevent re-entry if refresh takes longer than the interval
         AutoRefreshTimer.Stop()
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -12,6 +12,7 @@ Public Class IgnoredWordsAndPhrases
     Private AutoRefreshTimer As Timer
     Private boolCurrentlyEditing As Boolean = False
     Private boolF1KeyDown As Boolean = False
+    Private Const strWindowTitle As String = "Ignored Words and Phrases"
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -122,6 +123,8 @@ Public Class IgnoredWordsAndPhrases
             ChkRegex.Checked = False
             ChkEnabled.Checked = True
             ChkRemoteProcess.Checked = False
+
+            Text = $"{strWindowTitle} — Auto Refresh Enabled"
         End If
     End Sub
 
@@ -237,6 +240,8 @@ Public Class IgnoredWordsAndPhrases
         ChkRefreshOnlyIfActive.Checked = My.Settings.AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases
         ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
 
+        Text = If(ChkAutoRefresh.Checked, $"{strWindowTitle} — Auto Refresh Enabled", $"{strWindowTitle} — Auto Refresh Paused")
+
         InitializeAutoRefreshTimer()
 
         Size = My.Settings.ConfigureIgnoredSize
@@ -314,6 +319,8 @@ Public Class IgnoredWordsAndPhrases
             boolEditMode = True
             BtnAdd.Text = "Save"
             Label4.Text = "Edit Ignored Words and Phrases"
+
+            Text = $"{strWindowTitle} — Auto Refresh Paused"
 
             Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
@@ -516,6 +523,7 @@ Public Class IgnoredWordsAndPhrases
         If e.KeyCode = Keys.F1 Then
             boolF1KeyDown = True
             ChkAutoRefresh.Enabled = False
+            Text = $"{strWindowTitle} — Auto Refresh Paused"
         End If
     End Sub
 
@@ -527,6 +535,7 @@ Public Class IgnoredWordsAndPhrases
         ElseIf e.KeyCode = Keys.F1 Then
             boolF1KeyDown = False
             ChkAutoRefresh.Enabled = True
+            Text = $"{strWindowTitle} — Auto Refresh Enabled"
         End If
     End Sub
 
@@ -588,6 +597,8 @@ Public Class IgnoredWordsAndPhrases
         ChkEnabled.Checked = True
         BtnCancel.Visible = False
         boolCurrentlyEditing = False
+
+        Text = $"{strWindowTitle} — Auto Refresh Enabled"
     End Sub
 
     Private Sub btnDeleteDuringEditing_Click(sender As Object, e As EventArgs) Handles btnDeleteDuringEditing.Click
@@ -730,6 +741,7 @@ Public Class IgnoredWordsAndPhrases
         My.Settings.AutomaticStatRefreshOnIgnoredWordsAndPhrases = ChkAutoRefresh.Checked
         AutoRefreshTimer.Enabled = ChkAutoRefresh.Checked
         ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
+        Text = If(ChkAutoRefresh.Checked, $"{strWindowTitle} — Auto Refresh Enabled", $"{strWindowTitle} — Auto Refresh Paused")
     End Sub
 
     Private Sub ChkRefreshOnlyIfActive_Click(sender As Object, e As EventArgs) Handles ChkRefreshOnlyIfActive.Click

--- a/Free SysLog/Windows/Integer Input Form.vb
+++ b/Free SysLog/Windows/Integer Input Form.vb
@@ -13,10 +13,22 @@
 
     Private Sub BtnSave_Click(sender As Object, e As EventArgs) Handles BtnSave.Click
         If Integer.TryParse(TxtSetting.Text, intResult) Then
+            If intResult < intMin OrElse intResult > intMax Then
+                MsgBox($"Please enter a number between {intMin} and {intMax}.", MsgBoxStyle.Critical, Text)
+
+                TxtSetting.SelectAll()
+                TxtSetting.Focus()
+
+                Exit Sub
+            End If
+
             DialogResult = DialogResult.OK
             Close()
         Else
             MsgBox("Invalid user input!", MsgBoxStyle.Critical, Text)
+
+            TxtSetting.SelectAll()
+            TxtSetting.Focus()
         End If
     End Sub
 
@@ -50,8 +62,24 @@
             DialogResult = DialogResult.Cancel
             Close()
         ElseIf e.KeyData = Keys.Enter Then
-            DialogResult = DialogResult.OK
-            Close()
+            If Integer.TryParse(TxtSetting.Text, intResult) Then
+                If intResult < intMin OrElse intResult > intMax Then
+                    MsgBox($"Please enter a number between {intMin} and {intMax}.", MsgBoxStyle.Critical, Text)
+
+                    TxtSetting.SelectAll()
+                    TxtSetting.Focus()
+
+                    Exit Sub
+                End If
+
+                DialogResult = DialogResult.OK
+                Close()
+            Else
+                MsgBox("Invalid user input!", MsgBoxStyle.Critical, Text)
+
+                TxtSetting.SelectAll()
+                TxtSetting.Focus()
+            End If
         End If
     End Sub
 End Class

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -2,7 +2,7 @@
 
 Public Class Replacements
     Private boolDoneLoading As Boolean = False
-    Public boolChanged As Boolean = False
+    Private boolChanged As Boolean = False
     Private boolEditMode As Boolean = False
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
@@ -186,6 +186,8 @@ Public Class Replacements
 
             My.Settings.replacements = tempReplacements
             My.Settings.Save()
+
+            ReplacementsRegexCache.Clear()
         Catch ex As Exception
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -334,7 +334,7 @@ Public Class Replacements
                 listOfReplacementsClass.Add(New ReplacementsClass With {.BoolRegex = item.BoolRegex, .StrReplace = item.SubItems(0).Text, .StrReplaceWith = item.SubItems(1).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolEnabled = item.BoolEnabled})
             Next
 
-            IO.File.WriteAllText(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
+            WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
                 Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -331,6 +331,10 @@
                 serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases"
+                serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -327,6 +327,10 @@
             <setting name="ColSinceLastEventWidth" serializeAs="String">
                 <value>100</value>
             </setting>
+            <setting name="AutomaticStatRefreshOnIgnoredWordsAndPhrases"
+                serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Minor changes to the SetDoubleBufferingFlag() code.
- Added auto-refresh of the stats on the "Ignored Rules and Phrases" window.
- Made it so that the stat data is only refreshed if the "Ignored Words and Phrases" window is visible.
- Resized the "Ignored Words and Phrases" base window size.
- Made it so that the user can choose to keep refreshing of stats on the "Ignored Words and Phrases" window even if it's not the active window.
- De-coupled many of the config windows from the main window so that while they're open, you can still use the main window.
- Put a check to see if an ignored rule is even enabled before acting on it when refreshing the statistics on the "Ignored Words and Phrases" window.
- Added a process uptime label at the bottom of the main window.
- Fixed a bug on the main window where manually checking and unchecking logs in the logs list would not update the number of selected/checked logs on the bottom of the window.
- Fixed a bug that could cause the program to crash if the user clicks on the "Delete?" column header thus triggering a column sort. Data can't be sorted by the "Delete?" column.
- Added the ability to save stats for the ignored rules.
- Made many of the config windows single-instance.
- We now write the number of saved ignored logs to a file on disk instead of the Settings file.
- We now write text data to a file on disk atomically. This makes sure that data is 100% guaranteed to have been successfully written to disk or the original data is kept.
- Put some additional sanity checks into the code on the "Integer Input Form" when pressing the Enter key. I also added textbox focusing after an error occurs.
- Additional safeguards were added to the Merge() function for ThreadSafeList.
- Added IgnoredStat cleanup code when editing an ignored rule.
- When disabling and enabling ignored rules using the Edit function, the rule list is appropriately updated now.
- Changed the tooltip for the "Save Ignored Log Count" menu item on the main window.
- Made it so that sorting on the "Ignored Words and Phrases" window always makes disabled rules sort last.

And a whole lot of other under the hood changes to the code which includes over 50 various commits to the code.