### PR TITLE
Version 5.0 Build 1

### DIFF
--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -110,6 +110,7 @@
     <Import Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.vb" />
     <Compile Include="Support Code\AlertsHistoryDataGridViewRow.vb" />
     <Compile Include="Support Code\My Custom ListViews.vb" />
     <Compile Include="Support Code\My Data Classes.vb" />

--- a/Free SysLog/GlobalSuppressions.vb
+++ b/Free SysLog/GlobalSuppressions.vb
@@ -1,0 +1,8 @@
+﻿' This file is used by Code Analysis to maintain SuppressMessage
+' attributes that are applied to this project.
+' Project-level suppressions either have no target or are given
+' a specific target and scoped to a namespace, type, member, etc.
+
+Imports System.Diagnostics.CodeAnalysis
+
+<Assembly: SuppressMessage("Style", "IDE1006:Naming Styles")>

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("4.9.2.112")>
+<Assembly: AssemblyFileVersion("5.0.1.113")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1412,6 +1412,18 @@ Namespace My
                 Me("ShowNTFSCompressionSizeDifferencePercentage") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property CompressBackupLogFiles() As Boolean
+            Get
+                Return CType(Me("CompressBackupLogFiles"),Boolean)
+            End Get
+            Set
+                Me("CompressBackupLogFiles") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1388,6 +1388,30 @@ Namespace My
                 Me("IncludeCommasInDHMS") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property ShowNTFSCompressionSizeDifference() As Boolean
+            Get
+                Return CType(Me("ShowNTFSCompressionSizeDifference"),Boolean)
+            End Get
+            Set
+                Me("ShowNTFSCompressionSizeDifference") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property ShowNTFSCompressionSizeDifferencePercentage() As Boolean
+            Get
+                Return CType(Me("ShowNTFSCompressionSizeDifferencePercentage"),Boolean)
+            End Get
+            Set
+                Me("ShowNTFSCompressionSizeDifferencePercentage") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1376,6 +1376,18 @@ Namespace My
                 Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property IncludeCommasInDHMS() As Boolean
+            Get
+                Return CType(Me("IncludeCommasInDHMS"),Boolean)
+            End Get
+            Set
+                Me("IncludeCommasInDHMS") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -344,5 +344,8 @@
     <Setting Name="ShowNTFSCompressionSizeDifferencePercentage" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="CompressBackupLogFiles" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -338,5 +338,11 @@
     <Setting Name="IncludeCommasInDHMS" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ShowNTFSCompressionSizeDifference" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="ShowNTFSCompressionSizeDifferencePercentage" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -335,5 +335,8 @@
     <Setting Name="AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="IncludeCommasInDHMS" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/My Custom ListViews.vb
+++ b/Free SysLog/Support Code/My Custom ListViews.vb
@@ -23,6 +23,7 @@ Public Class MyIgnoredListViewItem
     Public Property BoolRegex As Boolean
     Public Property BoolCaseSensitive As Boolean
     Public Property BoolEnabled As Boolean
+    Public Property BoolRecordLog As Boolean
     Public Property IgnoreType As IgnoreType
     Public Property timeSpanOfLastOccurrence As TimeSpan
     Public Property dateOfLastOccurrence As Date

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -118,6 +118,7 @@ End Class
 Public Class IgnoredClass
     Public BoolRegex As Boolean
     Public BoolCaseSensitive As Boolean
+    Public BoolRecordLog As Boolean
     Public StrIgnore, strComment As String
     Public BoolEnabled As Boolean = True
     Public IgnoreType As IgnoreType = IgnoreType.MainLog
@@ -162,9 +163,12 @@ Public Class IgnoredClass
             listViewItem.SubItems.Add("")
         End If
 
+        listViewItem.SubItems.Add(If(BoolRecordLog, "Yes", "No"))
+
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled
+        listViewItem.BoolRecordLog = BoolRecordLog
         listViewItem.IgnoreType = IgnoreType
         listViewItem.dateCreated = dateCreated
         listViewItem.strComment = strComment
@@ -192,6 +196,7 @@ Public Class IgnoredClass
         listViewItem.BoolRegex = BoolRegex
         listViewItem.BoolCaseSensitive = BoolCaseSensitive
         listViewItem.BoolEnabled = BoolEnabled
+        listViewItem.BoolRecordLog = BoolRecordLog
         listViewItem.IgnoreType = IgnoreType
         listViewItem.dateCreated = dateCreated
         listViewItem.strComment = strComment

--- a/Free SysLog/Support Code/Namespace Code/Data Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Data Handling.vb
@@ -54,16 +54,17 @@ Namespace DataHandling
                         End If
                     Next
 
-                    Using fileStream As New StreamWriter(saveFileDialog.FileName)
-                        If fileInfo.Extension.Equals(".xml", StringComparison.OrdinalIgnoreCase) Then
+                    If fileInfo.Extension.Equals(".xml", StringComparison.OrdinalIgnoreCase) Then
+                        Using memoryStream As New MemoryStream
                             Dim xmlSerializerObject As New Xml.Serialization.XmlSerializer(collectionOfSavedData.GetType)
-                            xmlSerializerObject.Serialize(fileStream, collectionOfSavedData)
-                        ElseIf fileInfo.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) Then
-                            fileStream.Write(Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
-                        ElseIf fileInfo.Extension.Equals(".csv", StringComparison.OrdinalIgnoreCase) Then
-                            fileStream.Write(csvStringBuilder.ToString.Trim)
-                        End If
-                    End Using
+                            xmlSerializerObject.Serialize(memoryStream, collectionOfSavedData)
+                            WriteFileAtomically(saveFileDialog.FileName, memoryStream.ToArray())
+                        End Using
+                    ElseIf fileInfo.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) Then
+                        WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
+                    ElseIf fileInfo.Extension.Equals(".csv", StringComparison.OrdinalIgnoreCase) Then
+                        WriteFileAtomically(saveFileDialog.FileName, csvStringBuilder.ToString.Trim)
+                    End If
 
                     If My.Settings.AskOpenExplorer Then
                         Using OpenExplorer As New OpenExplorer()
@@ -135,16 +136,17 @@ Namespace DataHandling
                         End If
                     Next
 
-                    Using fileStream As New StreamWriter(saveFileDialog.FileName)
-                        If fileInfo.Extension.Equals(".xml", StringComparison.OrdinalIgnoreCase) Then
+                    If fileInfo.Extension.Equals(".xml", StringComparison.OrdinalIgnoreCase) Then
+                        Using memoryStream As New MemoryStream
                             Dim xmlSerializerObject As New Xml.Serialization.XmlSerializer(collectionOfSavedData.GetType)
-                            xmlSerializerObject.Serialize(fileStream, collectionOfSavedData)
-                        ElseIf fileInfo.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) Then
-                            fileStream.Write(Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
-                        ElseIf fileInfo.Extension.Equals(".csv", StringComparison.OrdinalIgnoreCase) Then
-                            fileStream.Write(csvStringBuilder.ToString.Trim)
-                        End If
-                    End Using
+                            xmlSerializerObject.Serialize(memoryStream, collectionOfSavedData)
+                            WriteFileAtomically(saveFileDialog.FileName, memoryStream.ToArray())
+                        End Using
+                    ElseIf fileInfo.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) Then
+                        WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
+                    ElseIf fileInfo.Extension.Equals(".csv", StringComparison.OrdinalIgnoreCase) Then
+                        WriteFileAtomically(saveFileDialog.FileName, csvStringBuilder.ToString.Trim)
+                    End If
 
                     If My.Settings.AskOpenExplorer Then
                         Using OpenExplorer As New OpenExplorer()

--- a/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
+++ b/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
@@ -1,4 +1,5 @@
 ﻿Imports System.Runtime.InteropServices
+Imports Microsoft.Win32.SafeHandles
 
 Namespace NativeMethod
     Friend Class NativeMethods
@@ -43,6 +44,18 @@ Namespace NativeMethod
 
         <DllImport("user32.dll")>
         Public Shared Function GetForegroundWindow() As IntPtr
+        End Function
+
+        <DllImport("kernel32.dll", SetLastError:=True)>
+        Public Shared Function DeviceIoControl(hDevice As SafeFileHandle, dwIoControlCode As UInteger, lpInBuffer As IntPtr, nInBufferSize As UInteger, lpOutBuffer As IntPtr, nOutBufferSize As UInteger, ByRef lpBytesReturned As UInteger, lpOverlapped As IntPtr) As Boolean
+        End Function
+
+        Public Const FSCTL_SET_COMPRESSION As UInteger = &H9C040
+        Public Const COMPRESSION_FORMAT_NONE As UShort = 0
+        Public Const COMPRESSION_FORMAT_DEFAULT As UShort = 1
+
+        <DllImport("kernel32.dll", CharSet:=CharSet.Auto, SetLastError:=True)>
+        Public Shared Function GetCompressedFileSize(lpFileName As String, ByRef lpFileSizeHigh As UInteger) As UInteger
         End Function
     End Class
 

--- a/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
+++ b/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
@@ -61,10 +61,10 @@ Namespace SaveAppSettings
 
                     Return New Font(fontName, fontSize, fontStyle)
                 Else
-                    Return New Font("Microsoft Sans Serif", 9.75)
+                    Return Control.DefaultFont
                 End If
             Catch ex As Exception
-                Return New Font("Microsoft Sans Serif", 9.75)
+                Return Control.DefaultFont
             End Try
         End Function
 

--- a/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
+++ b/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
@@ -48,6 +48,8 @@ Namespace SaveAppSettings
 
                     If Not Single.TryParse(MatchResults.Groups("size").Value, fontSize) Then fontSize = 8.25
 
+                    fontSize = Math.Max(6.0F, Math.Min(fontSize, 32.0F))
+
                     If Not String.IsNullOrWhiteSpace(MatchResults.Groups("style").Value) Then
                         Dim strStyleValue As String = MatchResults.Groups("style").Value
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -139,7 +139,7 @@ Namespace SupportCode
             Dim tmpPath As String = path & ".tmp"
 
             Try
-                File.WriteAllText(tmpPath, contents)
+                File.WriteAllText(tmpPath, contents, Encoding.UTF8)
 
                 If File.Exists(path) Then
                     File.Replace(tmpPath, path, Nothing)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -135,6 +135,28 @@ Namespace SupportCode
             End If
         End Function
 
+        Public Sub WriteFileAtomically(path As String, contents As Byte())
+            Dim tmpPath As String = path & ".tmp"
+
+            Try
+                File.WriteAllBytes(tmpPath, contents)
+
+                If File.Exists(path) Then
+                    File.Replace(tmpPath, path, Nothing)
+                Else
+                    File.Move(tmpPath, path)
+                End If
+            Catch
+                ' Fail silently
+            Finally
+                Try
+                    If File.Exists(tmpPath) Then File.Delete(tmpPath)
+                Catch
+                    ' Fail silently
+                End Try
+            End Try
+        End Sub
+
         Public Sub WriteFileAtomically(path As String, contents As String)
             Dim tmpPath As String = path & ".tmp"
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -115,7 +115,7 @@ Namespace SupportCode
         Public Const boolDebugBuild As Boolean = False
 #End If
 
-        Public Function TimespanToHMS(timeSpan As TimeSpan, Optional boolUseCommas As Boolean = True) As String
+        Public Function TimespanToHMS(timeSpan As TimeSpan) As String
             If timeSpan.TotalMilliseconds < 1 Then Return "0s"
             If timeSpan < TimeSpan.Zero Then timeSpan = timeSpan.Duration()
 
@@ -128,7 +128,7 @@ Namespace SupportCode
 
             If parts.Count() = 0 Then parts.Add($"{timeSpan.Milliseconds}ms")
 
-            If boolUseCommas Then
+            If My.Settings.IncludeCommasInDHMS Then
                 Return String.Join(", ", parts)
             Else
                 Return String.Join(" ", parts)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -135,6 +135,20 @@ Namespace SupportCode
             End If
         End Function
 
+        Public Sub CompressFile(fileName As String)
+            If File.Exists(fileName) Then
+                Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+                    Dim comp As UShort = NativeMethod.NativeMethods.COMPRESSION_FORMAT_DEFAULT
+                    Dim ptr As IntPtr = Marshal.AllocHGlobal(2)
+                    Marshal.WriteInt16(ptr, comp)
+
+                    NativeMethod.NativeMethods.DeviceIoControl(handle.SafeFileHandle, NativeMethod.NativeMethods.FSCTL_SET_COMPRESSION, ptr, 2, IntPtr.Zero, 0, Nothing, IntPtr.Zero)
+
+                    Marshal.FreeHGlobal(ptr)
+                End Using
+            End If
+        End Sub
+
         Public Sub WriteFileAtomically(path As String, contents As Byte())
             Dim tmpPath As String = path & ".tmp"
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -479,7 +479,7 @@ Namespace SyslogParser
                                       ParentForm.SelectLatestLogEntry()
                                   End Sub)
             ElseIf boolIgnored Then
-                If ParentForm.ChkEnableRecordingOfIgnoredLogs.Checked Or boolRecordIgnoredLog Then
+                If My.Settings.recordIgnoredLogs Or boolRecordIgnoredLog Then
                     SyncLock ParentForm.IgnoredLogsLockObject
                         Dim NewIgnoredItem As MyDataGridViewRow = MakeDataGridRow(serverTimeStamp:=serverDate,
                                                                                   dateObject:=currentDate,

--- a/Free SysLog/Support Code/Namespace Code/Task Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Task Handling.vb
@@ -15,54 +15,58 @@ Namespace TaskHandling
         End Function
 
         Public Function DoesTaskExist()
-            Using taskService As New TaskService
-                Dim task As Task = Nothing
+            Try
+                Using taskService As New TaskService
+                    Dim task As Task = Nothing
 
-                If GetTaskObject(taskService, $"Free SysLog for {Environment.UserName}", task) Then
-                    If task.Definition.Settings.IdleSettings.StopOnIdleEnd Then
-                        task.Definition.Settings.IdleSettings.StopOnIdleEnd = False
-                        task.RegisterChanges()
-                    End If
-
-                    If task.Definition.Triggers.Any() Then
-                        Dim trigger As Trigger = task.Definition.Triggers(0)
-
-                        If trigger.TriggerType = TaskTriggerType.Logon Then
-                            Dim dblSeconds As Double = DirectCast(trigger, LogonTrigger).Delay.TotalSeconds
-
-                            If dblSeconds > 0 Then
-                                ParentForm.StartUpDelay.Checked = True
-                                ParentForm.StartUpDelay.Text = $"        Startup Delay ({dblSeconds} {If(dblSeconds = 1, "Second", "Seconds")})"
-                            End If
-                        End If
-                    End If
-
-                    If Not Debugger.IsAttached Then
-                        If task.Definition.Actions.Any() Then
-                            Dim action As Action = task.Definition.Actions(0)
-
-                            If action.ActionType = TaskActionType.Execute Then
-                                If Not DirectCast(action, ExecAction).Path.Replace(strQuote, "").Equals(strEXEPath, StringComparison.OrdinalIgnoreCase) Then
-                                    task.Definition.Actions.Remove(action)
-
-                                    Dim exeFileInfo As New FileInfo(strEXEPath)
-                                    task.Definition.Actions.Add(New ExecAction($"{strQuote}{strEXEPath}{strQuote}", Nothing, exeFileInfo.DirectoryName))
-                                    task.RegisterChanges()
-                                End If
-                            End If
-                        Else
-                            Dim exeFileInfo As New FileInfo(strEXEPath)
-                            task.Definition.Actions.Add(New ExecAction($"{strQuote}{strEXEPath}{strQuote}", Nothing, exeFileInfo.DirectoryName))
+                    If GetTaskObject(taskService, $"Free SysLog for {Environment.UserName}", task) Then
+                        If task.Definition.Settings.IdleSettings.StopOnIdleEnd Then
+                            task.Definition.Settings.IdleSettings.StopOnIdleEnd = False
                             task.RegisterChanges()
                         End If
+
+                        If task.Definition.Triggers.Any() Then
+                            Dim trigger As Trigger = task.Definition.Triggers(0)
+
+                            If trigger.TriggerType = TaskTriggerType.Logon Then
+                                Dim dblSeconds As Double = DirectCast(trigger, LogonTrigger).Delay.TotalSeconds
+
+                                If dblSeconds > 0 Then
+                                    ParentForm.StartUpDelay.Checked = True
+                                    ParentForm.StartUpDelay.Text = $"        Startup Delay ({dblSeconds} {If(dblSeconds = 1, "Second", "Seconds")})"
+                                End If
+                            End If
+                        End If
+
+                        If Not Debugger.IsAttached Then
+                            If task.Definition.Actions.Any() Then
+                                Dim action As Action = task.Definition.Actions(0)
+
+                                If action.ActionType = TaskActionType.Execute Then
+                                    If Not DirectCast(action, ExecAction).Path.Replace(strQuote, "").Equals(strEXEPath, StringComparison.OrdinalIgnoreCase) Then
+                                        task.Definition.Actions.Remove(action)
+
+                                        Dim exeFileInfo As New FileInfo(strEXEPath)
+                                        task.Definition.Actions.Add(New ExecAction($"{strQuote}{strEXEPath}{strQuote}", Nothing, exeFileInfo.DirectoryName))
+                                        task.RegisterChanges()
+                                    End If
+                                End If
+                            Else
+                                Dim exeFileInfo As New FileInfo(strEXEPath)
+                                task.Definition.Actions.Add(New ExecAction($"{strQuote}{strEXEPath}{strQuote}", Nothing, exeFileInfo.DirectoryName))
+                                task.RegisterChanges()
+                            End If
+                        End If
+
+                        ParentForm.StartUpDelay.Enabled = True
+                        Return True
                     End If
+                End Using
 
-                    ParentForm.StartUpDelay.Enabled = True
-                    Return True
-                End If
-            End Using
-
-            Return False
+                Return False
+            Catch ex As Exception
+                Return False
+            End Try
         End Function
 
         Public Sub CreateTask()

--- a/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
+++ b/Free SysLog/Support Code/Namespace Code/Thread Safety Lists.vb
@@ -124,6 +124,24 @@ Namespace ThreadSafetyLists
         Private ReadOnly _list As New List(Of T)
         Private ReadOnly _lock As New Object()
 
+        Public Function OrderByDescending(Of TKey)(keySelector As Func(Of T, TKey)) As IOrderedEnumerable(Of T)
+            SyncLock _lock
+                Return _list.OrderByDescending(keySelector)
+            End SyncLock
+        End Function
+
+        Public Function OrderByAscending(Of TKey)(keySelector As Func(Of T, TKey)) As IOrderedEnumerable(Of T)
+            SyncLock _lock
+                Return _list.OrderBy(keySelector)
+            End SyncLock
+        End Function
+
+        Public Function ThenBy(Of TKey)(keySelector As Func(Of T, TKey)) As List(Of T)
+            SyncLock _lock
+                Return _list.OrderBy(keySelector)
+            End SyncLock
+        End Function
+
         Public Function Count() As Integer
             SyncLock _lock
                 Return _list.Count

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -313,6 +313,7 @@ Public Class Alerts
             Next
 
             newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             alertsList.Clear()

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -1,4 +1,5 @@
-﻿Imports Free_SysLog.SupportCode
+﻿Imports System.ComponentModel
+Imports Free_SysLog.SupportCode
 
 Public Class Alerts
     Private boolDoneLoading As Boolean = False
@@ -312,8 +313,7 @@ Public Class Alerts
                 tempAlerts.Add(Newtonsoft.Json.JsonConvert.SerializeObject(AlertsClass))
             Next
 
-            newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            newAlertsList.Sort(Function(x As AlertsClass, y As AlertsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+            newAlertsList.OrderByDescending(Function(i As AlertsClass) i.BoolEnabled).ThenBy(Function(i As AlertsClass) i.BoolRegex)
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             alertsList.Clear()
@@ -403,8 +403,7 @@ Public Class Alerts
                 listOfAlertsClass.Add(New AlertsClass() With {.StrLogText = item.StrLogText, .StrAlertText = item.StrAlertText, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .alertType = item.AlertType, .BoolEnabled = item.BoolEnabled, .BoolLimited = item.BoolLimited})
             Next
 
-            listOfAlertsClass.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            listOfAlertsClass.Sort(Function(x As AlertsClass, y As AlertsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+            listOfAlertsClass.OrderByDescending(Function(i As AlertsClass) i.BoolEnabled).ThenBy(Function(i As AlertsClass) i.BoolRegex)
 
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
 

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -402,6 +402,9 @@ Public Class Alerts
                 listOfAlertsClass.Add(New AlertsClass() With {.StrLogText = item.StrLogText, .StrAlertText = item.StrAlertText, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .alertType = item.AlertType, .BoolEnabled = item.BoolEnabled, .BoolLimited = item.BoolLimited})
             Next
 
+            listOfAlertsClass.Sort(Function(x As AlertsClass, y As AlertsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            listOfAlertsClass.Sort(Function(x As AlertsClass, y As AlertsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -187,6 +187,8 @@ Public Class ConfigureSysLogMirrorClients
                 tempServer.Add(Newtonsoft.Json.JsonConvert.SerializeObject(SysLogProxyServer))
             Next
 
+            serversList.Sort(Function(x As SysLogProxyServer, y As SysLogProxyServer) y.boolEnabled.CompareTo(x.boolEnabled))
+
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             serversList.Clear()
             serversList.Merge(newServerList.GetSnapshot())

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -247,6 +247,8 @@ Public Class ConfigureSysLogMirrorClients
                 listOfSysLogProxyServer.Add(New SysLogProxyServer() With {.ip = item.SubItems(0).Text, .port = Integer.Parse(item.SubItems(1).Text), .boolEnabled = item.BoolEnabled, .name = item.SubItems(3).Text})
             Next
 
+            listOfSysLogProxyServer.Sort(Function(x As SysLogProxyServer, y As SysLogProxyServer) y.boolEnabled.CompareTo(x.boolEnabled))
+
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfSysLogProxyServer, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -101,6 +101,7 @@ Partial Class Form1
         Me.ExportsLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ImportExportSettingsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.IncludeButtonsOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
+        Me.IncludeCommasInDHMS = New System.Windows.Forms.ToolStripMenuItem()
         Me.IPv6Support = New System.Windows.Forms.ToolStripMenuItem()
         Me.ExportToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ImportToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -483,7 +484,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -716,6 +717,14 @@ Partial Class Form1
         Me.IncludeButtonsOnNotifications.Name = "IncludeButtonsOnNotifications"
         Me.IncludeButtonsOnNotifications.Size = New System.Drawing.Size(319, 22)
         Me.IncludeButtonsOnNotifications.Text = "Include Buttons on Notifications"
+        '
+        'IncludeCommasInDHMS
+        '
+        Me.IncludeCommasInDHMS.CheckOnClick = True
+        Me.IncludeCommasInDHMS.Name = "IncludeCommasInDHMS"
+        Me.IncludeCommasInDHMS.Size = New System.Drawing.Size(319, 22)
+        Me.IncludeCommasInDHMS.Text = "Include Commas in DHMS Strings"
+        Me.IncludeCommasInDHMS.ToolTipText = "Changes how DHMS strings are shown." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & """d, h, m, s"" or ""d h m s"""
         '
         'IPv6Support
         '
@@ -1105,6 +1114,7 @@ Partial Class Form1
     Friend WithEvents ToolStripMenuSeparator As ToolStripSeparator
     Friend WithEvents ImportExportSettingsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents IncludeButtonsOnNotifications As ToolStripMenuItem
+    Friend WithEvents IncludeCommasInDHMS As ToolStripMenuItem
     Friend WithEvents IPv6Support As ToolStripMenuItem
     Friend WithEvents ExportToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ImportToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -833,8 +833,8 @@ Partial Class Form1
         'DonationStripMenuItem
         '
         Me.DonationStripMenuItem.Name = "DonationStripMenuItem"
-        Me.DonationStripMenuItem.Size = New System.Drawing.Size(113, 20)
-        Me.DonationStripMenuItem.Text = "Donate via PayPal"
+        Me.DonationStripMenuItem.Size = New System.Drawing.Size(177, 20)
+        Me.DonationStripMenuItem.Text = "Donate to me via ""Buy Me A Coffee"""
         '
         'StopServerStripMenuItem
         '

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -87,6 +87,7 @@ Partial Class Form1
         Me.ConfigureAlertsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ConfigureHostnames = New System.Windows.Forms.ToolStripMenuItem()
         Me.ColumnControls = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CompressBackupLogFilesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ClearNotificationLimits = New System.Windows.Forms.ToolStripMenuItem()
         Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
@@ -484,7 +485,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.CompressBackupLogFilesToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -501,6 +502,13 @@ Partial Class Form1
         Me.ColumnControls.Name = "ColumnControls"
         Me.ColumnControls.Size = New System.Drawing.Size(319, 22)
         Me.ColumnControls.Text = "Column Controls"
+        '
+        'CompressBackupLogFilesToolStripMenuItem
+        '
+        Me.CompressBackupLogFilesToolStripMenuItem.CheckOnClick = True
+        Me.CompressBackupLogFilesToolStripMenuItem.Name = "CompressBackupLogFilesToolStripMenuItem"
+        Me.CompressBackupLogFilesToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
+        Me.CompressBackupLogFilesToolStripMenuItem.Text = "Compress Backup Log Files using NTFS Compression"
         '
         'ColLogsAutoFill
         '
@@ -1107,6 +1115,7 @@ Partial Class Form1
     Friend WithEvents ConfigureAlertsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ConfigureHostnames As ToolStripMenuItem
     Friend WithEvents ColumnControls As ToolStripMenuItem
+    Friend WithEvents CompressBackupLogFilesToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ClearNotificationLimits As ToolStripMenuItem
     Friend WithEvents ColLogsAutoFill As ToolStripMenuItem
     Friend WithEvents AboutToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1137,11 +1137,12 @@ Public Class Form1
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
         SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
             ShowSingleInstanceWindow(IgnoredLogsAndSearchResultsInstance, Function()
-                                                                              Dim instanceToBeReturned As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.Icon = Icon}
-
-                                                                              instanceToBeReturned.MainProgramForm = Me
-                                                                              instanceToBeReturned.Text = "Ignored Logs"
-                                                                              instanceToBeReturned.LogsToBeDisplayed = IgnoredLogs.GetSnapshot()
+                                                                              Dim instanceToBeReturned As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {
+                                                                                  .Icon = Icon,
+                                                                                  .MainProgramForm = Me,
+                                                                                  .Text = "Ignored Logs",
+                                                                                  .LogsToBeDisplayed = IgnoredLogs.GetSnapshot()
+                                                                              }
                                                                               instanceToBeReturned.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
 
                                                                               Return instanceToBeReturned
@@ -1992,7 +1993,7 @@ Public Class Form1
     Private Sub LogFunctionsToolStripMenuItem_DropDownOpening(sender As Object, e As EventArgs) Handles LogFunctionsToolStripMenuItem.DropDownOpening
         SyncLock dataGridLockObject
             AlertsHistory.Enabled = Logs.Rows.Cast(Of MyDataGridViewRow).Any(Function(row As MyDataGridViewRow) Not String.IsNullOrWhiteSpace(row.AlertText))
-            IgnoredLogsToolStripMenuItem.Visible = IgnoredLogs.Count > 0
+            IgnoredLogsToolStripMenuItem.Visible = IgnoredLogs.Count > 0 Or My.Settings.recordIgnoredLogs
         End SyncLock
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1250,6 +1250,11 @@ Public Class Form1
         IgnoredStats.Clear()
         longNumberOfIgnoredLogs = 0
         LblNumberOfIgnoredIncomingLogs.Text = $"Number of ignored incoming logs: {longNumberOfIgnoredLogs:N0}"
+
+        If My.Settings.saveIgnoredLogCount Then
+            NumberOfIgnoredLogs = longNumberOfIgnoredLogs
+            WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+        End If
     End Sub
 
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1136,12 +1136,16 @@ Public Class Form1
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
         SyncLock IgnoredLogsAndSearchResultsInstanceLockObject
-            ShowSingleInstanceWindow(IgnoredLogsAndSearchResultsInstance, Function() New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.Icon = Icon})
+            ShowSingleInstanceWindow(IgnoredLogsAndSearchResultsInstance, Function()
+                                                                              Dim instanceToBeReturned As New IgnoredLogsAndSearchResults(Me, IgnoreOrSearchWindowDisplayMode.ignored) With {.Icon = Icon}
 
-            IgnoredLogsAndSearchResultsInstance.MainProgramForm = Me
-            IgnoredLogsAndSearchResultsInstance.Text = "Ignored Logs"
-            IgnoredLogsAndSearchResultsInstance.LogsToBeDisplayed = IgnoredLogs.GetSnapshot()
-            IgnoredLogsAndSearchResultsInstance.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
+                                                                              instanceToBeReturned.MainProgramForm = Me
+                                                                              instanceToBeReturned.Text = "Ignored Logs"
+                                                                              instanceToBeReturned.LogsToBeDisplayed = IgnoredLogs.GetSnapshot()
+                                                                              instanceToBeReturned.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
+
+                                                                              Return instanceToBeReturned
+                                                                          End Function)
         End SyncLock
     End Sub
 
@@ -1988,6 +1992,7 @@ Public Class Form1
     Private Sub LogFunctionsToolStripMenuItem_DropDownOpening(sender As Object, e As EventArgs) Handles LogFunctionsToolStripMenuItem.DropDownOpening
         SyncLock dataGridLockObject
             AlertsHistory.Enabled = Logs.Rows.Cast(Of MyDataGridViewRow).Any(Function(row As MyDataGridViewRow) Not String.IsNullOrWhiteSpace(row.AlertText))
+            IgnoredLogsToolStripMenuItem.Visible = IgnoredLogs.Count > 0
         End SyncLock
     End Sub
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -327,6 +327,7 @@ Public Class Form1
         ConfirmDelete.Checked = My.Settings.ConfirmDelete
         ProcessReplacementsInSyslogDataFirst.Checked = My.Settings.ProcessReplacementsInSyslogDataFirst
         ShowCloseButtonOnNotifications.Checked = My.Settings.ShowCloseButtonOnNotifications
+        IncludeCommasInDHMS.Checked = My.Settings.IncludeCommasInDHMS
     End Sub
 
     Private Sub LoadAndDeserializeArrays()
@@ -482,7 +483,7 @@ Public Class Form1
         LoadCheckboxSettings()
 
         processUptimeTimer = New Timer() With {.Interval = 1000, .Enabled = True}
-        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now - dateProcessStarted, False)}"
+        AddHandler processUptimeTimer.Tick, Sub() lblProcessUptime.Text = $"Program Uptime: {TimespanToHMS(Now - dateProcessStarted)}"
 
         SetDoubleBufferingFlag(Logs)
 
@@ -2144,6 +2145,10 @@ Public Class Form1
                 LblItemsSelected.Text = $"Checked Logs: {intNumberOfCheckedLogs:N0}"
             End If
         End If
+    End Sub
+
+    Private Sub IncludeCommasInDHMS_Click(sender As Object, e As EventArgs) Handles IncludeCommasInDHMS.Click
+        My.Settings.IncludeCommasInDHMS = IncludeCommasInDHMS.Checked
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -19,7 +19,7 @@ Public Class Form1
     Public sortOrder As SortOrder = SortOrder.Ascending ' Define soSortOrder at class level
     Public ReadOnly dataGridLockObject As New Object
     Public ReadOnly IgnoredLogsLockObject As New Object
-    Private Const strPayPal As String = "https://paypal.me/trparky"
+    Private Const strBuyMeACoffee As String = "https://buymeacoffee.com/trparky"
     Private serverThread As Threading.Thread
     Private SyslogTcpServer As SyslogTcpServer.SyslogTcpServer
     Private boolServerRunning As Boolean = False
@@ -1543,7 +1543,7 @@ Public Class Form1
     End Sub
 
     Private Sub DonationStripMenuItem_Click(sender As Object, e As EventArgs) Handles DonationStripMenuItem.Click
-        Process.Start(strPayPal)
+        Process.Start(New ProcessStartInfo(strBuyMeACoffee) With {.UseShellExecute = True})
     End Sub
 
     Private Sub StopServerStripMenuItem_Click(sender As Object, e As EventArgs) Handles StopServerStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -178,7 +178,9 @@ Public Class Form1
 
     Private Sub MakeLogBackup()
         WriteLogsToDisk()
-        File.Copy(strPathToDataFile, GetUniqueFileName(Path.Combine(strPathToDataBackupFolder, $"{GetDateStringBasedOnUserPreference(Now.AddDays(-1))} Backup.json")))
+        Dim strLogFileBackupFileName As String = GetUniqueFileName(Path.Combine(strPathToDataBackupFolder, $"{GetDateStringBasedOnUserPreference(Now.AddDays(-1))} Backup.json"))
+        File.Copy(strPathToDataFile, strLogFileBackupFileName)
+        If My.Settings.CompressBackupLogFiles Then CompressFile(strLogFileBackupFileName)
     End Sub
 
     Private Sub ChkStartAtUserStartup_Click(sender As Object, e As EventArgs) Handles ChkEnableStartAtUserStartup.Click
@@ -328,6 +330,7 @@ Public Class Form1
         ProcessReplacementsInSyslogDataFirst.Checked = My.Settings.ProcessReplacementsInSyslogDataFirst
         ShowCloseButtonOnNotifications.Checked = My.Settings.ShowCloseButtonOnNotifications
         IncludeCommasInDHMS.Checked = My.Settings.IncludeCommasInDHMS
+        CompressBackupLogFilesToolStripMenuItem.Checked = My.Settings.CompressBackupLogFiles
     End Sub
 
     Private Sub LoadAndDeserializeArrays()
@@ -2160,6 +2163,10 @@ Public Class Form1
 
     Private Sub IncludeCommasInDHMS_Click(sender As Object, e As EventArgs) Handles IncludeCommasInDHMS.Click
         My.Settings.IncludeCommasInDHMS = IncludeCommasInDHMS.Checked
+    End Sub
+
+    Private Sub CompressBackupLogFilesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CompressBackupLogFilesToolStripMenuItem.Click
+        My.Settings.CompressBackupLogFiles = CompressBackupLogFilesToolStripMenuItem.Checked
     End Sub
 
 #Region "-- SysLog Server Code --"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1617,6 +1617,8 @@ Public Class Form1
                     End If
                 End If
             End Using
+        Else
+            MsgBox("This instance doesn't own the mutex lock for Free Syslog, thus this function is disabled.", MsgBoxStyle.Information, Text)
         End If
     End Sub
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -347,7 +347,7 @@ Public Class IgnoredLogsAndSearchResults
                     Else
                         savedData = New SavedData With {
                                                     .time = myItem.Cells(ColumnIndex_ComputedTime).Value,
-                                                    .ServerDate = myItem.Cells(ColumnIndex_ServerTime).Value,
+                                                    .ServerDate = myItem.ServerDate,
                                                     .logType = myItem.Cells(ColumnIndex_LogType).Value,
                                                     .ip = myItem.Cells(ColumnIndex_IPAddress).Value,
                                                     .hostname = myItem.Cells(ColumnIndex_Hostname).Value,
@@ -630,8 +630,7 @@ Public Class IgnoredLogsAndSearchResults
             Dim selectedRow As MyDataGridViewRow = Logs.Rows(Logs.SelectedCells(0).RowIndex)
             Dim strIgnoredPattern As String = selectedRow.IgnoredPattern
 
-            Dim IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-            IgnoredWordsAndPhrasesOrAlertsInstance.strIgnoredPattern = strIgnoredPattern
+            Dim IgnoredWordsAndPhrasesOrAlertsInstance As New IgnoredWordsAndPhrases With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent, .strIgnoredPattern = strIgnoredPattern}
             IgnoredWordsAndPhrasesOrAlertsInstance.Show()
         End If
     End Sub

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -445,6 +445,8 @@ Partial Class IgnoredWordsAndPhrases
         Me.EnableDisableRecordingToolStripMenuItem.Name = "EnableDisableRecordingToolStripMenuItem"
         Me.EnableDisableRecordingToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
         Me.EnableDisableRecordingToolStripMenuItem.Text = "Enable/Disable Recording"
+        Me.EnableDisableRecordingToolStripMenuItem.ToolTipText = "Makes it so that even if the log is ignored, the log text is still recorded in pr" &
+    "ogram memory and not written to disk."
         '
         'IgnoredWordsAndPhrases
         '

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -63,6 +63,9 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkAutoRefresh = New System.Windows.Forms.CheckBox()
         Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
         Me.ChkRefreshOnlyIfActive = New System.Windows.Forms.CheckBox()
+        Me.colRecord = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.EnableDisableRecordingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkRecord = New System.Windows.Forms.CheckBox()
         Me.ListViewMenu.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -94,7 +97,7 @@ Partial Class IgnoredWordsAndPhrases
         Me.IgnoredListView.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent, Me.colSinceLastEvent})
+        Me.IgnoredListView.Columns.AddRange(New System.Windows.Forms.ColumnHeader() {Me.Ignored, Me.Regex, Me.CaseSensitive, Me.ColEnabled, Me.colHits, Me.colTarget, Me.colDateCreated, Me.colDateOfLastEvent, Me.colSinceLastEvent, Me.colRecord})
         Me.IgnoredListView.ContextMenuStrip = Me.ListViewMenu
         Me.IgnoredListView.FullRowSelect = True
         Me.IgnoredListView.HideSelection = False
@@ -151,20 +154,20 @@ Partial Class IgnoredWordsAndPhrases
         '
         'ListViewMenu
         '
-        Me.ListViewMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.EnableDisableToolStripMenuItem, Me.ResetHitsToolStripMenuItem})
+        Me.ListViewMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.EnableDisableToolStripMenuItem, Me.ResetHitsToolStripMenuItem, Me.EnableDisableRecordingToolStripMenuItem})
         Me.ListViewMenu.Name = "ContextMenuStrip1"
-        Me.ListViewMenu.Size = New System.Drawing.Size(153, 48)
+        Me.ListViewMenu.Size = New System.Drawing.Size(210, 92)
         '
         'EnableDisableToolStripMenuItem
         '
         Me.EnableDisableToolStripMenuItem.Name = "EnableDisableToolStripMenuItem"
-        Me.EnableDisableToolStripMenuItem.Size = New System.Drawing.Size(152, 22)
+        Me.EnableDisableToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
         Me.EnableDisableToolStripMenuItem.Text = "Enable/Disable"
         '
         'ResetHitsToolStripMenuItem
         '
         Me.ResetHitsToolStripMenuItem.Name = "ResetHitsToolStripMenuItem"
-        Me.ResetHitsToolStripMenuItem.Size = New System.Drawing.Size(152, 22)
+        Me.ResetHitsToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
         Me.ResetHitsToolStripMenuItem.Text = "Reset Hit"
         '
         'BtnEdit
@@ -420,11 +423,35 @@ Partial Class IgnoredWordsAndPhrases
         Me.ChkRefreshOnlyIfActive.Text = "Only If Active Window"
         Me.ChkRefreshOnlyIfActive.UseVisualStyleBackColor = True
         '
+        'colRecord
+        '
+        Me.colRecord.Text = "Record?"
+        '
+        'ChkRecord
+        '
+        Me.ChkRecord.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkRecord.AutoSize = True
+        Me.ChkRecord.Location = New System.Drawing.Point(800, 351)
+        Me.ChkRecord.Name = "ChkRecord"
+        Me.ChkRecord.Size = New System.Drawing.Size(67, 17)
+        Me.ChkRecord.TabIndex = 55
+        Me.ChkRecord.Text = "Record?"
+        Me.ToolTip.SetToolTip(Me.ChkRecord, "Makes it so that even if the log is ignored, the log text is still recorded in pr" &
+        "ogram memory and not written to disk.")
+        Me.ChkRecord.UseVisualStyleBackColor = True
+        '
+        'EnableDisableRecordingToolStripMenuItem
+        '
+        Me.EnableDisableRecordingToolStripMenuItem.Name = "EnableDisableRecordingToolStripMenuItem"
+        Me.EnableDisableRecordingToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
+        Me.EnableDisableRecordingToolStripMenuItem.Text = "Enable/Disable Recording"
+        '
         'IgnoredWordsAndPhrases
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(1118, 437)
+        Me.Controls.Add(Me.ChkRecord)
         Me.Controls.Add(Me.ChkRefreshOnlyIfActive)
         Me.Controls.Add(Me.ChkAutoRefresh)
         Me.Controls.Add(Me.btnUpdateHits)
@@ -501,4 +528,7 @@ Partial Class IgnoredWordsAndPhrases
     Friend WithEvents ChkAutoRefresh As CheckBox
     Friend WithEvents ToolTip As ToolTip
     Friend WithEvents ChkRefreshOnlyIfActive As CheckBox
+    Friend WithEvents colRecord As ColumnHeader
+    Friend WithEvents ChkRecord As CheckBox
+    Friend WithEvents EnableDisableRecordingToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -787,7 +787,7 @@ Public Class IgnoredWordsAndPhrases
                         sinceLastEvent = currentDate - dateOfLastEvent
                         item.timeSpanOfLastOccurrence = sinceLastEvent
                         item.dateOfLastOccurrence = dateOfLastEvent
-                        item.SubItems(colDateOfLastEvent.Index).Text = $"{dateOfLastEvent.ToLocalTime.ToLongDateString} {dateOfLastEvent.ToLocalTime.ToLongTimeString}"
+                        item.SubItems(colDateOfLastEvent.Index).Text = $"{dateOfLastEvent.ToLocalTime:D} {dateOfLastEvent.ToLocalTime:T}"
                         item.SubItems(colSinceLastEvent.Index).Text = TimespanToHMS(sinceLastEvent)
                     Else
                         item.SubItems(colDateOfLastEvent.Index).Text = ""

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -224,8 +224,7 @@ Public Class IgnoredWordsAndPhrases
                 tempIgnoredRules.Add(Newtonsoft.Json.JsonConvert.SerializeObject(ignoredClass))
             Next
 
-            newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+            newIgnoredList.OrderByDescending(Function(i As IgnoredClass) i.BoolEnabled).ThenBy(Function(i As IgnoredClass) i.BoolRegex)
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             ignoredList.Clear()
@@ -533,8 +532,7 @@ Public Class IgnoredWordsAndPhrases
                 listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(Ignored.Index).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment, .BoolRecordLog = item.BoolRecordLog})
             Next
 
-            listOfIgnoredClass.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            listOfIgnoredClass.Sort(Function(x As IgnoredClass, y As IgnoredClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+            listOfIgnoredClass.OrderByDescending(Function(i As IgnoredClass) i.BoolEnabled).ThenBy(Function(i As IgnoredClass) i.BoolRegex)
 
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -10,10 +10,25 @@ Public Class IgnoredWordsAndPhrases
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
     Private AutoRefreshTimer As Timer
-    Private boolCurrentlyEditing As Boolean = False
+    Private _boolCurrentlyEditing As Boolean = False
     Private boolF1KeyDown As Boolean = False
     Private Const strWindowTitle As String = "Ignored Words and Phrases"
     Private strOldRuleText As String
+
+    Private Property boolCurrentlyEditing As Boolean
+        Get
+            Return _boolCurrentlyEditing
+        End Get
+        Set(value As Boolean)
+            _boolCurrentlyEditing = value
+
+            If value Then
+                Text = $"{strWindowTitle} — Auto Refresh Paused"
+            Else
+                Text = $"{strWindowTitle} — Auto Refresh Enabled"
+            End If
+        End Set
+    End Property
 
     Private Sub IgnoredListView_ItemDrag(sender As Object, e As ItemDragEventArgs) Handles IgnoredListView.ItemDrag
         draggedItem = CType(e.Item, ListViewItem)
@@ -156,8 +171,6 @@ Public Class IgnoredWordsAndPhrases
             ChkRemoteProcess.Checked = False
             ChkRecord.Checked = False
             strOldRuleText = Nothing
-
-            Text = $"{strWindowTitle} — Auto Refresh Enabled"
         End If
     End Sub
 
@@ -236,7 +249,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
-        If boolCurrentlyEditing Or boolF1KeyDown OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
+        If _boolCurrentlyEditing Or boolF1KeyDown OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
         btnUpdateHits.PerformClick()
     End Sub
 
@@ -355,8 +368,6 @@ Public Class IgnoredWordsAndPhrases
             boolEditMode = True
             BtnAdd.Text = "Save"
             Label4.Text = "Edit Ignored Words and Phrases"
-
-            Text = $"{strWindowTitle} — Auto Refresh Paused"
 
             Dim selectedItemObject As MyIgnoredListViewItem = DirectCast(IgnoredListView.SelectedItems(0), MyIgnoredListViewItem)
 
@@ -646,8 +657,6 @@ Public Class IgnoredWordsAndPhrases
         ChkEnabled.Checked = True
         BtnCancel.Visible = False
         boolCurrentlyEditing = False
-
-        Text = $"{strWindowTitle} — Auto Refresh Enabled"
     End Sub
 
     Private Sub btnDeleteDuringEditing_Click(sender As Object, e As EventArgs) Handles btnDeleteDuringEditing.Click

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -532,6 +532,9 @@ Public Class IgnoredWordsAndPhrases
                 listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(Ignored.Index).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment, .BoolRecordLog = item.BoolRecordLog})
             Next
 
+            listOfIgnoredClass.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            listOfIgnoredClass.Sort(Function(x As IgnoredClass, y As IgnoredClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -76,9 +76,11 @@ Public Class IgnoredWordsAndPhrases
                     .SubItems(CaseSensitive.Index).Text = If(ChkCaseSensitive.Checked, "Yes", "No")
                     .SubItems(ColEnabled.Index).Text = If(ChkEnabled.Checked, "Yes", "No")
                     .SubItems(colTarget.Index).Text = If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text")
+                    .SubItems(colRecord.Index).Text = If(ChkRecord.Checked, "Yes", "No")
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .BoolRegex = ChkRegex.Checked
+                    .BoolRecordLog = ChkRecord.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                     .strComment = txtComment.Text
@@ -129,11 +131,13 @@ Public Class IgnoredWordsAndPhrases
                     .SubItems.Add("0")
                     .SubItems.Add(If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text"))
                     .SubItems.Add(Date.Now.ToLongDateString)
+                    .SubItems.Add(If(ChkRecord.Checked, "Yes", "No"))
                     .BoolRegex = ChkRegex.Checked
                     .BoolCaseSensitive = ChkCaseSensitive.Checked
                     .BoolEnabled = ChkEnabled.Checked
                     .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
                     .strComment = txtComment.Text
+                    .BoolRecordLog = ChkRecord.Checked
                     .dateCreated = Date.Now
                     If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
@@ -150,6 +154,7 @@ Public Class IgnoredWordsAndPhrases
             ChkRegex.Checked = False
             ChkEnabled.Checked = True
             ChkRemoteProcess.Checked = False
+            ChkRecord.Checked = False
             strOldRuleText = Nothing
 
             Text = $"{strWindowTitle} — Auto Refresh Enabled"
@@ -190,6 +195,7 @@ Public Class IgnoredWordsAndPhrases
                     .BoolCaseSensitive = item.BoolCaseSensitive,
                     .BoolRegex = item.BoolRegex,
                     .BoolEnabled = item.BoolEnabled,
+                    .BoolRecordLog = item.BoolRecordLog,
                     .IgnoreType = item.IgnoreType,
                     .dateCreated = item.dateCreated,
                     .strComment = item.strComment
@@ -359,6 +365,7 @@ Public Class IgnoredWordsAndPhrases
             ChkRegex.Checked = selectedItemObject.BoolRegex
             ChkCaseSensitive.Checked = selectedItemObject.BoolCaseSensitive
             ChkEnabled.Checked = selectedItemObject.BoolEnabled
+            ChkRecord.Checked = selectedItemObject.BoolRecordLog
             txtComment.Text = selectedItemObject.strComment
 
             strOldRuleText = selectedItemObject.SubItems(Ignored.Index).Text
@@ -373,10 +380,18 @@ Public Class IgnoredWordsAndPhrases
         EditItem()
     End Sub
 
+    Private Sub EnableDisableRecordingToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles EnableDisableRecordingToolStripMenuItem.Click
+        Dim selectedItem As MyIgnoredListViewItem = IgnoredListView.SelectedItems(0)
+        selectedItem.BoolRecordLog = Not selectedItem.BoolRecordLog ' Flip the setting
+        selectedItem.SubItems(colRecord.Index).Text = If(selectedItem.BoolRecordLog, "Yes", "No")
+        boolChanged = True
+    End Sub
+
     Private Sub ListViewMenu_Opening(sender As Object, e As ComponentModel.CancelEventArgs) Handles ListViewMenu.Opening
         ' Default visibility settings
         EnableDisableToolStripMenuItem.Visible = False
         ResetHitsToolStripMenuItem.Visible = False
+        EnableDisableRecordingToolStripMenuItem.Visible = False
 
         ' Handle different cases based on the number of selected items
         If IgnoredListView.SelectedItems.Count = 0 Then
@@ -389,10 +404,12 @@ Public Class IgnoredWordsAndPhrases
         If IgnoredListView.SelectedItems.Count = 1 Then
             EnableDisableToolStripMenuItem.Visible = True
             ResetHitsToolStripMenuItem.Visible = True
+            EnableDisableRecordingToolStripMenuItem.Visible = True
 
             ' Update the Enable/Disable text based on the item's BoolEnabled property
             Dim selectedItem As MyIgnoredListViewItem = IgnoredListView.SelectedItems(0)
             EnableDisableToolStripMenuItem.Text = If(selectedItem.BoolEnabled, "Disable", "Enable")
+            EnableDisableRecordingToolStripMenuItem.Text = If(selectedItem.BoolRecordLog, "Disable Log Recording", "Enable Log Recording")
 
             ' Make Reset Hits option be singular.
             ResetHitsToolStripMenuItem.Text = "Reset Hit"
@@ -493,7 +510,7 @@ Public Class IgnoredWordsAndPhrases
 
         If saveFileDialog.ShowDialog() = DialogResult.OK Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
-                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(Ignored.Index).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment})
+                listOfIgnoredClass.Add(New IgnoredClass() With {.StrIgnore = item.SubItems(Ignored.Index).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolRegex = item.BoolRegex, .BoolEnabled = item.BoolEnabled, .IgnoreType = item.IgnoreType, .dateCreated = item.dateCreated, .strComment = item.strComment, .BoolRecordLog = item.BoolRecordLog})
             Next
 
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -225,6 +225,7 @@ Public Class IgnoredWordsAndPhrases
             Next
 
             newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            newIgnoredList.Sort(Function(x As IgnoredClass, y As IgnoredClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             ignoredList.Clear()

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -15,6 +15,10 @@ Public Class IgnoredWordsAndPhrases
     Private Const strWindowTitle As String = "Ignored Words and Phrases"
     Private strOldRuleText As String
 
+    Private Sub ListViewMenu_Closed(sender As Object, e As ToolStripDropDownClosedEventArgs) Handles ListViewMenu.Closed
+        boolCurrentlyEditing = False
+    End Sub
+
     Private Property boolCurrentlyEditing As Boolean
         Get
             Return _boolCurrentlyEditing
@@ -105,29 +109,29 @@ Public Class IgnoredWordsAndPhrases
                         .SubItems(colDateCreated.Index).Text = Date.Now.ToLongDateString
                     End If
 
-	                If Not strOldRuleText.Equals(TxtIgnored.Text, StringComparison.OrdinalIgnoreCase) Then
+                    If Not strOldRuleText.Equals(TxtIgnored.Text, StringComparison.OrdinalIgnoreCase) Then
                         IgnoredStats.TryRemove(.SubItems(Ignored.Index).Text, Nothing)
                         .intHits = 0
-                		.dateOfLastOccurrence = Date.MinValue
-                		.timeSpanOfLastOccurrence = TimeSpan.MinValue
-                		.SubItems(colHits.Index).Text = "0"
-                		.SubItems(colDateOfLastEvent.Index).Text = ""
-                		.SubItems(colSinceLastEvent.Index).Text = ""
-                		.intHits = 0
-	                End If
+                        .dateOfLastOccurrence = Date.MinValue
+                        .timeSpanOfLastOccurrence = TimeSpan.MinValue
+                        .SubItems(colHits.Index).Text = "0"
+                        .SubItems(colDateOfLastEvent.Index).Text = ""
+                        .SubItems(colSinceLastEvent.Index).Text = ""
+                        .intHits = 0
+                    End If
 
-	                If .BoolEnabled Then
-	                    .BackColor = Color.LightGreen
-	                    .SubItems(colHits.Index).Text = "0"
-	                    .intHits = 0
-	                Else
-	                    .BackColor = Color.Pink
-	                    .SubItems(colHits.Index).Text = ""
-	                    .SubItems(colDateOfLastEvent.Index).Text = ""
-	                    .SubItems(colSinceLastEvent.Index).Text = ""
-	                    .intHits = 0
-	                    .dateOfLastOccurrence = Date.MinValue
-	                    .timeSpanOfLastOccurrence = TimeSpan.MinValue
+                    If .BoolEnabled Then
+                        .BackColor = Color.LightGreen
+                        .SubItems(colHits.Index).Text = "0"
+                        .intHits = 0
+                    Else
+                        .BackColor = Color.Pink
+                        .SubItems(colHits.Index).Text = ""
+                        .SubItems(colDateOfLastEvent.Index).Text = ""
+                        .SubItems(colSinceLastEvent.Index).Text = ""
+                        .intHits = 0
+                        .dateOfLastOccurrence = Date.MinValue
+                        .timeSpanOfLastOccurrence = TimeSpan.MinValue
                         IgnoredStats.TryRemove(.SubItems(Ignored.Index).Text, Nothing)
                     End If
                 End With
@@ -399,6 +403,8 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub ListViewMenu_Opening(sender As Object, e As ComponentModel.CancelEventArgs) Handles ListViewMenu.Opening
+        boolCurrentlyEditing = True
+
         ' Default visibility settings
         EnableDisableToolStripMenuItem.Visible = False
         ResetHitsToolStripMenuItem.Visible = False

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -147,9 +147,11 @@ Public Class IgnoredWordsAndPhrases
                     .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
                     .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
                     .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
-                    .SubItems.Add("0")
                     .SubItems.Add(If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text"))
                     .SubItems.Add(Date.Now.ToLongDateString)
+                    .SubItems.Add("")
+                    .SubItems.Add("0")
+                    .SubItems.Add("")
                     .SubItems.Add(If(ChkRecord.Checked, "Yes", "No"))
                     .BoolRegex = ChkRegex.Checked
                     .BoolCaseSensitive = ChkCaseSensitive.Checked

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -334,6 +334,9 @@ Public Class Replacements
                 listOfReplacementsClass.Add(New ReplacementsClass With {.BoolRegex = item.BoolRegex, .StrReplace = item.SubItems(0).Text, .StrReplaceWith = item.SubItems(1).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolEnabled = item.BoolEnabled})
             Next
 
+            listOfReplacementsClass.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            listOfReplacementsClass.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -178,8 +178,7 @@ Public Class Replacements
                 tempReplacements.Add(Newtonsoft.Json.JsonConvert.SerializeObject(replacementsClass))
             Next
 
-            newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+            newReplacementsList.OrderByDescending(Function(i As ReplacementsClass) i.BoolEnabled).ThenBy(Function(i As ReplacementsClass) i.BoolRegex)
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             replacementsList.Clear()
@@ -335,8 +334,7 @@ Public Class Replacements
                 listOfReplacementsClass.Add(New ReplacementsClass With {.BoolRegex = item.BoolRegex, .StrReplace = item.SubItems(0).Text, .StrReplaceWith = item.SubItems(1).Text, .BoolCaseSensitive = item.BoolCaseSensitive, .BoolEnabled = item.BoolEnabled})
             Next
 
-            listOfReplacementsClass.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
-            listOfReplacementsClass.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
+            listOfReplacementsClass.OrderByDescending(Function(i As ReplacementsClass) i.BoolEnabled).ThenBy(Function(i As ReplacementsClass) i.BoolRegex)
 
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
 

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -179,6 +179,7 @@ Public Class Replacements
             Next
 
             newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) x.BoolRegex.CompareTo(y.BoolRegex))
+            newReplacementsList.Sort(Function(x As ReplacementsClass, y As ReplacementsClass) y.BoolEnabled.CompareTo(x.BoolEnabled))
 
             ' We now save the new list to the main lists in memory now that we know nothing wrong happened above.
             replacementsList.Clear()

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -32,6 +32,8 @@ Partial Class ViewLogBackups
         Me.ViewToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnView = New System.Windows.Forms.Button()
         Me.BtnDelete = New System.Windows.Forms.Button()
+        Me.ChkShowNTFSCompressionSizeDifference = New System.Windows.Forms.CheckBox()
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage = New System.Windows.Forms.CheckBox()
         Me.BtnRefresh = New System.Windows.Forms.Button()
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.lblNumberOfFiles = New System.Windows.Forms.ToolStripStatusLabel()
@@ -83,7 +85,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(929, 243)
+        Me.FileList.Size = New System.Drawing.Size(990, 243)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -118,7 +120,7 @@ Partial Class ViewLogBackups
         '
         Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.CompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 202)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 180)
         '
         'DeleteToolStripMenuItem
         '
@@ -181,7 +183,7 @@ Partial Class ViewLogBackups
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.lblTotalNumberOfHiddenLogs, Me.LblTotalDiskSpace})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(954, 22)
+        Me.StatusStrip1.Size = New System.Drawing.Size(1015, 22)
         Me.StatusStrip1.TabIndex = 5
         Me.StatusStrip1.Text = "StatusStrip1"
         '
@@ -226,6 +228,28 @@ Partial Class ViewLogBackups
         Me.ChkRegExSearch.TabIndex = 32
         Me.ChkRegExSearch.Text = "Regex?"
         Me.ChkRegExSearch.UseVisualStyleBackColor = True
+        '
+        'ChkShowNTFSCompressionSizeDifference
+        '
+        Me.ChkShowNTFSCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkShowNTFSCompressionSizeDifference.AutoSize = True
+        Me.ChkShowNTFSCompressionSizeDifference.Location = New System.Drawing.Point(714, 265)
+        Me.ChkShowNTFSCompressionSizeDifference.Name = "ChkShowNTFSCompressionSizeDifference"
+        Me.ChkShowNTFSCompressionSizeDifference.Size = New System.Drawing.Size(222, 17)
+        Me.ChkShowNTFSCompressionSizeDifference.TabIndex = 43
+        Me.ChkShowNTFSCompressionSizeDifference.Text = "Show NTFS Compression Size Difference"
+        Me.ChkShowNTFSCompressionSizeDifference.UseVisualStyleBackColor = True
+        '
+        'ChkShowNTFSCompressionSizeDifferencePercentage
+        '
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.AutoSize = True
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(714, 292)
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Name = "ChkShowNTFSCompressionSizeDifferencePercentage"
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(280, 17)
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.TabIndex = 44
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Text = "Show NTFS Compression Size Difference Percentage"
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.UseVisualStyleBackColor = True
         '
         'BtnSearch
         '
@@ -397,7 +421,7 @@ Partial Class ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(954, 364)
+        Me.ClientSize = New System.Drawing.Size(1015, 364)
         Me.Controls.Add(Me.btnViewLogsWithLimits)
         Me.Controls.Add(Me.boxLimiter)
         Me.Controls.Add(Me.boxLimitBy)
@@ -416,10 +440,12 @@ Partial Class ViewLogBackups
         Me.Controls.Add(Me.BtnView)
         Me.Controls.Add(Me.FileList)
         Me.Controls.Add(Me.ChkLogFileDeletions)
+        Me.Controls.Add(Me.ChkShowNTFSCompressionSizeDifference)
+        Me.Controls.Add(Me.ChkShowNTFSCompressionSizeDifferencePercentage)
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(970, 403)
+        Me.MinimumSize = New System.Drawing.Size(1031, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)
@@ -469,4 +495,6 @@ Partial Class ViewLogBackups
     Friend WithEvents RenameToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents UncompressFileToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ChkShowNTFSCompressionSizeDifference As CheckBox
+    Friend WithEvents ChkShowNTFSCompressionSizeDifferencePercentage As CheckBox
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -233,7 +233,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowNTFSCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowNTFSCompressionSizeDifference.AutoSize = True
-        Me.ChkShowNTFSCompressionSizeDifference.Location = New System.Drawing.Point(714, 265)
+        Me.ChkShowNTFSCompressionSizeDifference.Location = New System.Drawing.Point(554, 292)
         Me.ChkShowNTFSCompressionSizeDifference.Name = "ChkShowNTFSCompressionSizeDifference"
         Me.ChkShowNTFSCompressionSizeDifference.Size = New System.Drawing.Size(222, 17)
         Me.ChkShowNTFSCompressionSizeDifference.TabIndex = 43
@@ -244,7 +244,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.AutoSize = True
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(714, 292)
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(554, 319)
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.Name = "ChkShowNTFSCompressionSizeDifferencePercentage"
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(280, 17)
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.TabIndex = 44
@@ -290,7 +290,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHidden.AutoSize = True
-        Me.ChkShowHidden.Location = New System.Drawing.Point(275, 265)
+        Me.ChkShowHidden.Location = New System.Drawing.Point(843, 292)
         Me.ChkShowHidden.Name = "ChkShowHidden"
         Me.ChkShowHidden.Size = New System.Drawing.Size(114, 17)
         Me.ChkShowHidden.TabIndex = 34
@@ -308,7 +308,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHiddenAsGray.AutoSize = True
-        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(395, 265)
+        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(843, 319)
         Me.ChkShowHiddenAsGray.Name = "ChkShowHiddenAsGray"
         Me.ChkShowHiddenAsGray.Size = New System.Drawing.Size(153, 17)
         Me.ChkShowHiddenAsGray.TabIndex = 35
@@ -342,7 +342,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkIgnoreSearchResultsLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkIgnoreSearchResultsLimits.AutoSize = True
-        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(554, 292)
+        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(843, 265)
         Me.ChkIgnoreSearchResultsLimits.Name = "ChkIgnoreSearchResultsLimits"
         Me.ChkIgnoreSearchResultsLimits.Size = New System.Drawing.Size(160, 17)
         Me.ChkIgnoreSearchResultsLimits.TabIndex = 37

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -57,6 +57,7 @@ Partial Class ViewLogBackups
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
+        Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.StatusStrip1.SuspendLayout()
         CType(Me.FileList, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -112,32 +113,32 @@ Partial Class ViewLogBackups
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.UnhideToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(147, 92)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 136)
         '
         'DeleteToolStripMenuItem
         '
         Me.DeleteToolStripMenuItem.Name = "DeleteToolStripMenuItem"
-        Me.DeleteToolStripMenuItem.Size = New System.Drawing.Size(146, 22)
+        Me.DeleteToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.DeleteToolStripMenuItem.Text = "&Delete"
         '
         'ViewToolStripMenuItem
         '
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(146, 22)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.ViewToolStripMenuItem.Text = "&View"
         '
         'HideToolStripMenuItem
         '
         Me.HideToolStripMenuItem.Name = "HideToolStripMenuItem"
-        Me.HideToolStripMenuItem.Size = New System.Drawing.Size(146, 22)
+        Me.HideToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.HideToolStripMenuItem.Text = "Hide"
         '
         'UnhideToolStripMenuItem
         '
         Me.UnhideToolStripMenuItem.Name = "UnhideToolStripMenuItem"
-        Me.UnhideToolStripMenuItem.Size = New System.Drawing.Size(146, 22)
+        Me.UnhideToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.UnhideToolStripMenuItem.Text = "Unhide/Show"
         '
         'BtnView
@@ -365,6 +366,12 @@ Partial Class ViewLogBackups
         Me.btnViewLogsWithLimits.Text = "View All with Limits"
         Me.btnViewLogsWithLimits.UseVisualStyleBackColor = True
         '
+        'ShowInWindowsExplorerToolStripMenuItem
+        '
+        Me.ShowInWindowsExplorerToolStripMenuItem.Name = "ShowInWindowsExplorerToolStripMenuItem"
+        Me.ShowInWindowsExplorerToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.ShowInWindowsExplorerToolStripMenuItem.Text = "Show in Windows Explorer"
+        '
         'ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -437,4 +444,5 @@ Partial Class ViewLogBackups
     Friend WithEvents boxLimitBy As ComboBox
     Friend WithEvents boxLimiter As ComboBox
     Friend WithEvents btnViewLogsWithLimits As Button
+    Friend WithEvents ShowInWindowsExplorerToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -58,6 +58,7 @@ Partial Class ViewLogBackups
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
         Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.RenameToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.StatusStrip1.SuspendLayout()
         CType(Me.FileList, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -113,9 +114,9 @@ Partial Class ViewLogBackups
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 136)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 158)
         '
         'DeleteToolStripMenuItem
         '
@@ -311,6 +312,12 @@ Partial Class ViewLogBackups
         Me.ToolTip.SetToolTip(Me.ChkIgnoreSearchResultsLimits, "Warning: Enabling this could cause performance issues.")
         Me.ChkIgnoreSearchResultsLimits.UseVisualStyleBackColor = True
         '
+        'RenameToolStripMenuItem
+        '
+        Me.RenameToolStripMenuItem.Name = "RenameToolStripMenuItem"
+        Me.RenameToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.RenameToolStripMenuItem.Text = "Rename"
+        '
         'ChkLogFileDeletions
         '
         Me.ChkLogFileDeletions.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -445,4 +452,5 @@ Partial Class ViewLogBackups
     Friend WithEvents boxLimiter As ComboBox
     Friend WithEvents btnViewLogsWithLimits As Button
     Friend WithEvents ShowInWindowsExplorerToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents RenameToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -237,7 +237,7 @@ Partial Class ViewLogBackups
         Me.ChkShowNTFSCompressionSizeDifference.Name = "ChkShowNTFSCompressionSizeDifference"
         Me.ChkShowNTFSCompressionSizeDifference.Size = New System.Drawing.Size(222, 17)
         Me.ChkShowNTFSCompressionSizeDifference.TabIndex = 43
-        Me.ChkShowNTFSCompressionSizeDifference.Text = "Show NTFS Compression Size Difference"
+        Me.ChkShowNTFSCompressionSizeDifference.Text = "Show NTFS Compression Size Differences"
         Me.ChkShowNTFSCompressionSizeDifference.UseVisualStyleBackColor = True
         '
         'ChkShowNTFSCompressionSizeDifferencePercentage
@@ -248,7 +248,7 @@ Partial Class ViewLogBackups
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.Name = "ChkShowNTFSCompressionSizeDifferencePercentage"
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(280, 17)
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.TabIndex = 44
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Text = "Show NTFS Compression Size Difference Percentage"
+        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Text = "Show NTFS Compression Size Difference Percentages"
         Me.ChkShowNTFSCompressionSizeDifferencePercentage.UseVisualStyleBackColor = True
         '
         'BtnSearch

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -55,6 +55,8 @@ Partial Class ViewLogBackups
         Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
+        Me.CompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.UncompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
         Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -100,7 +102,7 @@ Partial Class ViewLogBackups
         '
         'ColFileSize
         '
-        Me.ColFileSize.HeaderText = "File Size"
+        Me.ColFileSize.HeaderText = "File Size (Compressed File Size)"
         Me.ColFileSize.Name = "ColFileSize"
         Me.ColFileSize.ReadOnly = True
         Me.ColFileSize.Width = 240
@@ -114,9 +116,9 @@ Partial Class ViewLogBackups
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.CompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 158)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 202)
         '
         'DeleteToolStripMenuItem
         '
@@ -201,6 +203,18 @@ Partial Class ViewLogBackups
         Me.ChkCaseInsensitiveSearch.TabIndex = 33
         Me.ChkCaseInsensitiveSearch.Text = "Case Insensitive?"
         Me.ChkCaseInsensitiveSearch.UseVisualStyleBackColor = True
+        '
+        'CompressFileToolStripMenuItem
+        '
+        Me.CompressFileToolStripMenuItem.Name = "CompressFileToolStripMenuItem"
+        Me.CompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.CompressFileToolStripMenuItem.Text = "Compress File"
+        '
+        'UncompressFileToolStripMenuItem
+        '
+        Me.UncompressFileToolStripMenuItem.Name = "UncompressFileToolStripMenuItem"
+        Me.UncompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.UncompressFileToolStripMenuItem.Text = "Uncompress File"
         '
         'ChkRegExSearch
         '
@@ -453,4 +467,6 @@ Partial Class ViewLogBackups
     Friend WithEvents btnViewLogsWithLimits As Button
     Friend WithEvents ShowInWindowsExplorerToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents RenameToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents CompressFileToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents UncompressFileToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -158,9 +158,11 @@ Public Class ViewLogBackups
                                                    If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
                                                        row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
+                                                   ElseIf boolIsCompressed AndAlso Not ChkShowNTFSCompressionSizeDifference.Checked Then
+                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
+                                                   ElseIf Not boolIsCompressed Then
+                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
                                                    End If
-
-                                                   If Not boolIsCompressed Then Interlocked.Add(longUsedDiskSpace, file.Length)
 
                                                    threadSafeListOfDataGridViewRows.Add(row)
                                                End If
@@ -189,7 +191,7 @@ Public Class ViewLogBackups
                    lblNumberOfFiles.Text = $"Number of Files: {intFileCount:N0}"
 
                    If intNumberOfCompressedFiles = 0 Then
-                       LblTotalDiskSpace.Text = $"Total Disk Space Used: {FileSizeToHumanSize(longUsedDiskSpace)}"
+                       LblTotalDiskSpace.Text = $"Total File Size: {FileSizeToHumanSize(longUsedDiskSpace)}"
                    Else
                        LblTotalDiskSpace.Text = $"Total Disk Space Used on Disk: {FileSizeToHumanSize(longUsedDiskSpace)}"
                    End If

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -429,6 +429,7 @@ Public Class ViewLogBackups
     Private Sub ContextMenuStrip1_Opening(sender As Object, e As CancelEventArgs) Handles ContextMenuStrip1.Opening
         If FileList.SelectedRows.Count > 0 Then
             DeleteToolStripMenuItem.Enabled = True
+            ShowInWindowsExplorerToolStripMenuItem.Visible = True
             ViewToolStripMenuItem.Enabled = FileList.SelectedRows.Count <= 1
 
             Dim fileName As String = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
@@ -443,6 +444,7 @@ Public Class ViewLogBackups
         Else
             DeleteToolStripMenuItem.Enabled = False
             ViewToolStripMenuItem.Enabled = False
+            ShowInWindowsExplorerToolStripMenuItem.Visible = False
         End If
     End Sub
 
@@ -705,5 +707,9 @@ Public Class ViewLogBackups
                                               End Sub
 
         worker.RunWorkerAsync()
+    End Sub
+
+    Private Sub ShowInWindowsExplorerToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ShowInWindowsExplorerToolStripMenuItem.Click
+        SelectFileInWindowsExplorer(Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value))
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -72,6 +72,18 @@ Public Class ViewLogBackups
         End Try
     End Function
 
+    Private Function GetNTFSFileCompressionInfo(file As FileInfo) As String
+        Dim longNTFSCompressedFileSize As Long = GetCompressedSize(file.FullName)
+        Dim strFileSizeString As String = FileSizeToHumanSize(longNTFSCompressedFileSize)
+
+        If ChkShowNTFSCompressionSizeDifferencePercentage.Checked Then
+            Dim strPercentString As String = MyRoundingFunction(longNTFSCompressedFileSize / file.Length * 100, 2)
+            strFileSizeString &= $", {strPercentString}% smaller"
+        End If
+
+        Return strFileSizeString
+    End Function
+
     Private Sub LoadFileList()
         Dim filesInDirectory As FileInfo()
 
@@ -129,7 +141,6 @@ Public Class ViewLogBackups
                                                        .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
                                                    End With
 
-
                                                    For Each cell As DataGridViewCell In row.Cells
                                                        cell.Style.Font = My.Settings.font
                                                        If boolIsHidden AndAlso ChkShowHiddenAsGray.Checked Then cell.Style.ForeColor = Color.Gray
@@ -138,18 +149,9 @@ Public Class ViewLogBackups
 
                                                    row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
-                                                   If boolIsCompressed Then
-                                                       intCompresedSize = GetCompressedSize(file.FullName)
-
-                                                       If ChkShowNTFSCompressionSizeDifference.Checked Then
-                                                           If ChkShowNTFSCompressionSizeDifferencePercentage.Checked Then
-                                                               row.Cells(2).Value &= $" ({FileSizeToHumanSize(intCompresedSize)}, {MyRoundingFunction(intCompresedSize / file.Length * 100, 2)}% smaller)"
-                                                           Else
-                                                               row.Cells(2).Value &= $" ({FileSizeToHumanSize(intCompresedSize)})"
-                                                           End If
-
-                                                           Interlocked.Increment(intNumberOfCompressedFiles)
-                                                       End If
+                                                   If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
+                                                       row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file)})"
+                                                       Interlocked.Increment(intNumberOfCompressedFiles)
                                                    End If
 
                                                    threadSafeListOfDataGridViewRows.Add(row)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -133,6 +133,8 @@ Public Class ViewLogBackups
                                                        If boolIsCompressed Then cell.Style.ForeColor = Color.Blue
                                                    Next
 
+                                                   row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
+
                                                    If boolIsCompressed Then row.Cells(2).Value &= " (" & FileSizeToHumanSize(GetCompressedSize(file.FullName)) & ")"
 
                                                    ' Thread-safe add to list
@@ -167,7 +169,7 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub DataGridView1_CellPainting(sender As Object, e As DataGridViewCellPaintingEventArgs) Handles FileList.CellPainting
-        If e.RowIndex = -1 AndAlso (e.ColumnIndex = colHidden.Index Or e.ColumnIndex = colEntryCount.Index) Then
+        If e.RowIndex = -1 AndAlso (e.ColumnIndex = colHidden.Index Or e.ColumnIndex = colEntryCount.Index Or e.ColumnIndex = ColFileSize.Index) Then
             e.PaintBackground(e.CellBounds, False)
             TextRenderer.DrawText(e.Graphics, e.FormattedValue.ToString(), e.CellStyle.Font, e.CellBounds, e.CellStyle.ForeColor, TextFormatFlags.HorizontalCenter Or TextFormatFlags.VerticalCenter)
             e.Handled = True

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -568,20 +568,6 @@ Public Class ViewLogBackups
         BtnRefresh.PerformClick()
     End Sub
 
-    Private Sub CompressFile(fileName As String)
-        If File.Exists(fileName) Then
-            Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
-                Dim comp As UShort = NativeMethod.NativeMethods.COMPRESSION_FORMAT_DEFAULT
-                Dim ptr As IntPtr = Marshal.AllocHGlobal(2)
-                Marshal.WriteInt16(ptr, comp)
-
-                NativeMethod.NativeMethods.DeviceIoControl(handle.SafeFileHandle, NativeMethod.NativeMethods.FSCTL_SET_COMPRESSION, ptr, 2, IntPtr.Zero, 0, Nothing, IntPtr.Zero)
-
-                Marshal.FreeHGlobal(ptr)
-            End Using
-        End If
-    End Sub
-
     Private Shared Function GetCompressedSize(fileName As String) As Long
         If Not File.Exists(fileName) Then Return -1
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -517,7 +517,7 @@ Public Class ViewLogBackups
         My.Settings.boolShowHiddenFilesOnViewLogBackyupsWindow = ChkShowHidden.Checked
         ChkShowHiddenAsGray.Enabled = ChkShowHidden.Checked
         colHidden.Visible = ChkShowHidden.Checked
-        BtnRefresh.PerformClick()
+        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
     Private Sub UncompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UncompressFileToolStripMenuItem.Click
@@ -533,7 +533,7 @@ Public Class ViewLogBackups
             UncompressFile(fileName)
         End If
 
-        BtnRefresh.PerformClick()
+        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
     Private Sub CompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CompressFileToolStripMenuItem.Click
@@ -549,7 +549,7 @@ Public Class ViewLogBackups
             CompressFile(fileName)
         End If
 
-        BtnRefresh.PerformClick()
+        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
     Private Sub UnhideToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UnhideToolStripMenuItem.Click
@@ -565,7 +565,7 @@ Public Class ViewLogBackups
             UnhideFile(fileName)
         End If
 
-        BtnRefresh.PerformClick()
+        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
     Private Sub HideToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles HideToolStripMenuItem.Click
@@ -581,7 +581,7 @@ Public Class ViewLogBackups
             HideFile(fileName)
         End If
 
-        BtnRefresh.PerformClick()
+        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
     ''' <summary>Returns the NTFS compressed size of a file on disk. Returns a -1 if an error occurs.</summary>
@@ -633,7 +633,7 @@ Public Class ViewLogBackups
 
     Private Sub ChkShowHiddenAsGray_Click(sender As Object, e As EventArgs) Handles ChkShowHiddenAsGray.Click
         My.Settings.boolShowHiddenAsGray = ChkShowHiddenAsGray.Checked
-        BtnRefresh.PerformClick()
+        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
     Private Sub FileList_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles FileList.ColumnWidthChanged

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -113,7 +113,7 @@ Public Class ViewLogBackups
                                                        .Cells(0).Value = file.Name
                                                        .Cells(0).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
-                                                       .Cells(1).Value = $"{file.LastWriteTime.ToLongDateString} {file.LastWriteTime.ToLongTimeString}"
+                                                       .Cells(1).Value = $"{file.LastWriteTime:D} {file.LastWriteTime:T}"
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        .Cells(2).Value = FileSizeToHumanSize(file.Length)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -158,9 +158,7 @@ Public Class ViewLogBackups
                                                    If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
                                                        row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
-                                                   ElseIf boolIsCompressed AndAlso Not ChkShowNTFSCompressionSizeDifference.Checked Then
-                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
-                                                   ElseIf Not boolIsCompressed Then
+                                                   Else
                                                        Interlocked.Add(longUsedDiskSpace, file.Length)
                                                    End If
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -92,7 +92,7 @@ Public Class ViewLogBackups
         End If
     End Function
 
-    Private Sub LoadFileList()
+    Private Sub LoadFileList(Optional intReselectItem As Integer = -1)
         Dim filesInDirectory As FileInfo()
 
         If ChkShowHidden.Checked Then
@@ -202,6 +202,12 @@ Public Class ViewLogBackups
                    lblTotalNumberOfHiddenLogs.Visible = intHiddenFileCount > 0
                    lblNumberOfHiddenFiles.Text = $"Number of Hidden Files: {intHiddenFileCount:N0}"
                    lblTotalNumberOfHiddenLogs.Text = $"Number of Hidden Logs: {intHiddenTotalLogCount:N0}"
+
+                   If intReselectItem <> -1 AndAlso intReselectItem < FileList.Rows.Count Then
+                       FileList.ClearSelection()
+                       FileList.Rows(intReselectItem).Selected = True
+                       FileList.FirstDisplayedScrollingRowIndex = intReselectItem
+                   End If
                End Sub)
     End Sub
 
@@ -521,6 +527,7 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub UncompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UncompressFileToolStripMenuItem.Click
+        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim fileName As String
 
         If FileList.SelectedRows.Count > 1 Then
@@ -533,10 +540,11 @@ Public Class ViewLogBackups
             UncompressFile(fileName)
         End If
 
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
     End Sub
 
     Private Sub CompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CompressFileToolStripMenuItem.Click
+        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim fileName As String
 
         If FileList.SelectedRows.Count > 1 Then
@@ -549,10 +557,11 @@ Public Class ViewLogBackups
             CompressFile(fileName)
         End If
 
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
     End Sub
 
     Private Sub UnhideToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UnhideToolStripMenuItem.Click
+        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim fileName As String
 
         If FileList.SelectedRows.Count > 1 Then
@@ -565,10 +574,15 @@ Public Class ViewLogBackups
             UnhideFile(fileName)
         End If
 
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        If ChkShowHidden.Checked Then
+            ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
+        Else
+            ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        End If
     End Sub
 
     Private Sub HideToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles HideToolStripMenuItem.Click
+        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim fileName As String
 
         If FileList.SelectedRows.Count > 1 Then
@@ -581,7 +595,11 @@ Public Class ViewLogBackups
             HideFile(fileName)
         End If
 
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        If ChkShowHidden.Checked Then
+            ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
+        Else
+            ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        End If
     End Sub
 
     ''' <summary>Returns the NTFS compressed size of a file on disk. Returns a -1 if an error occurs.</summary>
@@ -834,6 +852,7 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub RenameToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles RenameToolStripMenuItem.Click
+        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim strOldFileName As String = FileList.SelectedRows(0).Cells(0).Value.ToString()
         Dim strOldFileNameFullPath As String = Path.Combine(strPathToDataBackupFolder, strOldFileName)
 
@@ -878,7 +897,7 @@ Public Class ViewLogBackups
 
         MsgBox("File renamed successfully.", MsgBoxStyle.Information, Text)
 
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
     End Sub
 
     Private Sub ChkShowNTFSCompressionSizeDifference_Click(sender As Object, e As EventArgs) Handles ChkShowNTFSCompressionSizeDifference.Click

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -344,6 +344,9 @@
             <setting name="ShowNTFSCompressionSizeDifferencePercentage" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="CompressBackupLogFiles" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -335,6 +335,9 @@
                 serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="IncludeCommasInDHMS" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -338,6 +338,12 @@
             <setting name="IncludeCommasInDHMS" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="ShowNTFSCompressionSizeDifference" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="ShowNTFSCompressionSizeDifferencePercentage" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Added an indication as to why the Change Port menu function doesn't work when it's the second instance running on the machine.
- Included a setting to change how DHMS strings are presented to the user, with commas or no commas.
- Added a way to make it so that you can only make some ignored rules trigger a recorded ignored log. Again, these recorded logs are only stored in program memory and not written to disk.
- Fixed a bug on the "Ignored Logs and Search Results" window in which attempting to export data to either an XML or JSON file would cause the program to crash.
- Added code to disable and enable the refreshing of stats when opening and closing the rules list context menu on the "Ignored Words and Phrases" window.
- Fixed a cosmetic bug on the "Ignored Words and Phrases" window in which adding a new rule would result in an incorrectly created item in the list of rules.
- Added sorting of data before exporting many of the rules used by this program to a JSON file.
- Added sorting by the boolEnabled flag when closing out the windows that change the rules used by this program.
- I now use "Buy Me A Coffee" instead of PayPal.
- Added a "Show in Windows Explorer" menu option to the "View Log Backups" window.
- Added a file rename function to the "View Log Backups" window.
- Added code to save the ignored rule stats to disk when you zero them out on the main window.
- Added the ability to compress and uncompress the backed up log files that the program creates using NTFS compression to the "View Log Backups" window.
- Centered the file size column on the "View Log Backups" window.
- Added the option to compress log file backups using NTFS file compression upon backup at midnight.
- Added an exception handler to the DoesTaskExist() function.
- Moved some checkboxes around on the "View Log Backups" window.
- Made the text of some checkboxes on the "View Log Backups" window plural.
- Added a way for the LoadFileList() function to re-select the file in the list after the list has been refreshed on the "View Log Backups" window.
- Added additional sanity checks to the ParseFontFromString() function to check if the incoming font size is either too big or too small.
- The ParseFontFromString() function now returns the value of Control.DefaultFont if parsing fails instead of creating my own Font object.
- Added a tooltip to a menu item on the "Ignored Words and Phrases" window.

And a whole lot of other under the hood changes to the code.