### PR TITLE
Version 5.0 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.0.1.113")>
+<Assembly: AssemblyFileVersion("5.0.2.114")>

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -32,6 +32,7 @@ Public Class SavedData
             .RawLogData = rawLogData
             .AlertText = alertText
             .alertType = alertType
+            .ServerDate = ServerDate
 
             If My.Settings.font IsNot Nothing Then
                 .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -90,6 +90,7 @@ Partial Class Form1
         Me.ClearNotificationLimits = New System.Windows.Forms.ToolStripMenuItem()
         Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.LogsHeaderMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.CopyRawLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.AboutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -782,9 +783,15 @@ Partial Class Form1
         Me.ChkEnableConfirmCloseToolStripItem.Size = New System.Drawing.Size(319, 22)
         Me.ChkEnableConfirmCloseToolStripItem.Text = "Enable Confirm Close"
         '
+        'LogsHeaderMenu
+        '
+        Me.LogsHeaderMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LogsMenuHideAlertsColumn, Me.LogsMenuHideHostnameColumn, Me.LogsMenuHideLogTypeColumn, Me.LogsMenuHideServerTimeColumn})
+        Me.LogsHeaderMenu.Name = "LogsHeaderMenu"
+        Me.LogsHeaderMenu.Size = New System.Drawing.Size(183, 180)
+        '
         'LogsMenu
         '
-        Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LogsMenuHideAlertsColumn, Me.LogsMenuHideHostnameColumn, Me.LogsMenuHideLogTypeColumn, Me.LogsMenuHideServerTimeColumn, Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
+        Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
         Me.LogsMenu.Name = "LogsMenu"
         Me.LogsMenu.Size = New System.Drawing.Size(183, 180)
         '
@@ -1038,6 +1045,7 @@ Partial Class Form1
         Me.MenuStrip.PerformLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).EndInit()
         Me.LogsMenu.ResumeLayout(False)
+        Me.LogsHeaderMenu.ResumeLayout(False)
         Me.IconMenu.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
@@ -1122,6 +1130,7 @@ Partial Class Form1
     Friend WithEvents NotifyIcon As NotifyIcon
     Friend WithEvents ChkEnableConfirmCloseToolStripItem As ToolStripMenuItem
     Friend WithEvents LogsMenu As ContextMenuStrip
+    Friend WithEvents LogsHeaderMenu As ContextMenuStrip
     Friend WithEvents CopyLogTextToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CopyRawLogTextToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OpenLogViewerToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -86,7 +86,6 @@ Partial Class Form1
         Me.ChangeFont = New System.Windows.Forms.ToolStripMenuItem()
         Me.ConfigureAlertsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ConfigureHostnames = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ColumnControls = New System.Windows.Forms.ToolStripMenuItem()
         Me.CompressBackupLogFilesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ClearNotificationLimits = New System.Windows.Forms.ToolStripMenuItem()
         Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
@@ -115,15 +114,11 @@ Partial Class Form1
         Me.OlderThan3DaysToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OlderThanAWeekToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpenWindowsExplorerToAppConfigFile = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChkShowAlertedColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.ProcessReplacementsInSyslogDataFirst = New System.Windows.Forms.ToolStripMenuItem()
         Me.RemoveNumbersFromRemoteApp = New System.Windows.Forms.ToolStripMenuItem()
         Me.ShowRawLogOnLogViewer = New System.Windows.Forms.ToolStripMenuItem()
         Me.ShowCloseButtonOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
         Me.SaveIgnoredLogCount = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChkShowLogTypeColumn = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChkShowServerTimeColumn = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChkShowHostnameColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DonationStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.StopServerStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -489,7 +484,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.CompressBackupLogFilesToolStripMenuItem, Me.ColumnControls, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.CompressBackupLogFilesToolStripMenuItem, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -499,13 +494,6 @@ Partial Class Form1
         Me.ClearNotificationLimits.Name = "ClearNotificationLimits"
         Me.ClearNotificationLimits.Size = New System.Drawing.Size(239, 22)
         Me.ClearNotificationLimits.Text = "Clear Notification Limits"
-        '
-        'ColumnControls
-        '
-        Me.ColumnControls.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ChkShowAlertedColumn, Me.ChkShowHostnameColumn, Me.ChkShowLogTypeColumn, Me.ChkShowServerTimeColumn})
-        Me.ColumnControls.Name = "ColumnControls"
-        Me.ColumnControls.Size = New System.Drawing.Size(319, 22)
-        Me.ColumnControls.Text = "Column Controls"
         '
         'CompressBackupLogFilesToolStripMenuItem
         '
@@ -896,34 +884,6 @@ Partial Class Form1
         Me.OpenWindowsExplorerToAppConfigFile.Size = New System.Drawing.Size(338, 22)
         Me.OpenWindowsExplorerToAppConfigFile.Text = "Open Windows Explorer to Application Config File"
         '
-        'ChkShowLogTypeColumn
-        '
-        Me.ChkShowLogTypeColumn.CheckOnClick = True
-        Me.ChkShowLogTypeColumn.Name = "ChkShowLogTypeColumn"
-        Me.ChkShowLogTypeColumn.Size = New System.Drawing.Size(214, 22)
-        Me.ChkShowLogTypeColumn.Text = "Show Log Type Column"
-        '
-        'ChkShowServerTimeColumn
-        '
-        Me.ChkShowServerTimeColumn.CheckOnClick = True
-        Me.ChkShowServerTimeColumn.Name = "ChkShowServerTimeColumn"
-        Me.ChkShowServerTimeColumn.Size = New System.Drawing.Size(214, 22)
-        Me.ChkShowServerTimeColumn.Text = "Show Server Time Column"
-        '
-        'ChkShowHostnameColumn
-        '
-        Me.ChkShowHostnameColumn.CheckOnClick = True
-        Me.ChkShowHostnameColumn.Name = "ChkShowHostnameColumn"
-        Me.ChkShowHostnameColumn.Size = New System.Drawing.Size(214, 22)
-        Me.ChkShowHostnameColumn.Text = "Show Hostname Column"
-        '
-        'ChkShowAlertedColumn
-        '
-        Me.ChkShowAlertedColumn.CheckOnClick = True
-        Me.ChkShowAlertedColumn.Name = "ChkShowAlertedColumn"
-        Me.ChkShowAlertedColumn.Size = New System.Drawing.Size(214, 22)
-        Me.ChkShowAlertedColumn.Text = "Show Alerted Column"
-        '
         'RemoveNumbersFromRemoteApp
         '
         Me.RemoveNumbersFromRemoteApp.CheckOnClick = True
@@ -1142,7 +1102,6 @@ Partial Class Form1
     Friend WithEvents ChangeFont As ToolStripMenuItem
     Friend WithEvents ConfigureAlertsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ConfigureHostnames As ToolStripMenuItem
-    Friend WithEvents ColumnControls As ToolStripMenuItem
     Friend WithEvents CompressBackupLogFilesToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ClearNotificationLimits As ToolStripMenuItem
     Friend WithEvents ColLogsAutoFill As ToolStripMenuItem
@@ -1185,15 +1144,11 @@ Partial Class Form1
     Friend WithEvents LblItemsSelected As ToolStripStatusLabel
     Friend WithEvents ChkDeselectItemAfterMinimizingWindow As ToolStripMenuItem
     Friend WithEvents ChkDebug As ToolStripMenuItem
-    Friend WithEvents ChkShowAlertedColumn As ToolStripMenuItem
     Friend WithEvents ProcessReplacementsInSyslogDataFirst As ToolStripMenuItem
     Friend WithEvents RemoveNumbersFromRemoteApp As ToolStripMenuItem
     Friend WithEvents ShowRawLogOnLogViewer As ToolStripMenuItem
     Friend WithEvents ShowCloseButtonOnNotifications As ToolStripMenuItem
     Friend WithEvents SaveIgnoredLogCount As ToolStripMenuItem
-    Friend WithEvents ChkShowLogTypeColumn As ToolStripMenuItem
-    Friend WithEvents ChkShowServerTimeColumn As ToolStripMenuItem
-    Friend WithEvents ChkShowHostnameColumn As ToolStripMenuItem
     Friend WithEvents ConfigureSysLogMirrorServers As ToolStripMenuItem
     Friend WithEvents ConfigureTimeBetweenSameNotifications As ToolStripMenuItem
     Friend WithEvents ConfirmDelete As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -97,6 +97,10 @@ Partial Class Form1
         Me.CloseMe = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripMenuSeparator = New System.Windows.Forms.ToolStripSeparator()
         Me.OpenLogViewerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.LogsMenuHideAlertsColumn = New System.Windows.Forms.ToolStripMenuItem()
+        Me.LogsMenuHideHostnameColumn = New System.Windows.Forms.ToolStripMenuItem()
+        Me.LogsMenuHideLogTypeColumn = New System.Windows.Forms.ToolStripMenuItem()
+        Me.LogsMenuHideServerTimeColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.DeleteLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DeleteSimilarLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ExportsLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -792,7 +796,7 @@ Partial Class Form1
         '
         'LogsMenu
         '
-        Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
+        Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LogsMenuHideAlertsColumn, Me.LogsMenuHideHostnameColumn, Me.LogsMenuHideLogTypeColumn, Me.LogsMenuHideServerTimeColumn, Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
         Me.LogsMenu.Name = "LogsMenu"
         Me.LogsMenu.Size = New System.Drawing.Size(183, 180)
         '
@@ -813,6 +817,30 @@ Partial Class Form1
         Me.OpenLogViewerToolStripMenuItem.Name = "OpenLogViewerToolStripMenuItem"
         Me.OpenLogViewerToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
         Me.OpenLogViewerToolStripMenuItem.Text = "Open Log Viewer"
+        '
+        'LogsMenuHideAlertsColumn
+        '
+        Me.LogsMenuHideAlertsColumn.Name = "LogsMenuHideAlertsColumn"
+        Me.LogsMenuHideAlertsColumn.Size = New System.Drawing.Size(182, 22)
+        Me.LogsMenuHideAlertsColumn.Text = "Hide 'Alerts' Column"
+        '
+        'LogsMenuHideHostnameColumn
+        '
+        Me.LogsMenuHideHostnameColumn.Name = "LogsMenuHideHostnameColumn"
+        Me.LogsMenuHideHostnameColumn.Size = New System.Drawing.Size(182, 22)
+        Me.LogsMenuHideHostnameColumn.Text = "Hide 'Hostname' Column"
+        '
+        'LogsMenuHideLogTypeColumn
+        '
+        Me.LogsMenuHideLogTypeColumn.Name = "LogsMenuHideLogTypeColumn"
+        Me.LogsMenuHideLogTypeColumn.Size = New System.Drawing.Size(182, 22)
+        Me.LogsMenuHideLogTypeColumn.Text = "Hide 'Log Type' Column"
+        '
+        'LogsMenuHideServerTimeColumn
+        '
+        Me.LogsMenuHideServerTimeColumn.Name = "LogsMenuHideServerTimeColumn"
+        Me.LogsMenuHideServerTimeColumn.Size = New System.Drawing.Size(182, 22)
+        Me.LogsMenuHideServerTimeColumn.Text = "Hide 'Server Time' Column"
         '
         'DeleteSimilarLogsToolStripMenuItem
         '
@@ -1138,6 +1166,10 @@ Partial Class Form1
     Friend WithEvents CopyLogTextToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CopyRawLogTextToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents OpenLogViewerToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents LogsMenuHideAlertsColumn As ToolStripMenuItem
+    Friend WithEvents LogsMenuHideHostnameColumn As ToolStripMenuItem
+    Friend WithEvents LogsMenuHideLogTypeColumn As ToolStripMenuItem
+    Friend WithEvents LogsMenuHideServerTimeColumn As ToolStripMenuItem
     Friend WithEvents DeleteLogsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents DeleteSimilarLogsToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ExportsLogsToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1398,44 +1398,118 @@ Public Class Form1
         My.Settings.boolConfirmClose = ChkEnableConfirmCloseToolStripItem.Checked
     End Sub
 
+    Private Sub LogsMenuHideAlertsColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideAlertsColumn.Click
+        ColAlerts.Visible = Not ColAlerts.Visible
+        My.Settings.boolShowAlertedColumn = ColAlerts.Visible
+        ChkShowAlertedColumn.Checked = ColAlerts.Visible
+    End Sub
+
+    Private Sub LogsMenuHideHostnameColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideHostnameColumn.Click
+        ColHostname.Visible = Not ColHostname.Visible
+        My.Settings.boolShowHostnameColumn = ColHostname.Visible
+        ChkShowHostnameColumn.Checked = ColHostname.Visible
+    End Sub
+
+    Private Sub LogsMenuHideLogTypeColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideLogTypeColumn.Click
+        colLogType.Visible = Not colLogType.Visible
+        My.Settings.boolShowLogTypeColumn = colLogType.Visible
+        ChkShowLogTypeColumn.Checked = colLogType.Visible
+    End Sub
+
+    Private Sub LogsMenuHideServerTimeColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideServerTimeColumn.Click
+        colServerTime.Visible = Not colServerTime.Visible
+        My.Settings.boolShowServerTimeColumn = colServerTime.Visible
+        ChkShowServerTimeColumn.Checked = colServerTime.Visible
+    End Sub
+
     Private Sub LogsMenu_Opening(sender As Object, e As CancelEventArgs) Handles LogsMenu.Opening
         Dim hitTest As DataGridView.HitTestInfo = Logs.HitTest(Logs.PointToClient(MousePosition).X, Logs.PointToClient(MousePosition).Y)
 
         If hitTest.Type = DataGridViewHitTestType.ColumnHeader Then
-            e.Cancel = True
-            Exit Sub
-        End If
-
-        If Logs.SelectedRows.Count = 0 Then
-            DeleteLogsToolStripMenuItem.Visible = False
-            ExportsLogsToolStripMenuItem.Visible = False
-            DeleteSimilarLogsToolStripMenuItem.Visible = False
-        Else
-            DeleteLogsToolStripMenuItem.Visible = True
-            ExportsLogsToolStripMenuItem.Visible = True
-            DeleteSimilarLogsToolStripMenuItem.Visible = True
-        End If
-
-        If Logs.SelectedRows.Count = 1 Then
-            CopyLogTextToolStripMenuItem.Visible = True
-            OpenLogViewerToolStripMenuItem.Visible = True
-            CreateAlertToolStripMenuItem.Visible = True
-            CreateReplacementToolStripMenuItem.Visible = True
-            CreateIgnoredLogToolStripMenuItem.Visible = True
-            DeleteSimilarLogsToolStripMenuItem.Visible = True
-
-            Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
-            If selectedItem IsNot Nothing Then CopyRawLogTextToolStripMenuItem.Visible = Not String.IsNullOrEmpty(selectedItem.RawLogData)
-        Else
-            OpenLogViewerToolStripMenuItem.Visible = False
+            CopyLogTextToolStripMenuItem.Visible = False
+            CopyRawLogTextToolStripMenuItem.Visible = False
             CreateAlertToolStripMenuItem.Visible = False
-            CreateReplacementToolStripMenuItem.Visible = False
             CreateIgnoredLogToolStripMenuItem.Visible = False
+            CreateReplacementToolStripMenuItem.Visible = False
+            DeleteLogsToolStripMenuItem.Visible = False
             DeleteSimilarLogsToolStripMenuItem.Visible = False
-        End If
+            ExportsLogsToolStripMenuItem.Visible = False
+            OpenLogViewerToolStripMenuItem.Visible = False
+            LogsMenuHideAlertsColumn.Visible = True
+            LogsMenuHideHostnameColumn.Visible = True
+            LogsMenuHideLogTypeColumn.Visible = True
+            LogsMenuHideServerTimeColumn.Visible = True
 
-        DeleteLogsToolStripMenuItem.Text = If(Logs.SelectedRows.Count = 1, "Delete Selected Log", "Delete Selected Logs")
-        ExportsLogsToolStripMenuItem.Text = If(Logs.SelectedRows.Count = 1, "Export Selected Log", "Export Selected Logs")
+            If ColAlerts.Visible Then
+                LogsMenuHideAlertsColumn.Text = "Hide 'Alerts' Column"
+            Else
+                LogsMenuHideAlertsColumn.Text = "Show 'Alerts' Column"
+            End If
+
+            If ColHostname.Visible Then
+                LogsMenuHideHostnameColumn.Text = "Hide 'Hostname' Column"
+            Else
+                LogsMenuHideHostnameColumn.Text = "Show 'Hostname' Column"
+            End If
+
+            If colLogType.Visible Then
+                LogsMenuHideLogTypeColumn.Text = "Hide 'Log Type' Column"
+            Else
+                LogsMenuHideLogTypeColumn.Text = "Show 'Log Type' Column"
+            End If
+
+            If colServerTime.Visible Then
+                LogsMenuHideServerTimeColumn.Text = "Hide 'Server Time' Column"
+            Else
+                LogsMenuHideServerTimeColumn.Text = "Show 'Server Time' Column"
+            End If
+        Else
+            ' Reset all to visible
+            CopyLogTextToolStripMenuItem.Visible = True
+            CopyRawLogTextToolStripMenuItem.Visible = True
+            CreateAlertToolStripMenuItem.Visible = True
+            CreateIgnoredLogToolStripMenuItem.Visible = True
+            CreateReplacementToolStripMenuItem.Visible = True
+            DeleteLogsToolStripMenuItem.Visible = True
+            DeleteSimilarLogsToolStripMenuItem.Visible = True
+            ExportsLogsToolStripMenuItem.Visible = True
+            OpenLogViewerToolStripMenuItem.Visible = True
+            LogsMenuHideAlertsColumn.Visible = False
+            LogsMenuHideHostnameColumn.Visible = False
+            LogsMenuHideLogTypeColumn.Visible = False
+            LogsMenuHideServerTimeColumn.Visible = False
+
+            If Logs.SelectedRows.Count = 0 Then
+                DeleteLogsToolStripMenuItem.Visible = False
+                ExportsLogsToolStripMenuItem.Visible = False
+                DeleteSimilarLogsToolStripMenuItem.Visible = False
+            Else
+                DeleteLogsToolStripMenuItem.Visible = True
+                ExportsLogsToolStripMenuItem.Visible = True
+                DeleteSimilarLogsToolStripMenuItem.Visible = True
+            End If
+
+            If Logs.SelectedRows.Count = 1 Then
+                CopyLogTextToolStripMenuItem.Visible = True
+                OpenLogViewerToolStripMenuItem.Visible = True
+                CreateAlertToolStripMenuItem.Visible = True
+                CreateReplacementToolStripMenuItem.Visible = True
+                CreateIgnoredLogToolStripMenuItem.Visible = True
+                DeleteSimilarLogsToolStripMenuItem.Visible = True
+
+                Dim selectedItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
+                If selectedItem IsNot Nothing Then CopyRawLogTextToolStripMenuItem.Visible = Not String.IsNullOrEmpty(selectedItem.RawLogData)
+            Else
+                OpenLogViewerToolStripMenuItem.Visible = False
+                CreateAlertToolStripMenuItem.Visible = False
+                CreateReplacementToolStripMenuItem.Visible = False
+                CreateIgnoredLogToolStripMenuItem.Visible = False
+                DeleteSimilarLogsToolStripMenuItem.Visible = False
+            End If
+
+            DeleteLogsToolStripMenuItem.Text = If(Logs.SelectedRows.Count = 1, "Delete Selected Log", "Delete Selected Logs")
+            ExportsLogsToolStripMenuItem.Text = If(Logs.SelectedRows.Count = 1, "Export Selected Log", "Export Selected Logs")
+        End If
     End Sub
 
     Private Sub CopyLogTextToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopyLogTextToolStripMenuItem.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -2168,6 +2168,13 @@ Public Class Form1
         My.Settings.CompressBackupLogFiles = CompressBackupLogFilesToolStripMenuItem.Checked
     End Sub
 
+    Private Sub LogsHeaderMenu_Opening(sender As Object, e As CancelEventArgs) Handles LogsHeaderMenu.Opening
+        LogsMenuHideAlertsColumn.Text = $"{If(ColAlerts.Visible, "Hide", "Show")} Alerts Column"
+        LogsMenuHideHostnameColumn.Text = $"{If(ColHostname.Visible, "Hide", "Show")} Hostname Column"
+        LogsMenuHideLogTypeColumn.Text = $"{If(colLogType.Visible, "Hide", "Show")} Log Type Column"
+        LogsMenuHideServerTimeColumn.Text = $"{If(colServerTime.Visible, "Hide", "Show")} Server Time Column"
+    End Sub
+
 #Region "-- SysLog Server Code --"
     Sub SysLogThread()
         Try

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1555,7 +1555,7 @@ Public Class Form1
     End Sub
 
     Private Sub StopServerStripMenuItem_Click(sender As Object, e As EventArgs) Handles StopServerStripMenuItem.Click
-        If StopServerStripMenuItem.Text = "Stop Server" Then
+        If StopServerStripMenuItem.Text = "Stop Server" AndAlso MsgBox("Are you sure you want to stop the server thread?", MsgBoxStyle.Question + MsgBoxStyle.YesNo, Text) = MsgBoxResult.Yes Then
             SendMessageToSysLogServer(strTerminate, My.Settings.sysLogPort)
             If My.Settings.EnableTCPServer Then SendMessageToTCPSysLogServer(strTerminate, My.Settings.sysLogPort)
             StopServerStripMenuItem.Text = "Start Server"

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -307,7 +307,6 @@ Public Class Form1
         ChkEnableConfirmCloseToolStripItem.Checked = My.Settings.boolConfirmClose
         LblAutoSaved.Visible = ChkEnableAutoSave.Checked
         ColAlerts.Visible = My.Settings.boolShowAlertedColumn
-        ChkShowAlertedColumn.Checked = My.Settings.boolShowAlertedColumn
         MinimizeToClockTray.Checked = My.Settings.MinimizeToClockTray
         StopServerStripMenuItem.Visible = boolDoWeOwnTheMutex
         ChkEnableStartAtUserStartup.Checked = TaskHandling.DoesTaskExist()
@@ -317,11 +316,8 @@ Public Class Form1
         ViewLogBackups.Visible = BackupOldLogsAfterClearingAtMidnight.Checked
         ChkEnableTCPSyslogServer.Checked = My.Settings.EnableTCPServer
         ColHostname.Visible = My.Settings.boolShowHostnameColumn
-        ChkShowHostnameColumn.Checked = My.Settings.boolShowHostnameColumn
         colServerTime.Visible = My.Settings.boolShowServerTimeColumn
-        ChkShowServerTimeColumn.Checked = My.Settings.boolShowServerTimeColumn
         colLogType.Visible = My.Settings.boolShowLogTypeColumn
-        ChkShowLogTypeColumn.Checked = My.Settings.boolShowLogTypeColumn
         RemoveNumbersFromRemoteApp.Checked = My.Settings.RemoveNumbersFromRemoteApp
         IPv6Support.Checked = My.Settings.IPv6Support
         ChkDisableAutoScrollUponScrolling.Checked = My.Settings.disableAutoScrollUponScrolling
@@ -1401,25 +1397,21 @@ Public Class Form1
     Private Sub LogsMenuHideAlertsColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideAlertsColumn.Click
         ColAlerts.Visible = Not ColAlerts.Visible
         My.Settings.boolShowAlertedColumn = ColAlerts.Visible
-        ChkShowAlertedColumn.Checked = ColAlerts.Visible
     End Sub
 
     Private Sub LogsMenuHideHostnameColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideHostnameColumn.Click
         ColHostname.Visible = Not ColHostname.Visible
         My.Settings.boolShowHostnameColumn = ColHostname.Visible
-        ChkShowHostnameColumn.Checked = ColHostname.Visible
     End Sub
 
     Private Sub LogsMenuHideLogTypeColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideLogTypeColumn.Click
         colLogType.Visible = Not colLogType.Visible
         My.Settings.boolShowLogTypeColumn = colLogType.Visible
-        ChkShowLogTypeColumn.Checked = colLogType.Visible
     End Sub
 
     Private Sub LogsMenuHideServerTimeColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideServerTimeColumn.Click
         colServerTime.Visible = Not colServerTime.Visible
         My.Settings.boolShowServerTimeColumn = colServerTime.Visible
-        ChkShowServerTimeColumn.Checked = colServerTime.Visible
     End Sub
 
     Private Sub LogsMenu_Opening(sender As Object, e As CancelEventArgs) Handles LogsMenu.Opening
@@ -1758,11 +1750,6 @@ Public Class Form1
         ShowSingleInstanceWindow(Of ConfigureSysLogMirrorClients)(ConfigureSysLogMirrorClientsInstance, Icon)
     End Sub
 
-    Private Sub ChkShowAlertedColumn_Click(sender As Object, e As EventArgs) Handles ChkShowAlertedColumn.Click
-        My.Settings.boolShowAlertedColumn = ChkShowAlertedColumn.Checked
-        ColAlerts.Visible = ChkShowAlertedColumn.Checked
-    End Sub
-
     Private Sub MinimizeToClockTray_Click(sender As Object, e As EventArgs) Handles MinimizeToClockTray.Click
         My.Settings.MinimizeToClockTray = MinimizeToClockTray.Checked
     End Sub
@@ -1892,21 +1879,6 @@ Public Class Form1
         Else
             SendMessageToTCPSysLogServer(strTerminate, My.Settings.sysLogPort)
         End If
-    End Sub
-
-    Private Sub ChkShowHostnameColumn_Click(sender As Object, e As EventArgs) Handles ChkShowHostnameColumn.Click
-        My.Settings.boolShowHostnameColumn = ChkShowHostnameColumn.Checked
-        ColHostname.Visible = My.Settings.boolShowHostnameColumn
-    End Sub
-
-    Private Sub ChkShowLogTypeColumn_Click(sender As Object, e As EventArgs) Handles ChkShowLogTypeColumn.Click
-        My.Settings.boolShowLogTypeColumn = ChkShowLogTypeColumn.Checked
-        colLogType.Visible = My.Settings.boolShowLogTypeColumn
-    End Sub
-
-    Private Sub ChkShowServerTimeColumn_Click(sender As Object, e As EventArgs) Handles ChkShowServerTimeColumn.Click
-        My.Settings.boolShowServerTimeColumn = ChkShowServerTimeColumn.Checked
-        colServerTime.Visible = My.Settings.boolShowServerTimeColumn
     End Sub
 
     Private Sub RemoveNumbersFromRemoteApp_Click(sender As Object, e As EventArgs) Handles RemoveNumbersFromRemoteApp.Click


### PR DESCRIPTION
- Put in code to ask the user if they really want to stop the server thread.
- Added column hide/show commands to the menu when you right-click on the column headers of the logs list.
- Fixed a long standing bug in which the server date wasn't being loaded back into program memory from the log data on disk.
- Moved some code around.