### PR TITLE
Version 5.2 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.1.2.116")>
+<Assembly: AssemblyFileVersion("5.2.1.117")>

--- a/Free SysLog/Support Code/Namespace Code/Data Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Data Handling.vb
@@ -67,7 +67,7 @@ Namespace DataHandling
                     End If
 
                     If My.Settings.AskOpenExplorer Then
-                        Using OpenExplorer As New OpenExplorer()
+                        Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                             OpenExplorer.StartPosition = FormStartPosition.CenterParent
                             OpenExplorer.MyParentForm = ParentForm
 
@@ -149,7 +149,7 @@ Namespace DataHandling
                     End If
 
                     If My.Settings.AskOpenExplorer Then
-                        Using OpenExplorer As New OpenExplorer()
+                        Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                             OpenExplorer.StartPosition = FormStartPosition.CenterParent
                             OpenExplorer.MyParentForm = ParentForm
 

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -135,6 +135,10 @@ Namespace SupportCode
             End If
         End Function
 
+        Public Function SearchListView(strRuleBase As String, listViewCollection As ListView.ListViewItemCollection) As Boolean
+            Return listViewCollection.Cast(Of ListViewItem).Any(Function(item As ListViewItem) item.SubItems(0).Text.Equals(strRuleBase, StringComparison.OrdinalIgnoreCase))
+        End Function
+
         Public Sub CompressFile(fileName As String)
             If File.Exists(fileName) Then
                 Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -652,12 +652,12 @@ Namespace SyslogParser
                         End If
                     End If
 
-                    If strAlertText.CaseInsensitiveContains("UPPER(") OrElse strAlertText.CaseInsensitiveContains("UPPERCASE(") OrElse strAlertText.CaseInsensitiveContains("LOWER(") OrElse strAlertText.CaseInsensitiveContains("LOWERCASE(") Then
-                        strAlertText = ExpandCaseFunctions(strAlertText)
-                    End If
-
                     If strAlertText.CaseInsensitiveContains("NSLOOKUP(") Then
                         strAlertText = regExNsLookup.Replace(strAlertText, Function(mm As Match) IpToHostname(mm.Groups(1).Value))
+                    End If
+
+                    If strAlertText.CaseInsensitiveContains("UPPER(") OrElse strAlertText.CaseInsensitiveContains("UPPERCASE(") OrElse strAlertText.CaseInsensitiveContains("LOWER(") OrElse strAlertText.CaseInsensitiveContains("LOWERCASE(") Then
+                        strAlertText = ExpandCaseFunctions(strAlertText)
                     End If
 
                     If alert.BoolLimited Then

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -149,7 +149,7 @@ Namespace SyslogParser
 
                 Return (facilityDescription, severityDescription)
             Else
-                Return Nothing
+                Return (Nothing, Nothing)
             End If
         End Function
 
@@ -277,7 +277,7 @@ Namespace SyslogParser
                 If Not String.IsNullOrWhiteSpace(strRawLogText) AndAlso Not String.IsNullOrWhiteSpace(strSourceIP) Then
                     Dim boolIgnored As Boolean = False
                     Dim boolAlerted As Boolean = False
-                    Dim priorityObject As (Facility As String, Severity As String) = Nothing
+                    Dim priorityObject As (Facility As String, Severity As String) = (Nothing, Nothing)
                     Dim priority As String = Nothing
                     Dim message As String = Nothing
                     Dim timestamp As String = Nothing

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -625,7 +625,7 @@ Namespace SyslogParser
 
                     strAlertText = If(String.IsNullOrWhiteSpace(alert.StrAlertText), strLogText, alert.StrAlertText)
 
-                    If alert.BoolRegex And Not String.IsNullOrWhiteSpace(alert.StrAlertText) Then
+                    If alert.BoolRegex And Not String.IsNullOrWhiteSpace(alert.StrAlertText) AndAlso RegExObject.IsMatch(strLogText) Then
                         regExGroupCollection = RegExObject.Match(strLogText).Groups
 
                         If regExGroupCollection.Count > 0 Then

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -652,6 +652,10 @@ Namespace SyslogParser
                         End If
                     End If
 
+                    If strAlertText.CaseInsensitiveContains("UPPER(") OrElse strAlertText.CaseInsensitiveContains("UPPERCASE(") OrElse strAlertText.CaseInsensitiveContains("LOWER(") OrElse strAlertText.CaseInsensitiveContains("LOWERCASE(") Then
+                        strAlertText = ExpandCaseFunctions(strAlertText)
+                    End If
+
                     If strAlertText.CaseInsensitiveContains("NSLOOKUP(") Then
                         strAlertText = regExNsLookup.Replace(strAlertText, Function(mm As Match) IpToHostname(mm.Groups(1).Value))
                     End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -11,12 +11,12 @@ Namespace SyslogParser
         Private ReadOnly rfc5424Regex As New Regex("<(?<priority>[0-9]+)>(?:\d ){0,1}(?<timestamp>[0-9]{4}[-.](?:1[0-2]|0[1-9])[-.](?:3[01]|[12][0-9]|0[1-9])T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]\.[0-9]+Z)(?: -){0,1} (?<hostname>(?:\\.|[^\n\r ])+) (?:\d+ ){0,1}(?<appname>(?:\\.|[^\n\r:]+?)(?: \d*){0,1}):{0,1} (?:- - %% ){0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
         Private ReadOnly rfc5424TransformRegex As New Regex("<{0,1}(?<priority>[0-9]{0,})>{0,1}(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} \[{0,1}(?<appname>(?:\\.|[^\n\r:]+))\]{0,1}:{0,1} {0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
 
-        Private ReadOnly regExTrim As New Regex("TRIM\(((?:[^()]+|\([^()]*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
-        Private ReadOnly regExUpper As New Regex("UPPER\(((?:[^()]+|\([^()]*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
-        Private ReadOnly regExUppercase As New Regex("UPPERCASE\(((?:[^()]+|\([^()]*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
-        Private ReadOnly regExLower As New Regex("LOWER\(((?:[^()]+|\([^()]*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
-        Private ReadOnly regExLowercase As New Regex("LOWERCASE\(((?:[^()]+|\([^()]*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
-        Private ReadOnly regExNsLookup As New Regex("NSLOOKUP\(((?:[^()]+|\([^()]*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+        Private ReadOnly regExTrim As New Regex("TRIM\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+        Private ReadOnly regExUpper As New Regex("UPPER\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+        Private ReadOnly regExUppercase As New Regex("UPPERCASE\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+        Private ReadOnly regExLower As New Regex("LOWER\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+        Private ReadOnly regExLowercase As New Regex("LOWERCASE\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+        Private ReadOnly regExNsLookup As New Regex("NSLOOKUP\(((?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
 
         Private ReadOnly NumberRemovingRegex As New Regex("([A-Za-z-]*)\[[0-9]*\]", RegexOptions.Compiled)
         Private ReadOnly SyslogPreProcessor1 As New Regex("\d+ (<\d+>)", RegexOptions.Compiled)

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -236,7 +236,7 @@ Partial Class Alerts
         Me.lblRegExBackReferences.AutoSize = True
         Me.lblRegExBackReferences.Location = New System.Drawing.Point(196, 349)
         Me.lblRegExBackReferences.Name = "lblRegExBackReferences"
-        Me.lblRegExBackReferences.Size = New System.Drawing.Size(595, 39)
+        Me.lblRegExBackReferences.Size = New System.Drawing.Size(757, 39)
         Me.lblRegExBackReferences.TabIndex = 37
         Me.lblRegExBackReferences.Text = resources.GetString("lblRegExBackReferences.Text")
         '

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -67,7 +67,7 @@ Partial Class Alerts
         '
         Me.BtnEdit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnEdit.Enabled = False
-        Me.BtnEdit.Location = New System.Drawing.Point(83, 248)
+        Me.BtnEdit.Location = New System.Drawing.Point(83, 237)
         Me.BtnEdit.Name = "BtnEdit"
         Me.BtnEdit.Size = New System.Drawing.Size(75, 23)
         Me.BtnEdit.TabIndex = 12
@@ -87,7 +87,7 @@ Partial Class Alerts
         Me.AlertsListView.HideSelection = False
         Me.AlertsListView.Location = New System.Drawing.Point(12, 12)
         Me.AlertsListView.Name = "AlertsListView"
-        Me.AlertsListView.Size = New System.Drawing.Size(933, 230)
+        Me.AlertsListView.Size = New System.Drawing.Size(933, 219)
         Me.AlertsListView.TabIndex = 11
         Me.AlertsListView.UseCompatibleStateImageBehavior = False
         Me.AlertsListView.View = System.Windows.Forms.View.Details
@@ -142,7 +142,7 @@ Partial Class Alerts
         '
         Me.BtnDelete.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnDelete.Enabled = False
-        Me.BtnDelete.Location = New System.Drawing.Point(12, 248)
+        Me.BtnDelete.Location = New System.Drawing.Point(12, 237)
         Me.BtnDelete.Name = "BtnDelete"
         Me.BtnDelete.Size = New System.Drawing.Size(65, 23)
         Me.BtnDelete.TabIndex = 10
@@ -152,7 +152,7 @@ Partial Class Alerts
         'BtnAdd
         '
         Me.BtnAdd.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnAdd.Location = New System.Drawing.Point(12, 424)
+        Me.BtnAdd.Location = New System.Drawing.Point(12, 423)
         Me.BtnAdd.Name = "BtnAdd"
         Me.BtnAdd.Size = New System.Drawing.Size(65, 23)
         Me.BtnAdd.TabIndex = 9
@@ -163,7 +163,7 @@ Partial Class Alerts
         '
         Me.BtnEnableDisable.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnEnableDisable.Enabled = False
-        Me.BtnEnableDisable.Location = New System.Drawing.Point(164, 248)
+        Me.BtnEnableDisable.Location = New System.Drawing.Point(164, 237)
         Me.BtnEnableDisable.Name = "BtnEnableDisable"
         Me.BtnEnableDisable.Size = New System.Drawing.Size(75, 23)
         Me.BtnEnableDisable.TabIndex = 13
@@ -173,7 +173,7 @@ Partial Class Alerts
         'BtnExport
         '
         Me.BtnExport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnExport.Location = New System.Drawing.Point(819, 248)
+        Me.BtnExport.Location = New System.Drawing.Point(819, 237)
         Me.BtnExport.Name = "BtnExport"
         Me.BtnExport.Size = New System.Drawing.Size(75, 23)
         Me.BtnExport.TabIndex = 15
@@ -183,7 +183,7 @@ Partial Class Alerts
         'BtnImport
         '
         Me.BtnImport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnImport.Location = New System.Drawing.Point(900, 248)
+        Me.BtnImport.Location = New System.Drawing.Point(900, 237)
         Me.BtnImport.Name = "BtnImport"
         Me.BtnImport.Size = New System.Drawing.Size(75, 23)
         Me.BtnImport.TabIndex = 14
@@ -193,7 +193,7 @@ Partial Class Alerts
         'BtnDeleteAll
         '
         Me.BtnDeleteAll.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnDeleteAll.Location = New System.Drawing.Point(245, 248)
+        Me.BtnDeleteAll.Location = New System.Drawing.Point(245, 237)
         Me.BtnDeleteAll.Name = "BtnDeleteAll"
         Me.BtnDeleteAll.Size = New System.Drawing.Size(75, 23)
         Me.BtnDeleteAll.TabIndex = 16
@@ -203,7 +203,7 @@ Partial Class Alerts
         'BtnDown
         '
         Me.BtnDown.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnDown.Location = New System.Drawing.Point(951, 219)
+        Me.BtnDown.Location = New System.Drawing.Point(951, 208)
         Me.BtnDown.Name = "BtnDown"
         Me.BtnDown.Size = New System.Drawing.Size(24, 23)
         Me.BtnDown.TabIndex = 21
@@ -225,7 +225,7 @@ Partial Class Alerts
         Me.SeparatingLine.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.SeparatingLine.BackColor = System.Drawing.Color.Black
-        Me.SeparatingLine.Location = New System.Drawing.Point(-1, 280)
+        Me.SeparatingLine.Location = New System.Drawing.Point(-1, 269)
         Me.SeparatingLine.Name = "SeparatingLine"
         Me.SeparatingLine.Size = New System.Drawing.Size(1000, 1)
         Me.SeparatingLine.TabIndex = 25
@@ -234,9 +234,9 @@ Partial Class Alerts
         '
         Me.lblRegExBackReferences.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblRegExBackReferences.AutoSize = True
-        Me.lblRegExBackReferences.Location = New System.Drawing.Point(196, 360)
+        Me.lblRegExBackReferences.Location = New System.Drawing.Point(196, 349)
         Me.lblRegExBackReferences.Name = "lblRegExBackReferences"
-        Me.lblRegExBackReferences.Size = New System.Drawing.Size(595, 26)
+        Me.lblRegExBackReferences.Size = New System.Drawing.Size(595, 39)
         Me.lblRegExBackReferences.TabIndex = 37
         Me.lblRegExBackReferences.Text = resources.GetString("lblRegExBackReferences.Text")
         '
@@ -246,7 +246,7 @@ Partial Class Alerts
         Me.ChkEnabled.AutoSize = True
         Me.ChkEnabled.Checked = True
         Me.ChkEnabled.CheckState = System.Windows.Forms.CheckState.Checked
-        Me.ChkEnabled.Location = New System.Drawing.Point(678, 401)
+        Me.ChkEnabled.Location = New System.Drawing.Point(678, 400)
         Me.ChkEnabled.Name = "ChkEnabled"
         Me.ChkEnabled.Size = New System.Drawing.Size(71, 17)
         Me.ChkEnabled.TabIndex = 36
@@ -256,7 +256,7 @@ Partial Class Alerts
         'IconPictureBox
         '
         Me.IconPictureBox.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.IconPictureBox.Location = New System.Drawing.Point(158, 363)
+        Me.IconPictureBox.Location = New System.Drawing.Point(158, 352)
         Me.IconPictureBox.Name = "IconPictureBox"
         Me.IconPictureBox.Size = New System.Drawing.Size(32, 32)
         Me.IconPictureBox.TabIndex = 35
@@ -267,7 +267,7 @@ Partial Class Alerts
         Me.AlertTypeComboBox.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.AlertTypeComboBox.FormattingEnabled = True
         Me.AlertTypeComboBox.Items.AddRange(New Object() {"Warning", "Error", "Information", "None"})
-        Me.AlertTypeComboBox.Location = New System.Drawing.Point(73, 363)
+        Me.AlertTypeComboBox.Location = New System.Drawing.Point(73, 352)
         Me.AlertTypeComboBox.Name = "AlertTypeComboBox"
         Me.AlertTypeComboBox.Size = New System.Drawing.Size(79, 21)
         Me.AlertTypeComboBox.TabIndex = 34
@@ -276,7 +276,7 @@ Partial Class Alerts
         '
         Me.Label3.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label3.AutoSize = True
-        Me.Label3.Location = New System.Drawing.Point(12, 366)
+        Me.Label3.Location = New System.Drawing.Point(12, 355)
         Me.Label3.Name = "Label3"
         Me.Label3.Size = New System.Drawing.Size(55, 13)
         Me.Label3.TabIndex = 33
@@ -286,7 +286,7 @@ Partial Class Alerts
         '
         Me.Label2.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label2.AutoSize = True
-        Me.Label2.Location = New System.Drawing.Point(12, 340)
+        Me.Label2.Location = New System.Drawing.Point(12, 329)
         Me.Label2.Name = "Label2"
         Me.Label2.Size = New System.Drawing.Size(52, 13)
         Me.Label2.TabIndex = 32
@@ -296,7 +296,7 @@ Partial Class Alerts
         '
         Me.TxtAlertText.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TxtAlertText.Location = New System.Drawing.Point(67, 337)
+        Me.TxtAlertText.Location = New System.Drawing.Point(67, 326)
         Me.TxtAlertText.Name = "TxtAlertText"
         Me.TxtAlertText.Size = New System.Drawing.Size(908, 20)
         Me.TxtAlertText.TabIndex = 31
@@ -305,7 +305,7 @@ Partial Class Alerts
         '
         Me.ChkCaseSensitive.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkCaseSensitive.AutoSize = True
-        Me.ChkCaseSensitive.Location = New System.Drawing.Point(499, 401)
+        Me.ChkCaseSensitive.Location = New System.Drawing.Point(499, 400)
         Me.ChkCaseSensitive.Name = "ChkCaseSensitive"
         Me.ChkCaseSensitive.Size = New System.Drawing.Size(102, 17)
         Me.ChkCaseSensitive.TabIndex = 30
@@ -316,7 +316,7 @@ Partial Class Alerts
         '
         Me.ChkRegex.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkRegex.AutoSize = True
-        Me.ChkRegex.Location = New System.Drawing.Point(15, 401)
+        Me.ChkRegex.Location = New System.Drawing.Point(15, 400)
         Me.ChkRegex.Name = "ChkRegex"
         Me.ChkRegex.Size = New System.Drawing.Size(478, 17)
         Me.ChkRegex.TabIndex = 29
@@ -328,7 +328,7 @@ Partial Class Alerts
         '
         Me.TxtLogText.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TxtLogText.Location = New System.Drawing.Point(67, 311)
+        Me.TxtLogText.Location = New System.Drawing.Point(67, 300)
         Me.TxtLogText.Name = "TxtLogText"
         Me.TxtLogText.Size = New System.Drawing.Size(908, 20)
         Me.TxtLogText.TabIndex = 28
@@ -337,7 +337,7 @@ Partial Class Alerts
         '
         Me.Label1.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label1.AutoSize = True
-        Me.Label1.Location = New System.Drawing.Point(12, 314)
+        Me.Label1.Location = New System.Drawing.Point(12, 303)
         Me.Label1.Name = "Label1"
         Me.Label1.Size = New System.Drawing.Size(49, 13)
         Me.Label1.TabIndex = 27
@@ -348,7 +348,7 @@ Partial Class Alerts
         '
         Me.Label4.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label4.AutoSize = True
-        Me.Label4.Location = New System.Drawing.Point(12, 291)
+        Me.Label4.Location = New System.Drawing.Point(12, 280)
         Me.Label4.Name = "Label4"
         Me.Label4.Size = New System.Drawing.Size(435, 13)
         Me.Label4.TabIndex = 38
@@ -358,7 +358,7 @@ Partial Class Alerts
         'BtnCancel
         '
         Me.BtnCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnCancel.Location = New System.Drawing.Point(83, 424)
+        Me.BtnCancel.Location = New System.Drawing.Point(83, 423)
         Me.BtnCancel.Name = "BtnCancel"
         Me.BtnCancel.Size = New System.Drawing.Size(75, 23)
         Me.BtnCancel.TabIndex = 39
@@ -369,7 +369,7 @@ Partial Class Alerts
         '
         Me.ChkLimited.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkLimited.AutoSize = True
-        Me.ChkLimited.Location = New System.Drawing.Point(607, 401)
+        Me.ChkLimited.Location = New System.Drawing.Point(607, 400)
         Me.ChkLimited.Name = "ChkLimited"
         Me.ChkLimited.Size = New System.Drawing.Size(65, 17)
         Me.ChkLimited.TabIndex = 40

--- a/Free SysLog/Windows/Alerts.resx
+++ b/Free SysLog/Windows/Alerts.resx
@@ -122,7 +122,8 @@
   </metadata>
   <data name="lblRegExBackReferences.Text" xml:space="preserve">
     <value>You can use RegEx back-references in your alert text. For numerical back-references, simply use put a $ before the number.
-For named back-references, put a $ and then put the name of the back-reference inside parentheses. For example... $(name)</value>
+For named back-references, put a $ and then put the name of the back-reference inside parentheses. For example... $(name)
+You can also use NSLOOKUP() to translate IP addresses to hostnames.</value>
   </data>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>145, 17</value>

--- a/Free SysLog/Windows/Alerts.resx
+++ b/Free SysLog/Windows/Alerts.resx
@@ -123,7 +123,7 @@
   <data name="lblRegExBackReferences.Text" xml:space="preserve">
     <value>You can use RegEx back-references in your alert text. For numerical back-references, simply use put a $ before the number.
 For named back-references, put a $ and then put the name of the back-reference inside parentheses. For example... $(name)
-You can also use NSLOOKUP() to translate IP addresses to hostnames.</value>
+You can use NSLOOKUP() to translate IP addresses to hostnames. UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM() are also able to be used.</value>
   </data>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>145, 17</value>

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -232,41 +232,45 @@ Public Class Alerts
                 BtnAdd.Text = "Add"
                 Label4.Text = "Add Alert"
             Else
-                Dim AlertsListViewItem As New AlertsListViewItem(TxtLogText.Text) With {.StrLogText = TxtLogText.Text, .StrAlertText = TxtAlertText.Text}
+                If SearchListView(TxtLogText.Text, AlertsListView.Items) Then
+                    MsgBox("An alert with the same log text already exists.", MsgBoxStyle.Critical, Text)
+                Else
+                    Dim AlertsListViewItem As New AlertsListViewItem(TxtLogText.Text) With {.StrLogText = TxtLogText.Text, .StrAlertText = TxtAlertText.Text}
 
-                With AlertsListViewItem
-                    .SubItems.Add(If(String.IsNullOrWhiteSpace(TxtAlertText.Text), "(Shows Log Text)", TxtAlertText.Text))
-                    .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
-                    .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
+                    With AlertsListViewItem
+                        .SubItems.Add(If(String.IsNullOrWhiteSpace(TxtAlertText.Text), "(Shows Log Text)", TxtAlertText.Text))
+                        .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
+                        .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
 
-                    Dim AlertType As AlertType
+                        Dim AlertType As AlertType
 
-                    If AlertTypeComboBox.SelectedIndex = 0 Then
-                        AlertType = AlertType.Warning
-                        .SubItems.Add("Warning")
-                    ElseIf AlertTypeComboBox.SelectedIndex = 1 Then
-                        AlertType = AlertType.ErrorMsg
-                        .SubItems.Add("Error")
-                    ElseIf AlertTypeComboBox.SelectedIndex = 2 Then
-                        AlertType = AlertType.Info
-                        .SubItems.Add("Information")
-                    ElseIf AlertTypeComboBox.SelectedIndex = 3 Then
-                        AlertType = AlertType.None
-                        .SubItems.Add("None")
-                    End If
+                        If AlertTypeComboBox.SelectedIndex = 0 Then
+                            AlertType = AlertType.Warning
+                            .SubItems.Add("Warning")
+                        ElseIf AlertTypeComboBox.SelectedIndex = 1 Then
+                            AlertType = AlertType.ErrorMsg
+                            .SubItems.Add("Error")
+                        ElseIf AlertTypeComboBox.SelectedIndex = 2 Then
+                            AlertType = AlertType.Info
+                            .SubItems.Add("Information")
+                        ElseIf AlertTypeComboBox.SelectedIndex = 3 Then
+                            AlertType = AlertType.None
+                            .SubItems.Add("None")
+                        End If
 
-                    .SubItems.Add(If(ChkLimited.Checked, "Yes", "No"))
-                    .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
-                    .BoolRegex = ChkRegex.Checked
-                    .BoolCaseSensitive = ChkCaseSensitive.Checked
-                    .AlertType = AlertType
-                    .BoolEnabled = ChkEnabled.Checked
-                    .BoolLimited = ChkLimited.Checked
-                    .BackColor = If(ChkEnabled.Checked, Color.LightGreen, Color.Pink)
-                    If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
-                End With
+                        .SubItems.Add(If(ChkLimited.Checked, "Yes", "No"))
+                        .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
+                        .BoolRegex = ChkRegex.Checked
+                        .BoolCaseSensitive = ChkCaseSensitive.Checked
+                        .AlertType = AlertType
+                        .BoolEnabled = ChkEnabled.Checked
+                        .BoolLimited = ChkLimited.Checked
+                        .BackColor = If(ChkEnabled.Checked, Color.LightGreen, Color.Pink)
+                        If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
+                    End With
 
-                AlertsListView.Items.Add(AlertsListViewItem)
+                    AlertsListView.Items.Add(AlertsListViewItem)
+                End If
             End If
 
             boolEditMode = False

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -408,7 +408,7 @@ Public Class Alerts
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfAlertsClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
-                Using OpenExplorer As New OpenExplorer()
+                Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
                     OpenExplorer.MyParentForm = Me
 

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -510,7 +510,6 @@ Public Class Alerts
         BtnAdd.Text = "Add"
         Label4.Text = "Add Alert"
         boolEditMode = False
-        boolChanged = True
         TxtAlertText.Text = Nothing
         TxtLogText.Text = Nothing
         IconPictureBox.Image = Nothing

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -254,7 +254,7 @@ Public Class ConfigureSysLogMirrorClients
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfSysLogProxyServer, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
-                Using OpenExplorer As New OpenExplorer()
+                Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
                     OpenExplorer.MyParentForm = Me
 

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -126,16 +126,20 @@ Public Class ConfigureSysLogMirrorClients
                 BtnAddServer.Text = "Add"
                 Label4.Text = "Add Server"
             Else
-                Dim ServerListView As New ServerListViewItem(txtIP.Text)
+                If SearchListView(txtIP.Text, servers.Items) Then
+                    MsgBox("A server with that IP address already exists in the list.", MsgBoxStyle.Critical, Text)
+                Else
+                    Dim ServerListView As New ServerListViewItem(txtIP.Text)
 
-                With ServerListView
-                    .SubItems.Add(txtPort.Text)
-                    .SubItems.Add(If(chkEnabled.Checked, "Yes", "No"))
-                    .SubItems.Add(txtName.Text)
-                    .BoolEnabled = chkEnabled.Checked
-                End With
+                    With ServerListView
+                        .SubItems.Add(txtPort.Text)
+                        .SubItems.Add(If(chkEnabled.Checked, "Yes", "No"))
+                        .SubItems.Add(txtName.Text)
+                        .BoolEnabled = chkEnabled.Checked
+                    End With
 
-                servers.Items.Add(ServerListView)
+                    servers.Items.Add(ServerListView)
+                End If
             End If
 
             boolEditMode = False

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -712,7 +712,7 @@ Public Class Form1
                     SaveAppSettings.SaveApplicationSettingsToFile(SaveFileDialog.FileName)
 
                     If My.Settings.AskOpenExplorer Then
-                        Using OpenExplorer As New OpenExplorer()
+                        Using OpenExplorer As New OpenExplorer(SaveFileDialog.FileName)
                             OpenExplorer.StartPosition = FormStartPosition.CenterParent
                             OpenExplorer.MyParentForm = SupportCode.ParentForm
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -425,6 +425,7 @@ Public Class Form1
         My.Settings.Save()
         WriteLogsToDisk()
         processUptimeTimer?.Dispose()
+        MyMidnightTimer?.Dispose()
 
         If My.Settings.saveIgnoredLogCount Then
             NumberOfIgnoredLogs = longNumberOfIgnoredLogs

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -67,11 +67,15 @@ Public Class Hostnames
                 lblAddEditHostNameLabel.Text = "Add New Custom Hostname"
                 BtnAddSave.Text = "Add"
             Else
-                Dim newListViewItem As New ListViewItem(txtIP.Text)
-                newListViewItem.SubItems.Add(txtHostname.Text)
-                If My.Settings.font IsNot Nothing Then newListViewItem.Font = My.Settings.font
+                If SupportCode.SearchListView(txtIP.Text, ListHostnames.Items) Then
+                    MsgBox("This IP Address already exists in the list.", MsgBoxStyle.Critical, Text)
+                Else
+                    Dim newListViewItem As New ListViewItem(txtIP.Text)
+                    newListViewItem.SubItems.Add(txtHostname.Text)
+                    If My.Settings.font IsNot Nothing Then newListViewItem.Font = My.Settings.font
 
-                ListHostnames.Items.Add(newListViewItem)
+                    ListHostnames.Items.Add(newListViewItem)
+                End If
             End If
 
             boolEditMode = False

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -206,7 +206,7 @@ Public Class Hostnames
             SupportCode.WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(My.Settings.hostnames, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
-                Using OpenExplorer As New OpenExplorer()
+                Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
                     OpenExplorer.MyParentForm = Me
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -375,7 +375,7 @@ Public Class IgnoredLogsAndSearchResults
             End Using
 
             If My.Settings.AskOpenExplorer Then
-                Using OpenExplorer As New OpenExplorer()
+                Using OpenExplorer As New OpenExplorer(SaveFileDialog.FileName)
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
                     OpenExplorer.MyParentForm = Me
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -548,7 +548,7 @@ Public Class IgnoredWordsAndPhrases
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfIgnoredClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
-                Using OpenExplorer As New OpenExplorer()
+                Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
                     OpenExplorer.MyParentForm = Me
 

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -141,30 +141,34 @@ Public Class IgnoredWordsAndPhrases
                 Label4.Text = "Add Ignored Words and Phrases"
                 boolCurrentlyEditing = False
             Else
-                Dim IgnoredListViewItem As New MyIgnoredListViewItem(TxtIgnored.Text)
+                If SearchListView(TxtIgnored.Text, IgnoredListView.Items) Then
+                    MsgBox("This ignored word or phrase already exists in the list.", MsgBoxStyle.Critical, Text)
+                Else
+                    Dim IgnoredListViewItem As New MyIgnoredListViewItem(TxtIgnored.Text)
 
-                With IgnoredListViewItem
-                    .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
-                    .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
-                    .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
-                    .SubItems.Add("0")
-                    .SubItems.Add(If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text"))
-                    .SubItems.Add(Date.Now.ToLongDateString)
-                    .SubItems.Add("")
-                    .SubItems.Add("")
-                    .SubItems.Add(If(ChkRecord.Checked, "Yes", "No"))
-                    .BoolRegex = ChkRegex.Checked
-                    .BoolCaseSensitive = ChkCaseSensitive.Checked
-                    .BoolEnabled = ChkEnabled.Checked
-                    .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
-                    .strComment = txtComment.Text
-                    .BoolRecordLog = ChkRecord.Checked
-                    .dateCreated = Date.Now
-                    If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
-                    .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
-                End With
+                    With IgnoredListViewItem
+                        .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
+                        .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
+                        .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
+                        .SubItems.Add("0")
+                        .SubItems.Add(If(ChkRemoteProcess.Checked, "Remote App", "Main Log Text"))
+                        .SubItems.Add(Date.Now.ToLongDateString)
+                        .SubItems.Add("")
+                        .SubItems.Add("")
+                        .SubItems.Add(If(ChkRecord.Checked, "Yes", "No"))
+                        .BoolRegex = ChkRegex.Checked
+                        .BoolCaseSensitive = ChkCaseSensitive.Checked
+                        .BoolEnabled = ChkEnabled.Checked
+                        .IgnoreType = If(ChkRemoteProcess.Checked, IgnoreType.RemoteApp, IgnoreType.MainLog)
+                        .strComment = txtComment.Text
+                        .BoolRecordLog = ChkRecord.Checked
+                        .dateCreated = Date.Now
+                        If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
+                        .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
+                    End With
 
-                IgnoredListView.Items.Add(IgnoredListViewItem)
+                    IgnoredListView.Items.Add(IgnoredListViewItem)
+                End If
             End If
 
             boolEditMode = False

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -676,7 +676,6 @@ Public Class IgnoredWordsAndPhrases
         BtnAdd.Text = "Add"
         Label4.Text = "Add Ignored Words and Phrases"
         boolEditMode = False
-        boolChanged = True
         TxtIgnored.Text = Nothing
         txtComment.Text = Nothing
         ChkCaseSensitive.Checked = False

--- a/Free SysLog/Windows/Integer Input Form.vb
+++ b/Free SysLog/Windows/Integer Input Form.vb
@@ -57,6 +57,10 @@
         Close()
     End Sub
 
+    Private Sub IntegerInputForm_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+
+    End Sub
+
     Private Sub IntegerInputForm_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
         If e.KeyData = Keys.Escape Then
             DialogResult = DialogResult.Cancel

--- a/Free SysLog/Windows/OpenExplorer.Designer.vb
+++ b/Free SysLog/Windows/OpenExplorer.Designer.vb
@@ -44,6 +44,7 @@ Partial Class OpenExplorer
         '
         'BtnYes
         '
+        Me.BtnYes.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.BtnYes.Location = New System.Drawing.Point(231, 75)
         Me.BtnYes.Name = "BtnYes"
         Me.BtnYes.Size = New System.Drawing.Size(75, 23)
@@ -53,6 +54,7 @@ Partial Class OpenExplorer
         '
         'BtnNo
         '
+        Me.BtnNo.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.BtnNo.Location = New System.Drawing.Point(312, 75)
         Me.BtnNo.Name = "BtnNo"
         Me.BtnNo.Size = New System.Drawing.Size(75, 23)
@@ -62,6 +64,8 @@ Partial Class OpenExplorer
         '
         'Panel1
         '
+        Me.Panel1.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.Panel1.BackColor = System.Drawing.Color.White
         Me.Panel1.Controls.Add(Me.Label1)
         Me.Panel1.Controls.Add(Me.PictureBox1)
@@ -77,8 +81,8 @@ Partial Class OpenExplorer
         Me.Label1.Name = "Label1"
         Me.Label1.Size = New System.Drawing.Size(316, 39)
         Me.Label1.TabIndex = 3
-        Me.Label1.Text = "Data exported successfully." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Do you want to open Windows Explorer to the locati" &
-    "on of the file?"
+        Me.Label1.Text = "Data exported successfully to ""{0}""." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Do you want to open Windows Explorer to t" &
+    "he location of the file?"
         '
         'PictureBox1
         '

--- a/Free SysLog/Windows/OpenExplorer.vb
+++ b/Free SysLog/Windows/OpenExplorer.vb
@@ -1,6 +1,16 @@
 ﻿Public Class OpenExplorer
     Public Property MyParentForm As Form
 
+    Public Sub New(strFilePath As String)
+        ' This call is required by the designer.
+        InitializeComponent()
+
+        ' Add any initialization after the InitializeComponent() call.
+        Debug.WriteLine(Label1.Width)
+        Label1.Text = String.Format(Label1.Text, strFilePath)
+        Size = New Size(Label1.Width + 80, Size.Height)
+    End Sub
+
     Private Sub OpenExplorer_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         Media.SystemSounds.Asterisk.Play()
         PictureBox1.Image = SystemIcons.Question.ToBitmap()

--- a/Free SysLog/Windows/Replacements.resx
+++ b/Free SysLog/Windows/Replacements.resx
@@ -123,6 +123,6 @@
   </data>
   <data name="lblReplacementNotes.Text" xml:space="preserve">
     <value>In the With field, you can reference the value of the Replace field by using $replace. You can also use RegEx back-references as well. If you do so, remember to tick the RegEx checkbox below.
-You can also modify the value of $replace using commands such as: UPPER($replace), UPPERCASE($replace), LOWER($replace), and LOWERCASE($replace).</value>
+You can also modify the value of $replace using commands such as: UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM(). You can also use RegEx backreferences.</value>
   </data>
 </root>

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -85,25 +85,23 @@ Public Class Replacements
             Else
                 If CheckForExistingItem(TxtReplace.Text, TxtReplaceWith.Text) Then
                     MsgBox("A similar item has already been found in your replacements list.", MsgBoxStyle.Critical, Text)
-                    Exit Sub
+                Else
+                    Dim MyReplacementsListViewItem As New MyReplacementsListViewItem(TxtReplace.Text)
+
+                    With MyReplacementsListViewItem
+                        .SubItems.Add(TxtReplaceWith.Text)
+                        .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
+                        .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
+                        .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
+                        .BoolRegex = ChkRegex.Checked
+                        .BoolCaseSensitive = ChkCaseSensitive.Checked
+                        .BoolEnabled = ChkEnabled.Checked
+                        If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
+                        .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
+                    End With
+
+                    ReplacementsListView.Items.Add(MyReplacementsListViewItem)
                 End If
-
-                Dim MyReplacementsListViewItem As New MyReplacementsListViewItem(TxtReplace.Text)
-
-                With MyReplacementsListViewItem
-                    .SubItems.Add(TxtReplaceWith.Text)
-                    .SubItems.Add(If(ChkRegex.Checked, "Yes", "No"))
-                    .SubItems.Add(If(ChkCaseSensitive.Checked, "Yes", "No"))
-                    .SubItems.Add(If(ChkEnabled.Checked, "Yes", "No"))
-                    .BoolRegex = ChkRegex.Checked
-                    .BoolCaseSensitive = ChkCaseSensitive.Checked
-                    .BoolEnabled = ChkEnabled.Checked
-                    If My.Settings.font IsNot Nothing Then .Font = My.Settings.font
-                    .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
-                End With
-
-                ReplacementsListView.Items.Add(MyReplacementsListViewItem)
-                boolChanged = True
             End If
 
             boolEditMode = False

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -339,7 +339,7 @@ Public Class Replacements
             WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(listOfReplacementsClass, Newtonsoft.Json.Formatting.Indented))
 
             If My.Settings.AskOpenExplorer Then
-                Using OpenExplorer As New OpenExplorer()
+                Using OpenExplorer As New OpenExplorer(saveFileDialog.FileName)
                     OpenExplorer.StartPosition = FormStartPosition.CenterParent
                     OpenExplorer.MyParentForm = Me
 

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -435,7 +435,6 @@ Public Class Replacements
         BtnAdd.Text = "Add"
         Label3.Text = "Add Replacement"
         boolEditMode = False
-        boolChanged = True
         TxtReplace.Text = Nothing
         TxtReplaceWith.Text = Nothing
         ChkCaseSensitive.Checked = False


### PR DESCRIPTION
- Added an NSLookup tool to be used in alert text to translate IP addresses to hostnames.
- Added the ability to display the file name that the data was exported to on the "Open Explorer" window.
- Fixed a potential bug when attempting to add a duplicate string replacement rule.
- Added duplicate rule checking to the Alerts, "Configure SysLog Mirror Clients", Hostnames, and "Ignored Words and Phrases".
- Added the ability to use UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM() for alert text.
- Removed the setting of boolChanged to True in the Cancel routines.

And a whole lot of other under the hood changes to the code.