### PR TITLE
Version 5.2 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.2.1.117")>
+<Assembly: AssemblyFileVersion("5.2.2.118")>

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -322,7 +322,7 @@ Namespace SyslogParser
                     Dim strIgnoredPattern As String = Nothing
                     Dim boolRecordIgnoredLog As Boolean = False
 
-                    If My.Settings.ProcessReplacementsInSyslogDataFirst AndAlso replacementsList IsNot Nothing AndAlso replacementsList.GetSnapshot.Any() Then
+                    If My.Settings.ProcessReplacementsInSyslogDataFirst AndAlso replacementsList IsNot Nothing AndAlso replacementsList.Any() Then
                         strRawLogText = ProcessReplacements(strRawLogText)
                     End If
 
@@ -354,18 +354,18 @@ Namespace SyslogParser
 
                     ' Step 3: Handle the ignored logs and alerts
                     If Not My.Settings.ProcessReplacementsInSyslogDataFirst Then
-                        If ignoredList IsNot Nothing AndAlso ignoredList.GetSnapshot.Any() Then
+                        If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then
                             boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, appName, strIgnoredPattern, boolRecordIgnoredLog)
                         End If
 
-                        If replacementsList IsNot Nothing AndAlso replacementsList.GetSnapshot.Any() Then message = ProcessReplacements(message)
+                        If replacementsList IsNot Nothing AndAlso replacementsList.Any() Then message = ProcessReplacements(message)
                     Else
-                        If ignoredList IsNot Nothing AndAlso ignoredList.GetSnapshot.Any() Then
+                        If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then
                             boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, appName, strIgnoredPattern, boolRecordIgnoredLog)
                         End If
                     End If
 
-                    If alertsList IsNot Nothing AndAlso alertsList.GetSnapshot.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType)
+                    If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType)
 
                     If Not boolIgnored Then
                         Dim strLimitBy As String = Nothing

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -550,6 +550,7 @@ Namespace SyslogParser
             If Not embeddedCommandParsingCheck.IsMatch(strInput) Then Return strInput
 
             Dim strFunctionName, strInnerValue, strBefore As String
+            Dim strOriginalInput As String = strInput
             Dim match As Match
             Dim byteIterationGuard As Byte = 0
 
@@ -562,7 +563,7 @@ Namespace SyslogParser
 
                 If byteIterationGuard >= 20 Then
                     ' Prevent infinite loops in case of unforeseen issues with the regex or input.
-                    AddToLogList(Nothing, "Embedded command processing exceeded maximum iterations. Possible malformed input.")
+                    AddToLogList(Nothing, $"Embedded command processing exceeded maximum iterations. Possible malformed input. The rule that caused it was... {strOriginalInput}")
                     Exit While
                 End If
 
@@ -586,7 +587,7 @@ Namespace SyslogParser
                 strInput = strInput.Remove(match.Index, match.Length).Insert(match.Index, strInnerValue)
 
                 If strInput.Equals(strBefore, StringComparison.OrdinalIgnoreCase) Then
-                    AddToLogList(Nothing, "Embedded command processing made no progress; stopping to avoid loop.")
+                    AddToLogList(Nothing, $"Embedded command processing made no progress; stopping to avoid loop. The rule that caused it was... {strOriginalInput}")
                     Exit While
                 End If
             End While

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1598,7 +1598,7 @@ Public Class Form1
                         Catch ex As Newtonsoft.Json.JsonSerializationException
                         End Try
                     Else
-                        If serversList IsNot Nothing AndAlso serversList.GetSnapshot.Any() Then
+                        If serversList IsNot Nothing AndAlso serversList.Any() Then
                             Threading.ThreadPool.QueueUserWorkItem(Sub()
                                                                        ProxiedSysLogData = New ProxiedSysLogData() With {.ip = strSourceIP, .log = strReceivedData}
                                                                        Dim strDataToSend As String = strProxiedString & Newtonsoft.Json.JsonConvert.SerializeObject(ProxiedSysLogData)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -296,7 +296,7 @@ Public Class IgnoredLogsAndSearchResults
         If TypeOf parentForm Is Form1 AndAlso MsgBox("Are you sure you want to clear the ignored logs stored in system memory?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then
             Logs.Rows.Clear()
             LblCount.Text = "Number of ignored logs: 0"
-            parentForm.IgnoredLogs.Clear()
+            SupportCode.ParentForm.IgnoredLogs.Clear()
         End If
     End Sub
 


### PR DESCRIPTION
- Added guardrails to the ProcessEmbeddedCommands() function. These guardrails limit the embedded command evaluation process to a maximum of 20 nested operations to prevent abuse and excessive CPU usage.
- Now when an error occurs due to possible malformed input, the ProcessEmbeddedCommands() function logs the input.
- Fixed a crash bug on the "Ignored Logs and Search Results" window.
- Improved parsing of syslog timestamps. Largely AI-generated code.
- Instead of calling GetSnapshot.Any(), we now make a direct call to Any() which bypasses creating a temporary List object in memory.