### PR TITLE
Version 5.3 Build 1

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -95,18 +95,22 @@ Namespace My
 
             If boolProcessAllFiles Then
                 Threading.Tasks.Parallel.ForEach(filesInDirectory, Sub(file As IO.FileInfo)
-                                                                       Using fileStream As New IO.StreamReader(file.FullName)
-                                                                           collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
+                                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                                           collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
+                                                                       Else
+                                                                           Using fileStream As New IO.StreamReader(file.FullName)
+                                                                               collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
+                                                                           End Using
+                                                                       End If
 
-                                                                           Threading.Tasks.Parallel.ForEach(collectionOfSavedData, Sub(savedData As SavedData)
-                                                                                                                                       With uniqueObjects
-                                                                                                                                           If Not String.IsNullOrWhiteSpace(savedData.logType) Then .logTypes.Add(savedData.logType)
-                                                                                                                                           If Not String.IsNullOrWhiteSpace(savedData.appName) Then .processes.Add(savedData.appName)
-                                                                                                                                           If Not String.IsNullOrWhiteSpace(savedData.hostname) Then .hostNames.Add(savedData.hostname)
-                                                                                                                                           If Not String.IsNullOrWhiteSpace(savedData.ip) Then .ipAddresses.Add(savedData.ip)
-                                                                                                                                       End With
-                                                                                                                                   End Sub)
-                                                                       End Using
+                                                                       Threading.Tasks.Parallel.ForEach(collectionOfSavedData, Sub(savedData As SavedData)
+                                                                                                                                   With uniqueObjects
+                                                                                                                                       If Not String.IsNullOrWhiteSpace(savedData.logType) Then .logTypes.Add(savedData.logType)
+                                                                                                                                       If Not String.IsNullOrWhiteSpace(savedData.appName) Then .processes.Add(savedData.appName)
+                                                                                                                                       If Not String.IsNullOrWhiteSpace(savedData.hostname) Then .hostNames.Add(savedData.hostname)
+                                                                                                                                       If Not String.IsNullOrWhiteSpace(savedData.ip) Then .ipAddresses.Add(savedData.ip)
+                                                                                                                                   End With
+                                                                                                                               End Sub)
                                                                    End Sub)
             End If
 

--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -95,7 +95,7 @@ Namespace My
 
             If boolProcessAllFiles Then
                 Threading.Tasks.Parallel.ForEach(filesInDirectory, Sub(file As IO.FileInfo)
-                                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
                                                                            collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                        Else
                                                                            Using fileStream As New IO.StreamReader(file.FullName)

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.2.3.119")>
+<Assembly: AssemblyFileVersion("5.3.1.120")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1392,24 +1392,24 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
-        Public Property ShowNTFSCompressionSizeDifference() As Boolean
+        Public Property ShowCompressionSizeDifference() As Boolean
             Get
-                Return CType(Me("ShowNTFSCompressionSizeDifference"),Boolean)
+                Return CType(Me("ShowCompressionSizeDifference"),Boolean)
             End Get
             Set
-                Me("ShowNTFSCompressionSizeDifference") = value
+                Me("ShowCompressionSizeDifference") = value
             End Set
         End Property
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
-        Public Property ShowNTFSCompressionSizeDifferencePercentage() As Boolean
+        Public Property ShowCompressionSizeDifferencePercentage() As Boolean
             Get
-                Return CType(Me("ShowNTFSCompressionSizeDifferencePercentage"),Boolean)
+                Return CType(Me("ShowCompressionSizeDifferencePercentage"),Boolean)
             End Get
             Set
-                Me("ShowNTFSCompressionSizeDifferencePercentage") = value
+                Me("ShowCompressionSizeDifferencePercentage") = value
             End Set
         End Property
         

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -338,10 +338,10 @@
     <Setting Name="IncludeCommasInDHMS" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="ShowNTFSCompressionSizeDifference" Type="System.Boolean" Scope="User">
+    <Setting Name="ShowCompressionSizeDifference" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="ShowNTFSCompressionSizeDifferencePercentage" Type="System.Boolean" Scope="User">
+    <Setting Name="ShowCompressionSizeDifferencePercentage" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="CompressBackupLogFiles" Type="System.Boolean" Scope="User">

--- a/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
+++ b/Free SysLog/Support Code/Namespace Code/NativeMethod.vb
@@ -49,14 +49,6 @@ Namespace NativeMethod
         <DllImport("kernel32.dll", SetLastError:=True)>
         Public Shared Function DeviceIoControl(hDevice As SafeFileHandle, dwIoControlCode As UInteger, lpInBuffer As IntPtr, nInBufferSize As UInteger, lpOutBuffer As IntPtr, nOutBufferSize As UInteger, ByRef lpBytesReturned As UInteger, lpOverlapped As IntPtr) As Boolean
         End Function
-
-        Public Const FSCTL_SET_COMPRESSION As UInteger = &H9C040
-        Public Const COMPRESSION_FORMAT_NONE As UShort = 0
-        Public Const COMPRESSION_FORMAT_DEFAULT As UShort = 1
-
-        <DllImport("kernel32.dll", CharSet:=CharSet.Auto, SetLastError:=True)>
-        Public Shared Function GetCompressedFileSize(lpFileName As String, ByRef lpFileSizeHigh As UInteger) As UInteger
-        End Function
     End Class
 
     Module APIs

--- a/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
+++ b/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
@@ -158,16 +158,14 @@ Namespace SaveAppSettings
         ''' <return>Returns a String value.</return>
         <Extension()>
         Private Function FindKeyInDictionaryAndReturnIt(haystack As Dictionary(Of String, Object), needle As String, ByRef value As Object) As Boolean
-            If String.IsNullOrEmpty(needle) Then
+            If String.IsNullOrWhiteSpace(needle) Then
                 Throw New ArgumentException($"'{NameOf(needle)}' cannot be null or empty.", NameOf(needle))
             End If
             If haystack Is Nothing Then
-                Throw New ArgumentNullException(NameOf(haystack))
+                Throw New ArgumentNullException($"'{NameOf(haystack)}' cannot be null or empty.", NameOf(haystack))
             End If
 
-            Dim KeyValuePair As KeyValuePair(Of String, Object) = haystack.FirstOrDefault(Function(item As KeyValuePair(Of String, Object)) item.Key.Trim.Equals(needle, StringComparison.OrdinalIgnoreCase))
-            If KeyValuePair.Value IsNot Nothing Then value = KeyValuePair.Value
-            Return KeyValuePair.Value IsNot Nothing
+            Return haystack.TryGetValue(needle, value)
         End Function
     End Module
 End Namespace

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -135,6 +135,16 @@ Namespace SupportCode
             End If
         End Function
 
+        Public Function GetTextContentsFromGZIPedLogFile(strPathToGZIPedLogFile As String) As String
+            Using sourceStream As FileStream = File.Open(strPathToGZIPedLogFile, FileMode.Open, FileAccess.Read, FileShare.Read)
+                Using gzipStream As New Compression.GZipStream(sourceStream, Compression.CompressionMode.Decompress)
+                    Using streamReader As New StreamReader(gzipStream)
+                        Return streamReader.ReadToEnd.Trim
+                    End Using
+                End Using
+            End Using
+        End Function
+
         Public Function SearchListView(strRuleBase As String, listViewCollection As ListView.ListViewItemCollection) As Boolean
             Return listViewCollection.Cast(Of ListViewItem).Any(Function(item As ListViewItem) item.SubItems(0).Text.Equals(strRuleBase, StringComparison.OrdinalIgnoreCase))
         End Function

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -166,18 +166,36 @@ Namespace SupportCode
             Return listViewCollection.Cast(Of ListViewItem).Any(Function(item As ListViewItem) item.SubItems(0).Text.Equals(strRuleBase, StringComparison.OrdinalIgnoreCase))
         End Function
 
-        Public Sub CompressFile(fileName As String)
-            If File.Exists(fileName) Then
-                Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
-                    Dim comp As UShort = NativeMethod.NativeMethods.COMPRESSION_FORMAT_DEFAULT
-                    Dim ptr As IntPtr = Marshal.AllocHGlobal(2)
-                    Marshal.WriteInt16(ptr, comp)
+        Public Sub GZIPCompressFile(strFilePath As String)
+            If String.IsNullOrWhiteSpace(strFilePath) Then Exit Sub
+            If Not File.Exists(strFilePath) Then Exit Sub
 
-                    NativeMethod.NativeMethods.DeviceIoControl(handle.SafeFileHandle, NativeMethod.NativeMethods.FSCTL_SET_COMPRESSION, ptr, 2, IntPtr.Zero, 0, Nothing, IntPtr.Zero)
-
-                    Marshal.FreeHGlobal(ptr)
-                End Using
+            If strFilePath.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) Then
+                ' Already compressed with .gz extension
+                Exit Sub
             End If
+
+            Dim strCompressedFilePath As String = strFilePath & ".gz"
+
+            ' Compress source file into .gz
+            Using sourceStream As FileStream = File.Open(strFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
+                Using destinationStream As FileStream = File.Create(strCompressedFilePath)
+                    Using gzipStream As New Compression.GZipStream(destinationStream, Compression.CompressionLevel.Optimal)
+                        sourceStream.CopyTo(gzipStream)
+                    End Using
+                End Using
+            End Using
+
+            ' Preserve timestamps (best-effort)
+            Try
+                File.SetCreationTimeUtc(strCompressedFilePath, File.GetCreationTimeUtc(strFilePath))
+                File.SetLastWriteTimeUtc(strCompressedFilePath, File.GetLastWriteTimeUtc(strFilePath))
+            Catch
+                ' Ignore timestamp preservation failures
+            End Try
+
+            ' Remove the original file after successful compression
+            File.Delete(strFilePath)
         End Sub
 
         Public Sub WriteFileAtomically(path As String, contents As Byte())

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -135,6 +135,23 @@ Namespace SupportCode
             End If
         End Function
 
+        Public Function IsGZipFile(strPath As String) As Boolean
+            Try
+                If Not File.Exists(strPath) Then Return False
+
+                Using fileStream As New FileStream(strPath, FileMode.Open, FileAccess.Read, FileShare.Read)
+                    If fileStream.Length < 2 Then Return False
+
+                    Dim magicBit1 As Integer = fileStream.ReadByte()
+                    Dim magicBit2 As Integer = fileStream.ReadByte()
+
+                    Return magicBit1 = &H1F AndAlso magicBit2 = &H8B
+                End Using
+            Catch
+                Return False
+            End Try
+        End Function
+
         Public Function GetTextContentsFromGZIPedLogFile(strPathToGZIPedLogFile As String) As String
             Using sourceStream As FileStream = File.Open(strPathToGZIPedLogFile, FileMode.Open, FileAccess.Read, FileShare.Read)
                 Using gzipStream As New Compression.GZipStream(sourceStream, Compression.CompressionMode.Decompress)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -732,6 +732,7 @@ Namespace SyslogParser
                     End If
 
                     strAlertText = ProcessEmbeddedCommands(strAlertText)
+                    strAlertText = strAlertText.Replace("{NewLine}", vbCrLf, StringComparison.OrdinalIgnoreCase).Trim()
 
                     If alert.BoolLimited Then
                         NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -732,6 +732,8 @@ Namespace SyslogParser
                     End If
 
                     strAlertText = strAlertText.Replace("{NewLine}", vbCrLf, StringComparison.OrdinalIgnoreCase).Trim()
+                    strAlertText = strAlertText.Replace("{CrLf}", vbCrLf, StringComparison.OrdinalIgnoreCase).Trim()
+                    strAlertText = strAlertText.Replace("{NL}", vbCrLf, StringComparison.OrdinalIgnoreCase).Trim()
                     strAlertText = ProcessEmbeddedCommands(strAlertText)
 
                     If alert.BoolLimited Then

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -731,8 +731,8 @@ Namespace SyslogParser
                         End If
                     End If
 
-                    strAlertText = ProcessEmbeddedCommands(strAlertText)
                     strAlertText = strAlertText.Replace("{NewLine}", vbCrLf, StringComparison.OrdinalIgnoreCase).Trim()
+                    strAlertText = ProcessEmbeddedCommands(strAlertText)
 
                     If alert.BoolLimited Then
                         NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType)

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -12,7 +12,7 @@
     Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
         strRawLogText = strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase)
 
-        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = alertType}
+        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = alertType, .Size = My.Settings.logViewerWindowSize}
             LogViewerInstance.LblLogDate.Text = $"Log Date: {strLogDate}"
             LogViewerInstance.LblSource.Text = $"Source IP Address: {strSourceIP}"
             LogViewerInstance.TopMost = True
@@ -31,7 +31,6 @@
         SupportCode.SetDoubleBufferingFlag(AlertHistoryList)
 
         AlertHistoryList.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = SupportCode.GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
-        Size = My.Settings.AlertHistorySize
         Location = SupportCode.VerifyWindowLocation(My.Settings.AlertHistoryLocation, Me)
 
         colTime.Width = My.Settings.columnTimeSize

--- a/Free SysLog/Windows/Alerts.Designer.vb
+++ b/Free SysLog/Windows/Alerts.Designer.vb
@@ -67,7 +67,7 @@ Partial Class Alerts
         '
         Me.BtnEdit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnEdit.Enabled = False
-        Me.BtnEdit.Location = New System.Drawing.Point(83, 237)
+        Me.BtnEdit.Location = New System.Drawing.Point(83, 223)
         Me.BtnEdit.Name = "BtnEdit"
         Me.BtnEdit.Size = New System.Drawing.Size(75, 23)
         Me.BtnEdit.TabIndex = 12
@@ -87,7 +87,7 @@ Partial Class Alerts
         Me.AlertsListView.HideSelection = False
         Me.AlertsListView.Location = New System.Drawing.Point(12, 12)
         Me.AlertsListView.Name = "AlertsListView"
-        Me.AlertsListView.Size = New System.Drawing.Size(933, 219)
+        Me.AlertsListView.Size = New System.Drawing.Size(933, 205)
         Me.AlertsListView.TabIndex = 11
         Me.AlertsListView.UseCompatibleStateImageBehavior = False
         Me.AlertsListView.View = System.Windows.Forms.View.Details
@@ -142,7 +142,7 @@ Partial Class Alerts
         '
         Me.BtnDelete.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnDelete.Enabled = False
-        Me.BtnDelete.Location = New System.Drawing.Point(12, 237)
+        Me.BtnDelete.Location = New System.Drawing.Point(12, 223)
         Me.BtnDelete.Name = "BtnDelete"
         Me.BtnDelete.Size = New System.Drawing.Size(65, 23)
         Me.BtnDelete.TabIndex = 10
@@ -163,7 +163,7 @@ Partial Class Alerts
         '
         Me.BtnEnableDisable.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnEnableDisable.Enabled = False
-        Me.BtnEnableDisable.Location = New System.Drawing.Point(164, 237)
+        Me.BtnEnableDisable.Location = New System.Drawing.Point(164, 223)
         Me.BtnEnableDisable.Name = "BtnEnableDisable"
         Me.BtnEnableDisable.Size = New System.Drawing.Size(75, 23)
         Me.BtnEnableDisable.TabIndex = 13
@@ -173,7 +173,7 @@ Partial Class Alerts
         'BtnExport
         '
         Me.BtnExport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnExport.Location = New System.Drawing.Point(819, 237)
+        Me.BtnExport.Location = New System.Drawing.Point(819, 223)
         Me.BtnExport.Name = "BtnExport"
         Me.BtnExport.Size = New System.Drawing.Size(75, 23)
         Me.BtnExport.TabIndex = 15
@@ -183,7 +183,7 @@ Partial Class Alerts
         'BtnImport
         '
         Me.BtnImport.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnImport.Location = New System.Drawing.Point(900, 237)
+        Me.BtnImport.Location = New System.Drawing.Point(900, 223)
         Me.BtnImport.Name = "BtnImport"
         Me.BtnImport.Size = New System.Drawing.Size(75, 23)
         Me.BtnImport.TabIndex = 14
@@ -193,7 +193,7 @@ Partial Class Alerts
         'BtnDeleteAll
         '
         Me.BtnDeleteAll.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnDeleteAll.Location = New System.Drawing.Point(245, 237)
+        Me.BtnDeleteAll.Location = New System.Drawing.Point(245, 223)
         Me.BtnDeleteAll.Name = "BtnDeleteAll"
         Me.BtnDeleteAll.Size = New System.Drawing.Size(75, 23)
         Me.BtnDeleteAll.TabIndex = 16
@@ -203,7 +203,7 @@ Partial Class Alerts
         'BtnDown
         '
         Me.BtnDown.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.BtnDown.Location = New System.Drawing.Point(951, 208)
+        Me.BtnDown.Location = New System.Drawing.Point(951, 194)
         Me.BtnDown.Name = "BtnDown"
         Me.BtnDown.Size = New System.Drawing.Size(24, 23)
         Me.BtnDown.TabIndex = 21
@@ -225,7 +225,7 @@ Partial Class Alerts
         Me.SeparatingLine.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.SeparatingLine.BackColor = System.Drawing.Color.Black
-        Me.SeparatingLine.Location = New System.Drawing.Point(-1, 269)
+        Me.SeparatingLine.Location = New System.Drawing.Point(-1, 255)
         Me.SeparatingLine.Name = "SeparatingLine"
         Me.SeparatingLine.Size = New System.Drawing.Size(1000, 1)
         Me.SeparatingLine.TabIndex = 25
@@ -234,9 +234,9 @@ Partial Class Alerts
         '
         Me.lblRegExBackReferences.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.lblRegExBackReferences.AutoSize = True
-        Me.lblRegExBackReferences.Location = New System.Drawing.Point(196, 349)
+        Me.lblRegExBackReferences.Location = New System.Drawing.Point(196, 335)
         Me.lblRegExBackReferences.Name = "lblRegExBackReferences"
-        Me.lblRegExBackReferences.Size = New System.Drawing.Size(757, 39)
+        Me.lblRegExBackReferences.Size = New System.Drawing.Size(757, 52)
         Me.lblRegExBackReferences.TabIndex = 37
         Me.lblRegExBackReferences.Text = resources.GetString("lblRegExBackReferences.Text")
         '
@@ -256,7 +256,7 @@ Partial Class Alerts
         'IconPictureBox
         '
         Me.IconPictureBox.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.IconPictureBox.Location = New System.Drawing.Point(158, 352)
+        Me.IconPictureBox.Location = New System.Drawing.Point(158, 338)
         Me.IconPictureBox.Name = "IconPictureBox"
         Me.IconPictureBox.Size = New System.Drawing.Size(32, 32)
         Me.IconPictureBox.TabIndex = 35
@@ -267,7 +267,7 @@ Partial Class Alerts
         Me.AlertTypeComboBox.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.AlertTypeComboBox.FormattingEnabled = True
         Me.AlertTypeComboBox.Items.AddRange(New Object() {"Warning", "Error", "Information", "None"})
-        Me.AlertTypeComboBox.Location = New System.Drawing.Point(73, 352)
+        Me.AlertTypeComboBox.Location = New System.Drawing.Point(73, 338)
         Me.AlertTypeComboBox.Name = "AlertTypeComboBox"
         Me.AlertTypeComboBox.Size = New System.Drawing.Size(79, 21)
         Me.AlertTypeComboBox.TabIndex = 34
@@ -276,7 +276,7 @@ Partial Class Alerts
         '
         Me.Label3.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label3.AutoSize = True
-        Me.Label3.Location = New System.Drawing.Point(12, 355)
+        Me.Label3.Location = New System.Drawing.Point(12, 341)
         Me.Label3.Name = "Label3"
         Me.Label3.Size = New System.Drawing.Size(55, 13)
         Me.Label3.TabIndex = 33
@@ -286,7 +286,7 @@ Partial Class Alerts
         '
         Me.Label2.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label2.AutoSize = True
-        Me.Label2.Location = New System.Drawing.Point(12, 329)
+        Me.Label2.Location = New System.Drawing.Point(12, 315)
         Me.Label2.Name = "Label2"
         Me.Label2.Size = New System.Drawing.Size(52, 13)
         Me.Label2.TabIndex = 32
@@ -296,7 +296,7 @@ Partial Class Alerts
         '
         Me.TxtAlertText.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TxtAlertText.Location = New System.Drawing.Point(67, 326)
+        Me.TxtAlertText.Location = New System.Drawing.Point(67, 312)
         Me.TxtAlertText.Name = "TxtAlertText"
         Me.TxtAlertText.Size = New System.Drawing.Size(908, 20)
         Me.TxtAlertText.TabIndex = 31
@@ -328,7 +328,7 @@ Partial Class Alerts
         '
         Me.TxtLogText.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.TxtLogText.Location = New System.Drawing.Point(67, 300)
+        Me.TxtLogText.Location = New System.Drawing.Point(67, 286)
         Me.TxtLogText.Name = "TxtLogText"
         Me.TxtLogText.Size = New System.Drawing.Size(908, 20)
         Me.TxtLogText.TabIndex = 28
@@ -337,7 +337,7 @@ Partial Class Alerts
         '
         Me.Label1.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label1.AutoSize = True
-        Me.Label1.Location = New System.Drawing.Point(12, 303)
+        Me.Label1.Location = New System.Drawing.Point(12, 289)
         Me.Label1.Name = "Label1"
         Me.Label1.Size = New System.Drawing.Size(49, 13)
         Me.Label1.TabIndex = 27
@@ -348,7 +348,7 @@ Partial Class Alerts
         '
         Me.Label4.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.Label4.AutoSize = True
-        Me.Label4.Location = New System.Drawing.Point(12, 280)
+        Me.Label4.Location = New System.Drawing.Point(12, 266)
         Me.Label4.Name = "Label4"
         Me.Label4.Size = New System.Drawing.Size(435, 13)
         Me.Label4.TabIndex = 38

--- a/Free SysLog/Windows/Alerts.resx
+++ b/Free SysLog/Windows/Alerts.resx
@@ -123,7 +123,8 @@
   <data name="lblRegExBackReferences.Text" xml:space="preserve">
     <value>You can use RegEx back-references in your alert text. For numerical back-references, simply use put a $ before the number.
 For named back-references, put a $ and then put the name of the back-reference inside parentheses. For example... $(name)
-You can use NSLOOKUP() to translate IP addresses to hostnames. UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM() are also able to be used.</value>
+You can use NSLOOKUP() to translate IP addresses to hostnames. UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM() are also able to be used.
+You can add new lines by including {NewLine} in the alert text.</value>
   </data>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>145, 17</value>

--- a/Free SysLog/Windows/Alerts.resx
+++ b/Free SysLog/Windows/Alerts.resx
@@ -124,7 +124,7 @@
     <value>You can use RegEx back-references in your alert text. For numerical back-references, simply use put a $ before the number.
 For named back-references, put a $ and then put the name of the back-reference inside parentheses. For example... $(name)
 You can use NSLOOKUP() to translate IP addresses to hostnames. UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM() are also able to be used.
-You can add new lines by including {NewLine} in the alert text.</value>
+You can add new lines by including {NewLine} in the alert text. {CrLf} and {NL} will also work.</value>
   </data>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>145, 17</value>

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -501,7 +501,7 @@ Partial Class Form1
         Me.CompressBackupLogFilesToolStripMenuItem.CheckOnClick = True
         Me.CompressBackupLogFilesToolStripMenuItem.Name = "CompressBackupLogFilesToolStripMenuItem"
         Me.CompressBackupLogFilesToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
-        Me.CompressBackupLogFilesToolStripMenuItem.Text = "Compress Backup Log Files using NTFS Compression"
+        Me.CompressBackupLogFilesToolStripMenuItem.Text = "Compress Backup Log Files"
         '
         'ColLogsAutoFill
         '

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1330,7 +1330,7 @@ Public Class Form1
             If DataToLoad.Count = 0 Then
                 MsgBox("There are no alerts to show in the Alerts History.", MsgBoxStyle.Information, Text)
             Else
-                Using Alerts_History As New Alerts_History() With {.Icon = Icon, .DataToLoad = DataToLoad, .StartPosition = FormStartPosition.CenterParent, .SetParentForm = Me}
+                Using Alerts_History As New Alerts_History() With {.Icon = Icon, .DataToLoad = DataToLoad, .StartPosition = FormStartPosition.CenterParent, .SetParentForm = Me, .Size = My.Settings.AlertHistorySize}
                     Alerts_History.ShowDialog(Me)
                 End Using
             End If
@@ -1992,7 +1992,7 @@ Public Class Form1
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
             Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
-            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .MyParentForm = Me, .alertType = selectedRow.alertType}
+            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .MyParentForm = Me, .alertType = selectedRow.alertType, .Size = My.Settings.logViewerWindowSize}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"
                 LogViewerInstance.LblSource.Text = $"Source IP Address: {selectedRow.Cells(ColumnIndex_IPAddress).Value}"
 
@@ -2008,7 +2008,7 @@ Public Class Form1
     Private Sub OpenLogViewerWindow(strLogText As String, strAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
         strRawLogText = strRawLogText.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase)
 
-        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = alertType}
+        Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = alertType, .Size = My.Settings.logViewerWindowSize}
             LogViewerInstance.LblLogDate.Text = $"Log Date: {strLogDate}"
             LogViewerInstance.LblSource.Text = $"Source IP Address: {strSourceIP}"
             LogViewerInstance.TopMost = True

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1671,7 +1671,14 @@ Public Class Form1
         WriteLogsToDisk()
         Dim strLogFileBackupFileName As String = GetUniqueFileName(Path.Combine(strPathToDataBackupFolder, $"{GetDateStringBasedOnUserPreference(Now.AddDays(-1))} Backup.json"))
         File.Copy(strPathToDataFile, strLogFileBackupFileName)
-        If My.Settings.CompressBackupLogFiles Then CompressFile(strLogFileBackupFileName)
+
+        If My.Settings.CompressBackupLogFiles Then
+            Try
+                GZIPCompressFile(strLogFileBackupFileName)
+            Catch
+                ' If something goes wrong, we don't care.
+            End Try
+        End If
     End Sub
 
     Private Sub LoadDataFile(Optional boolShowDataLoadedEvent As Boolean = True)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -553,7 +553,7 @@ Public Class Form1
     End Sub
 
     Private Sub IgnoredWordsAndPhrasesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Click
-        ShowSingleInstanceWindow(Of IgnoredWordsAndPhrases)(IgnoredWordsAndPhrasesOrAlertsInstance, Me.Icon)
+        ShowSingleInstanceWindow(IgnoredWordsAndPhrasesOrAlertsInstance, Me.Icon)
     End Sub
 
     Private Sub ViewIgnoredLogsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ViewIgnoredLogsToolStripMenuItem.Click
@@ -680,7 +680,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureReplacementsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureReplacementsToolStripMenuItem.Click
-        ShowSingleInstanceWindow(Of Replacements)(ReplacementsInstance, Icon)
+        ShowSingleInstanceWindow(ReplacementsInstance, Icon)
     End Sub
 
     Private Sub ConfigureAlternatingColorToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChangeAlternatingColorToolStripMenuItem.Click
@@ -983,7 +983,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureAlertsToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ConfigureAlertsToolStripMenuItem.Click
-        ShowSingleInstanceWindow(Of Alerts)(AlertsInstance, Icon)
+        ShowSingleInstanceWindow(AlertsInstance, Icon)
     End Sub
 
     Private Sub OpenWindowsExplorerToAppConfigFile_Click(sender As Object, e As EventArgs) Handles OpenWindowsExplorerToAppConfigFile.Click
@@ -992,7 +992,7 @@ Public Class Form1
     End Sub
 
     Private Sub CreateAlertToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateAlertToolStripMenuItem.Click
-        ShowSingleInstanceWindow(Of Alerts)(AlertsInstance, Icon)
+        ShowSingleInstanceWindow(AlertsInstance, Icon)
         AlertsInstance.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
     End Sub
 
@@ -1057,7 +1057,7 @@ Public Class Form1
 
     Private Sub CreateIgnoredLogToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateIgnoredLogToolStripMenuItem.Click
         If Logs.SelectedRows.Count > 0 Then
-            ShowSingleInstanceWindow(Of IgnoredWordsAndPhrases)(IgnoredWordsAndPhrasesOrAlertsInstance, Icon)
+            ShowSingleInstanceWindow(IgnoredWordsAndPhrasesOrAlertsInstance, Icon)
 
             Dim myItem As MyDataGridViewRow = TryCast(Logs.SelectedRows(0), MyDataGridViewRow)
             If myItem IsNot Nothing Then IgnoredWordsAndPhrasesOrAlertsInstance.TxtIgnored.Text = myItem.RawLogData
@@ -1065,7 +1065,7 @@ Public Class Form1
     End Sub
 
     Private Sub CreateReplacementToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateReplacementToolStripMenuItem.Click
-        ShowSingleInstanceWindow(Of Replacements)(ReplacementsInstance, Icon)
+        ShowSingleInstanceWindow(ReplacementsInstance, Icon)
         ReplacementsInstance.TxtReplace.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
     End Sub
 
@@ -1083,7 +1083,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureSysLogMirrorServers_Click(sender As Object, e As EventArgs) Handles ConfigureSysLogMirrorServers.Click
-        ShowSingleInstanceWindow(Of ConfigureSysLogMirrorClients)(ConfigureSysLogMirrorClientsInstance, Icon)
+        ShowSingleInstanceWindow(ConfigureSysLogMirrorClientsInstance, Icon)
     End Sub
 
     Private Sub MinimizeToClockTray_Click(sender As Object, e As EventArgs) Handles MinimizeToClockTray.Click
@@ -1249,7 +1249,7 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureHostnames_Click(sender As Object, e As EventArgs) Handles ConfigureHostnames.Click
-        ShowSingleInstanceWindow(Of Hostnames)(HostNamesInstance, Icon)
+        ShowSingleInstanceWindow(HostNamesInstance, Icon)
     End Sub
 
     Private Sub ChangeFont_Click(sender As Object, e As EventArgs) Handles ChangeFont.Click

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -54,6 +54,7 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ChkCaseInsensitiveSearch = New System.Windows.Forms.CheckBox()
         Me.ChkColLogsAutoFill = New System.Windows.Forms.CheckBox()
         Me.ChkRegExSearch = New System.Windows.Forms.CheckBox()
+        Me.ToolStripSelectedItems = New System.Windows.Forms.ToolStripStatusLabel()
         Me.BtnSearch = New System.Windows.Forms.Button()
         Me.TxtSearchTerms = New System.Windows.Forms.TextBox()
         Me.LblSearchLabel = New System.Windows.Forms.Label()
@@ -89,7 +90,7 @@ Partial Class IgnoredLogsAndSearchResults
         '
         'StatusStrip1
         '
-        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblCount, Me.LogsLoadedInLabel})
+        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblCount, Me.LogsLoadedInLabel, Me.ToolStripSelectedItems})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 403)
         Me.StatusStrip1.Name = "StatusStrip1"
         Me.StatusStrip1.Size = New System.Drawing.Size(1563, 22)
@@ -372,6 +373,14 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ChkKeepIgnoredLogsPastUserLimit.Text = "Keep Ignored Logs Past User-Set Limit"
         Me.ChkKeepIgnoredLogsPastUserLimit.UseVisualStyleBackColor = True
         '
+        'ToolStripSelectedItems
+        '
+        Me.ToolStripSelectedItems.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
+        Me.ToolStripSelectedItems.Name = "ToolStripSelectedItems"
+        Me.ToolStripSelectedItems.Size = New System.Drawing.Size(91, 17)
+        Me.ToolStripSelectedItems.Text = "Selected Logs: 0"
+        Me.ToolStripSelectedItems.Visible = False
+        '
         'IgnoredLogsAndSearchResults
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -437,4 +446,5 @@ Partial Class IgnoredLogsAndSearchResults
     Friend WithEvents OpenLogForViewingToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ChkAutoScroll As CheckBox
     Friend WithEvents ChkKeepIgnoredLogsPastUserLimit As CheckBox
+    Friend WithEvents ToolStripSelectedItems As ToolStripStatusLabel
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -459,9 +459,15 @@ Public Class IgnoredLogsAndSearchResults
         Dim collectionOfSavedData As New List(Of SavedData)
 
         Try
-            Using fileStream As New StreamReader(strFileName)
-                collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForSettingsFiles)
-            End Using
+            Dim fileInfo As New FileInfo(strFileName)
+
+            If fileInfo.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(fileInfo.FullName) Then
+                collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(fileInfo.FullName), JSONDecoderSettingsForSettingsFiles)
+            Else
+                Using fileStream As New StreamReader(strFileName)
+                    collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForSettingsFiles)
+                End Using
+            End If
 
             If collectionOfSavedData.Any() Then
                 collectionOfSavedData.Sort(Function(x As SavedData, y As SavedData) x.DateObject.CompareTo(y.DateObject))

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -321,7 +321,15 @@ Public Class IgnoredLogsAndSearchResults
                 End If
             End If
 
-            For Each item As DataGridViewRow In Logs.Rows
+            Dim dataToExport As List(Of DataGridViewRow)
+
+            If Logs.SelectedRows.Count > 1 Then
+                dataToExport = Logs.SelectedRows.Cast(Of DataGridViewRow).ToList()
+            Else
+                dataToExport = Logs.Rows.Cast(Of DataGridViewRow).ToList()
+            End If
+
+            For Each item As DataGridViewRow In dataToExport
                 If Not String.IsNullOrWhiteSpace(item.Cells(ColumnIndex_ComputedTime).Value) Then
                     myItem = DirectCast(item, MyDataGridViewRow)
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -681,4 +681,9 @@ Public Class IgnoredLogsAndSearchResults
             If selectedItem IsNot Nothing Then CopyTextToWindowsClipboard(selectedItem.RawLogData, Text)
         End If
     End Sub
+
+    Private Sub Logs_SelectionChanged(sender As Object, e As EventArgs) Handles Logs.SelectionChanged
+        ToolStripSelectedItems.Visible = Logs.SelectedRows.Count > 1
+        ToolStripSelectedItems.Text = $"Selected Logs: {Logs.SelectedRows.Count:N0}"
+    End Sub
 End Class

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -28,7 +28,7 @@ Public Class IgnoredLogsAndSearchResults
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
             Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
-            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = selectedRow.alertType}
+            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = selectedRow.alertType, .Size = My.Settings.logViewerWindowSize}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"
                 LogViewerInstance.LblSource.Text = $"Source IP Address: {selectedRow.Cells(ColumnIndex_IPAddress).Value}"
 
@@ -534,7 +534,7 @@ Public Class IgnoredLogsAndSearchResults
     End Sub
 
     Private Sub CreateAlertToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CreateAlertToolStripMenuItem.Click
-        Dim Alerts As New Alerts With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon}
+        Dim Alerts As New Alerts With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .Size = My.Settings.ConfigureAlertsSize}
         Alerts.TxtLogText.Text = Logs.SelectedRows(0).Cells(ColumnIndex_LogText).Value
         Alerts.Show()
     End Sub
@@ -609,7 +609,7 @@ Public Class IgnoredLogsAndSearchResults
             Dim strLogText As String = selectedRow.Cells(ColumnIndex_LogText).Value
             Dim strRawLogText As String = If(String.IsNullOrWhiteSpace(selectedRow.RawLogData), selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.RawLogData.Replace("{newline}", vbCrLf, StringComparison.OrdinalIgnoreCase))
 
-            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = selectedRow.alertType}
+            Using LogViewerInstance As New LogViewer With {.strRawLogText = strRawLogText, .strLogText = strLogText, .StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .alertType = selectedRow.alertType, .Size = My.Settings.logViewerWindowSize}
                 LogViewerInstance.LblLogDate.Text = $"Log Date: {selectedRow.Cells(ColumnIndex_ComputedTime).Value}"
                 LogViewerInstance.LblSource.Text = $"Source IP Address: {selectedRow.Cells(ColumnIndex_IPAddress).Value}"
 

--- a/Free SysLog/Windows/Log Viewer.vb
+++ b/Free SysLog/Windows/Log Viewer.vb
@@ -45,7 +45,6 @@ Public Class LogViewer
         End If
 
         ChkShowRawLog.Checked = My.Settings.boolShowRawLogOnLogViewer
-        Size = My.Settings.logViewerWindowSize
         LogText.Text = If(ChkShowRawLog.Checked, strRawLogText, strLogText)
         LogText.Select(0, 0)
 

--- a/Free SysLog/Windows/OpenExplorer.vb
+++ b/Free SysLog/Windows/OpenExplorer.vb
@@ -15,6 +15,7 @@
         Media.SystemSounds.Asterisk.Play()
         PictureBox1.Image = SystemIcons.Question.ToBitmap()
         ChkAskEveryTime.Checked = My.Settings.AskOpenExplorer
+        SupportCode.CenterFormOverParent(MyParentForm, Me)
     End Sub
 
     Private Sub BtnYes_Click(sender As Object, e As EventArgs) Handles BtnYes.Click

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -85,7 +85,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(990, 243)
+        Me.FileList.Size = New System.Drawing.Size(953, 243)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -183,7 +183,7 @@ Partial Class ViewLogBackups
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.lblTotalNumberOfHiddenLogs, Me.LblTotalDiskSpace})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(1015, 22)
+        Me.StatusStrip1.Size = New System.Drawing.Size(978, 22)
         Me.StatusStrip1.TabIndex = 5
         Me.StatusStrip1.Text = "StatusStrip1"
         '
@@ -283,14 +283,14 @@ Partial Class ViewLogBackups
         '
         Me.lblTotalNumberOfLogs.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
         Me.lblTotalNumberOfLogs.Name = "lblTotalNumberOfLogs"
-        Me.lblTotalNumberOfLogs.Size = New System.Drawing.Size(124, 17)
+        Me.lblTotalNumberOfLogs.Size = New System.Drawing.Size(125, 17)
         Me.lblTotalNumberOfLogs.Text = "Total Number of Logs:"
         '
         'ChkShowHidden
         '
         Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHidden.AutoSize = True
-        Me.ChkShowHidden.Location = New System.Drawing.Point(843, 292)
+        Me.ChkShowHidden.Location = New System.Drawing.Point(814, 292)
         Me.ChkShowHidden.Name = "ChkShowHidden"
         Me.ChkShowHidden.Size = New System.Drawing.Size(114, 17)
         Me.ChkShowHidden.TabIndex = 34
@@ -308,7 +308,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHiddenAsGray.AutoSize = True
-        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(843, 319)
+        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(814, 319)
         Me.ChkShowHiddenAsGray.Name = "ChkShowHiddenAsGray"
         Me.ChkShowHiddenAsGray.Size = New System.Drawing.Size(153, 17)
         Me.ChkShowHiddenAsGray.TabIndex = 35
@@ -335,14 +335,14 @@ Partial Class ViewLogBackups
         '
         Me.LblTotalDiskSpace.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
         Me.LblTotalDiskSpace.Name = "LblTotalDiskSpace"
-        Me.LblTotalDiskSpace.Size = New System.Drawing.Size(123, 17)
+        Me.LblTotalDiskSpace.Size = New System.Drawing.Size(124, 17)
         Me.LblTotalDiskSpace.Text = "Total Disk Space Used:"
         '
         'ChkIgnoreSearchResultsLimits
         '
         Me.ChkIgnoreSearchResultsLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkIgnoreSearchResultsLimits.AutoSize = True
-        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(843, 265)
+        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(814, 265)
         Me.ChkIgnoreSearchResultsLimits.Name = "ChkIgnoreSearchResultsLimits"
         Me.ChkIgnoreSearchResultsLimits.Size = New System.Drawing.Size(160, 17)
         Me.ChkIgnoreSearchResultsLimits.TabIndex = 37
@@ -421,7 +421,7 @@ Partial Class ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(1015, 364)
+        Me.ClientSize = New System.Drawing.Size(978, 364)
         Me.Controls.Add(Me.btnViewLogsWithLimits)
         Me.Controls.Add(Me.boxLimiter)
         Me.Controls.Add(Me.boxLimitBy)
@@ -445,7 +445,7 @@ Partial Class ViewLogBackups
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(1031, 403)
+        Me.MinimumSize = New System.Drawing.Size(994, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -58,6 +58,7 @@ Partial Class ViewLogBackups
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
         Me.CompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.GZIPCompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UncompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
@@ -118,7 +119,7 @@ Partial Class ViewLogBackups
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.CompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.CompressFileToolStripMenuItem, Me.GZIPCompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
         Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 180)
         '
@@ -205,6 +206,12 @@ Partial Class ViewLogBackups
         Me.ChkCaseInsensitiveSearch.TabIndex = 33
         Me.ChkCaseInsensitiveSearch.Text = "Case Insensitive?"
         Me.ChkCaseInsensitiveSearch.UseVisualStyleBackColor = True
+        '
+        'GZIPCompressFileToolStripMenuItem
+        '
+        Me.GZIPCompressFileToolStripMenuItem.Name = "GZIPCompressFileToolStripMenuItem"
+        Me.GZIPCompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.GZIPCompressFileToolStripMenuItem.Text = "Compress File using GZIP"
         '
         'CompressFileToolStripMenuItem
         '
@@ -494,6 +501,7 @@ Partial Class ViewLogBackups
     Friend WithEvents ShowInWindowsExplorerToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents RenameToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CompressFileToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents GZIPCompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents UncompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ChkShowNTFSCompressionSizeDifference As CheckBox
     Friend WithEvents ChkShowNTFSCompressionSizeDifferencePercentage As CheckBox

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -32,8 +32,8 @@ Partial Class ViewLogBackups
         Me.ViewToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnView = New System.Windows.Forms.Button()
         Me.BtnDelete = New System.Windows.Forms.Button()
-        Me.ChkShowNTFSCompressionSizeDifference = New System.Windows.Forms.CheckBox()
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage = New System.Windows.Forms.CheckBox()
+        Me.ChkShowCompressionSizeDifference = New System.Windows.Forms.CheckBox()
+        Me.ChkShowCompressionSizeDifferencePercentage = New System.Windows.Forms.CheckBox()
         Me.BtnRefresh = New System.Windows.Forms.Button()
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.lblNumberOfFiles = New System.Windows.Forms.ToolStripStatusLabel()
@@ -57,7 +57,6 @@ Partial Class ViewLogBackups
         Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
-        Me.CompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.GZIPCompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UncompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
@@ -119,7 +118,7 @@ Partial Class ViewLogBackups
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.CompressFileToolStripMenuItem, Me.GZIPCompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.GZIPCompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
         Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 180)
         '
@@ -211,13 +210,7 @@ Partial Class ViewLogBackups
         '
         Me.GZIPCompressFileToolStripMenuItem.Name = "GZIPCompressFileToolStripMenuItem"
         Me.GZIPCompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.GZIPCompressFileToolStripMenuItem.Text = "Compress File using GZIP"
-        '
-        'CompressFileToolStripMenuItem
-        '
-        Me.CompressFileToolStripMenuItem.Name = "CompressFileToolStripMenuItem"
-        Me.CompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.CompressFileToolStripMenuItem.Text = "Compress File using NTFS"
+        Me.GZIPCompressFileToolStripMenuItem.Text = "Compress File"
         '
         'UncompressFileToolStripMenuItem
         '
@@ -236,27 +229,27 @@ Partial Class ViewLogBackups
         Me.ChkRegExSearch.Text = "Regex?"
         Me.ChkRegExSearch.UseVisualStyleBackColor = True
         '
-        'ChkShowNTFSCompressionSizeDifference
+        'ChkShowCompressionSizeDifference
         '
-        Me.ChkShowNTFSCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.ChkShowNTFSCompressionSizeDifference.AutoSize = True
-        Me.ChkShowNTFSCompressionSizeDifference.Location = New System.Drawing.Point(554, 292)
-        Me.ChkShowNTFSCompressionSizeDifference.Name = "ChkShowNTFSCompressionSizeDifference"
-        Me.ChkShowNTFSCompressionSizeDifference.Size = New System.Drawing.Size(222, 17)
-        Me.ChkShowNTFSCompressionSizeDifference.TabIndex = 43
-        Me.ChkShowNTFSCompressionSizeDifference.Text = "Show NTFS Compression Size Differences"
-        Me.ChkShowNTFSCompressionSizeDifference.UseVisualStyleBackColor = True
+        Me.ChkShowCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkShowCompressionSizeDifference.AutoSize = True
+        Me.ChkShowCompressionSizeDifference.Location = New System.Drawing.Point(554, 292)
+        Me.ChkShowCompressionSizeDifference.Name = "ChkShowCompressionSizeDifference"
+        Me.ChkShowCompressionSizeDifference.Size = New System.Drawing.Size(196, 17)
+        Me.ChkShowCompressionSizeDifference.TabIndex = 43
+        Me.ChkShowCompressionSizeDifference.Text = "Show Compression Size Differences"
+        Me.ChkShowCompressionSizeDifference.UseVisualStyleBackColor = True
         '
-        'ChkShowNTFSCompressionSizeDifferencePercentage
+        'ChkShowCompressionSizeDifferencePercentage
         '
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.AutoSize = True
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(554, 319)
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Name = "ChkShowNTFSCompressionSizeDifferencePercentage"
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(280, 17)
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.TabIndex = 44
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.Text = "Show NTFS Compression Size Difference Percentages"
-        Me.ChkShowNTFSCompressionSizeDifferencePercentage.UseVisualStyleBackColor = True
+        Me.ChkShowCompressionSizeDifferencePercentage.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkShowCompressionSizeDifferencePercentage.AutoSize = True
+        Me.ChkShowCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(554, 319)
+        Me.ChkShowCompressionSizeDifferencePercentage.Name = "ChkShowCompressionSizeDifferencePercentage"
+        Me.ChkShowCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(254, 17)
+        Me.ChkShowCompressionSizeDifferencePercentage.TabIndex = 44
+        Me.ChkShowCompressionSizeDifferencePercentage.Text = "Show Compression Size Difference Percentages"
+        Me.ChkShowCompressionSizeDifferencePercentage.UseVisualStyleBackColor = True
         '
         'BtnSearch
         '
@@ -447,8 +440,8 @@ Partial Class ViewLogBackups
         Me.Controls.Add(Me.BtnView)
         Me.Controls.Add(Me.FileList)
         Me.Controls.Add(Me.ChkLogFileDeletions)
-        Me.Controls.Add(Me.ChkShowNTFSCompressionSizeDifference)
-        Me.Controls.Add(Me.ChkShowNTFSCompressionSizeDifferencePercentage)
+        Me.Controls.Add(Me.ChkShowCompressionSizeDifference)
+        Me.Controls.Add(Me.ChkShowCompressionSizeDifferencePercentage)
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -500,9 +493,8 @@ Partial Class ViewLogBackups
     Friend WithEvents btnViewLogsWithLimits As Button
     Friend WithEvents ShowInWindowsExplorerToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents RenameToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents CompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents GZIPCompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents UncompressFileToolStripMenuItem As ToolStripMenuItem
-    Friend WithEvents ChkShowNTFSCompressionSizeDifference As CheckBox
-    Friend WithEvents ChkShowNTFSCompressionSizeDifferencePercentage As CheckBox
+    Friend WithEvents ChkShowCompressionSizeDifference As CheckBox
+    Friend WithEvents ChkShowCompressionSizeDifferencePercentage As CheckBox
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -210,7 +210,7 @@ Partial Class ViewLogBackups
         '
         Me.CompressFileToolStripMenuItem.Name = "CompressFileToolStripMenuItem"
         Me.CompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.CompressFileToolStripMenuItem.Text = "Compress File"
+        Me.CompressFileToolStripMenuItem.Text = "Compress File using NTFS"
         '
         'UncompressFileToolStripMenuItem
         '

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -82,7 +82,7 @@ Public Class ViewLogBackups
 
     Private Function GetEntryCount(strFileName As String) As Integer
         Try
-            If New FileInfo(strFileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+            If New FileInfo(strFileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(strFileName) Then
                 Return Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(strFileName), JSONDecoderSettingsForLogFiles).Count
             Else
                 Using fileStream As New StreamReader(strFileName)
@@ -418,7 +418,7 @@ Public Class ViewLogBackups
                                           Dim myDataGridRow As MyDataGridViewRow
 
                                           Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
-                                                                                 If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                                                 If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
                                                                                      dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                                  Else
                                                                                      Using fileStream As New StreamReader(file.FullName)
@@ -573,6 +573,7 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub UncompressGZIPFile(strFilePath As String)
+        If Not IsGZipFile(strFilePath) Then Exit Sub
         If String.IsNullOrWhiteSpace(strFilePath) Then Exit Sub
         If Not File.Exists(strFilePath) Then Exit Sub
 
@@ -908,7 +909,7 @@ Public Class ViewLogBackups
                                       Dim boolDidWeHaveAMatch As Boolean = False
 
                                       Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
-                                                                             If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                                             If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
                                                                                  dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                              Else
                                                                                  Using fileStream As New StreamReader(file.FullName)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -94,26 +94,6 @@ Public Class ViewLogBackups
         End Try
     End Function
 
-    Private Function GetNTFSFileCompressionInfo(file As FileInfo, ByRef longUsedDiskSpace As Long) As String
-        Dim longNTFSCompressedFileSize As Long = GetCompressedSize(file.FullName)
-
-        If longNTFSCompressedFileSize = -1 Then
-            Interlocked.Add(longUsedDiskSpace, file.Length)
-            Return "Error"
-        Else
-            Interlocked.Add(longUsedDiskSpace, longNTFSCompressedFileSize)
-
-            Dim strFileSizeString As String = FileSizeToHumanSize(longNTFSCompressedFileSize)
-
-            If ChkShowNTFSCompressionSizeDifferencePercentage.Checked Then
-                Dim strPercentString As String = MyRoundingFunction(longNTFSCompressedFileSize / file.Length * 100, 2)
-                strFileSizeString &= $", {strPercentString}% smaller"
-            End If
-
-            Return strFileSizeString
-        End If
-    End Function
-
     Private Sub LoadFileList(Optional intReselectItem As Integer = -1)
         Dim filesInDirectory As FileInfo()
 
@@ -130,10 +110,8 @@ Public Class ViewLogBackups
 
         Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
                                                Dim boolIsHidden As Boolean = (file.Attributes And FileAttributes.Hidden) = FileAttributes.Hidden
-                                               Dim boolIsCompressed As Boolean = (file.Attributes And FileAttributes.Compressed) = FileAttributes.Compressed
                                                Dim intCount As Integer = GetEntryCount(file.FullName)
-                                               Dim intCompresedSize As Long = -1
-                                               Dim longNTFSCompressedFileSize As Long = -1
+                                               Dim intUnCompresedSize As Long = -1
 
                                                If intCount <> -1 Then
                                                    If boolIsHidden Then
@@ -158,12 +136,16 @@ Public Class ViewLogBackups
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                                                           intCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
+                                                           intUnCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
 
-                                                           If intCompresedSize <> -1 Then
-                                                               row.Cells(2).Value = FileSizeToHumanSize(intCompresedSize)
+                                                           If ChkShowCompressionSizeDifference.Checked Then
+                                                               If intUnCompresedSize = -1 Then
+                                                                   row.Cells(2).Value = "Error"
+                                                               Else
+                                                                   row.Cells(2).Value = FileSizeToHumanSize(intUnCompresedSize)
+                                                               End If
                                                            Else
-                                                               row.Cells(2).Value = "Error"
+                                                               row.Cells(2).Value = FileSizeToHumanSize(file.Length)
                                                            End If
                                                        Else
                                                            .Cells(2).Value = FileSizeToHumanSize(file.Length)
@@ -183,22 +165,26 @@ Public Class ViewLogBackups
                                                    For Each cell As DataGridViewCell In row.Cells
                                                        cell.Style.Font = My.Settings.font
                                                        If boolIsHidden AndAlso ChkShowHiddenAsGray.Checked Then cell.Style.ForeColor = Color.Gray
-                                                       If boolIsCompressed Or file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then cell.Style.ForeColor = Color.Blue
+                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then cell.Style.ForeColor = Color.Blue
                                                    Next
 
                                                    row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
                                                    If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"
+                                                       If ChkShowCompressionSizeDifference.Checked Then
+                                                           If ChkShowCompressionSizeDifferencePercentage.Checked Then
+                                                               row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)}"
+                                                               If intUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / intUnCompresedSize * 100):F2}% smaller"
+                                                               row.Cells(2).Value &= $")"
+                                                           Else
+                                                               row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"
+                                                           End If
+                                                       End If
+
                                                        Interlocked.Add(longUsedDiskSpace, file.Length)
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
                                                    Else
-                                                       If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
-                                                           row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
-                                                           Interlocked.Increment(intNumberOfCompressedFiles)
-                                                       Else
-                                                           Interlocked.Add(longUsedDiskSpace, file.Length)
-                                                       End If
+                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
                                                    End If
 
                                                    threadSafeListOfDataGridViewRows.Add(row)
@@ -209,10 +195,10 @@ Public Class ViewLogBackups
                    Dim listOfDataGridViewRows As List(Of DataGridViewRow) = threadSafeListOfDataGridViewRows.GetSnapshot.OrderBy(Function(row As MyDataGridViewFileRow) row.fileDate).ToList()
                    threadSafeListOfDataGridViewRows = Nothing
 
-                   If intNumberOfCompressedFiles = 0 Then
-                       ColFileSize.HeaderText = "File Size"
-                   Else
+                   If ChkShowCompressionSizeDifference.Checked And intNumberOfCompressedFiles <> 0 Then
                        ColFileSize.HeaderText = "File Size (Compressed Size)"
+                   Else
+                       ColFileSize.HeaderText = "File Size"
                    End If
 
                    If My.Settings.font IsNot Nothing Then
@@ -275,9 +261,9 @@ Public Class ViewLogBackups
         colEntryCount.Width = My.Settings.viewLogBackupsEntryCountColumnSize
         colHidden.Width = My.Settings.viewLogBackupsHiddenColumnSize
 
-        ChkShowNTFSCompressionSizeDifference.Checked = My.Settings.ShowNTFSCompressionSizeDifference
-        ChkShowNTFSCompressionSizeDifferencePercentage.Enabled = ChkShowNTFSCompressionSizeDifference.Checked
-        ChkShowNTFSCompressionSizeDifferencePercentage.Checked = My.Settings.ShowNTFSCompressionSizeDifferencePercentage
+        ChkShowCompressionSizeDifference.Checked = My.Settings.ShowCompressionSizeDifference
+        ChkShowCompressionSizeDifferencePercentage.Enabled = ChkShowCompressionSizeDifference.Checked
+        ChkShowCompressionSizeDifferencePercentage.Checked = My.Settings.ShowCompressionSizeDifferencePercentage
 
         LoadColumnOrders(FileList.Columns, My.Settings.fileListColumnOrder)
 
@@ -538,20 +524,12 @@ Public Class ViewLogBackups
                 HideToolStripMenuItem.Visible = True
             End If
 
-            If (fileInfo.Attributes And FileAttributes.Compressed) = FileAttributes.Compressed Then
-                UncompressFileToolStripMenuItem.Visible = True
-                CompressFileToolStripMenuItem.Visible = False
-            Else
-                UncompressFileToolStripMenuItem.Visible = False
-                CompressFileToolStripMenuItem.Visible = True
-            End If
-
             If fileInfo.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
                 GZIPCompressFileToolStripMenuItem.Visible = False
                 UncompressFileToolStripMenuItem.Visible = True
-                CompressFileToolStripMenuItem.Visible = False
             Else
                 GZIPCompressFileToolStripMenuItem.Visible = True
+                UncompressFileToolStripMenuItem.Visible = False
             End If
         Else
             DeleteToolStripMenuItem.Enabled = False
@@ -615,50 +593,6 @@ Public Class ViewLogBackups
         End Try
     End Sub
 
-    Private Sub GZIPCompressFile(strFilePath As String)
-        If String.IsNullOrWhiteSpace(strFilePath) Then Exit Sub
-        If Not File.Exists(strFilePath) Then Exit Sub
-
-        Try
-            If strFilePath.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) Then
-                ' Already compressed with .gz extension
-                Exit Sub
-            End If
-
-            Dim strCompressedFilePath As String = strFilePath & ".gz"
-
-            ' Compress source file into .gz
-            Using sourceStream As FileStream = File.Open(strFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
-                Using destinationStream As FileStream = File.Create(strCompressedFilePath)
-                    Using gzipStream As New Compression.GZipStream(destinationStream, Compression.CompressionLevel.Optimal)
-                        sourceStream.CopyTo(gzipStream)
-                    End Using
-                End Using
-            End Using
-
-            ' Preserve timestamps (best-effort)
-            Try
-                File.SetCreationTimeUtc(strCompressedFilePath, File.GetCreationTimeUtc(strFilePath))
-                File.SetLastWriteTimeUtc(strCompressedFilePath, File.GetLastWriteTimeUtc(strFilePath))
-            Catch
-                ' Ignore timestamp preservation failures
-            End Try
-
-            ' Remove the original file after successful compression
-            File.Delete(strFilePath)
-        Catch ex As Exception
-            Try
-                If InvokeRequired Then
-                    Invoke(Sub() MsgBox($"Error compressing file ""{Path.GetFileName(strFilePath)}"": {ex.Message}", MsgBoxStyle.Critical, Text))
-                Else
-                    MsgBox($"Error compressing file ""{Path.GetFileName(strFilePath)}"": {ex.Message}", MsgBoxStyle.Critical, Text)
-                End If
-            Catch
-                ' Swallow any exceptions raised while reporting the error
-            End Try
-        End Try
-    End Sub
-
     Private Sub UncompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UncompressFileToolStripMenuItem.Click
         Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim fileName As String
@@ -666,11 +600,11 @@ Public Class ViewLogBackups
         If FileList.SelectedRows.Count > 1 Then
             For Each item As DataGridViewRow In FileList.SelectedRows
                 fileName = Path.Combine(strPathToDataBackupFolder, item.Cells(0).Value)
-                UncompressFile(fileName)
+                UncompressGZIPFile(fileName)
             Next
         Else
             fileName = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
-            UncompressFile(fileName)
+            UncompressGZIPFile(fileName)
         End If
 
         ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
@@ -688,23 +622,6 @@ Public Class ViewLogBackups
         Else
             fileName = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
             GZIPCompressFile(fileName)
-        End If
-
-        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
-    End Sub
-
-    Private Sub CompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CompressFileToolStripMenuItem.Click
-        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
-        Dim fileName As String
-
-        If FileList.SelectedRows.Count > 1 Then
-            For Each item As DataGridViewRow In FileList.SelectedRows
-                fileName = Path.Combine(strPathToDataBackupFolder, item.Cells(0).Value)
-                CompressFile(fileName)
-            Next
-        Else
-            fileName = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
-            CompressFile(fileName)
         End If
 
         ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
@@ -749,41 +666,6 @@ Public Class ViewLogBackups
             ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
         Else
             ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
-        End If
-    End Sub
-
-    ''' <summary>Returns the NTFS compressed size of a file on disk. Returns a -1 if an error occurs.</summary>
-    ''' <param name="fileName">Path to the file to get the size of.</param>
-    ''' <returns>A 64-bit Integer.</returns>
-    Private Shared Function GetCompressedSize(fileName As String) As Long
-        If Not File.Exists(fileName) Then Return -1
-
-        Dim high As UInteger = 0
-        Dim low As UInteger = NativeMethod.NativeMethods.GetCompressedFileSize(fileName, high)
-
-        If low = &HFFFFFFFFUI AndAlso Marshal.GetLastWin32Error() <> 0 Then
-            ' error, return -1 or throw exception
-            Return -1
-        End If
-
-        Return (CLng(high) << 32) + low
-    End Function
-
-    Private Sub UncompressFile(fileName As String)
-        If File.Exists(fileName) Then
-            If New FileInfo(fileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                UncompressGZIPFile(fileName)
-            Else
-                Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
-                    Dim comp As UShort = NativeMethod.NativeMethods.COMPRESSION_FORMAT_NONE
-                    Dim ptr As IntPtr = Marshal.AllocHGlobal(2)
-                    Marshal.WriteInt16(ptr, comp)
-
-                    NativeMethod.NativeMethods.DeviceIoControl(handle.SafeFileHandle, NativeMethod.NativeMethods.FSCTL_SET_COMPRESSION, ptr, 2, IntPtr.Zero, 0, Nothing, IntPtr.Zero)
-
-                    Marshal.FreeHGlobal(ptr)
-                End Using
-            End If
         End If
     End Sub
 
@@ -1072,14 +954,14 @@ Public Class ViewLogBackups
         ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
     End Sub
 
-    Private Sub ChkShowNTFSCompressionSizeDifference_Click(sender As Object, e As EventArgs) Handles ChkShowNTFSCompressionSizeDifference.Click
-        My.Settings.ShowNTFSCompressionSizeDifference = ChkShowNTFSCompressionSizeDifference.Checked
-        ChkShowNTFSCompressionSizeDifferencePercentage.Enabled = ChkShowNTFSCompressionSizeDifference.Checked
+    Private Sub ChkShowCompressionSizeDifference_Click(sender As Object, e As EventArgs) Handles ChkShowCompressionSizeDifference.Click
+        My.Settings.ShowCompressionSizeDifference = ChkShowCompressionSizeDifference.Checked
+        ChkShowCompressionSizeDifferencePercentage.Enabled = ChkShowCompressionSizeDifference.Checked
         ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
-    Private Sub ChkShowNTFSCompressionSizeDifferencePercentage_Click(sender As Object, e As EventArgs) Handles ChkShowNTFSCompressionSizeDifferencePercentage.Click
-        My.Settings.ShowNTFSCompressionSizeDifferencePercentage = ChkShowNTFSCompressionSizeDifferencePercentage.Checked
+    Private Sub ChkShowCompressionSizeDifferencePercentage_Click(sender As Object, e As EventArgs) Handles ChkShowCompressionSizeDifferencePercentage.Click
+        My.Settings.ShowCompressionSizeDifferencePercentage = ChkShowCompressionSizeDifferencePercentage.Checked
         ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -40,6 +40,24 @@ Public Class ViewLogBackups
         End If
     End Sub
 
+    Private Function GetEstimatedUncompressedSizeOfGZIPedFile(strPathToGZIPedLogFile As String) As Long
+        Try
+            Using fs As New FileStream(strPathToGZIPedLogFile, FileMode.Open, FileAccess.Read, FileShare.Read)
+                If fs.Length < 4 Then Return -1
+
+                fs.Seek(-4, SeekOrigin.End)
+
+                Dim sizeBytes(3) As Byte
+                fs.Read(sizeBytes, 0, 4)
+
+                ' GZIP stores ISIZE as little-endian UInt32
+                Return BitConverter.ToUInt32(sizeBytes, 0)
+            End Using
+        Catch ex As Exception
+            Return -1 ' Return -1 to indicate an error occurred
+        End Try
+    End Function
+
     Private Sub SortLogsByDateObject(columnIndex As Integer, order As SortOrder)
         SortLogsByDateObjectNoLocking(columnIndex, order)
     End Sub
@@ -64,9 +82,13 @@ Public Class ViewLogBackups
 
     Private Function GetEntryCount(strFileName As String) As Integer
         Try
-            Using fileStream As New StreamReader(strFileName)
-                Return Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles).Count
-            End Using
+            If New FileInfo(strFileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                Return Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(strFileName), JSONDecoderSettingsForLogFiles).Count
+            Else
+                Using fileStream As New StreamReader(strFileName)
+                    Return Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles).Count
+                End Using
+            End If
         Catch ex As Exception
             Return -1
         End Try
@@ -150,16 +172,29 @@ Public Class ViewLogBackups
                                                    For Each cell As DataGridViewCell In row.Cells
                                                        cell.Style.Font = My.Settings.font
                                                        If boolIsHidden AndAlso ChkShowHiddenAsGray.Checked Then cell.Style.ForeColor = Color.Gray
-                                                       If boolIsCompressed Then cell.Style.ForeColor = Color.Blue
+                                                       If boolIsCompressed Or file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then cell.Style.ForeColor = Color.Blue
                                                    Next
 
                                                    row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
-                                                   If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
-                                                       row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
-                                                       Interlocked.Increment(intNumberOfCompressedFiles)
+                                                   If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                       intCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
+
+                                                       If intCompresedSize <> -1 Then
+                                                           row.Cells(2).Value &= $" ({FileSizeToHumanSize(intCompresedSize)})"
+                                                           Interlocked.Increment(intNumberOfCompressedFiles)
+                                                           Interlocked.Add(longUsedDiskSpace, file.Length)
+                                                       Else
+                                                           row.Cells(2).Value &= " (Error)"
+                                                           Interlocked.Add(longUsedDiskSpace, file.Length)
+                                                       End If
                                                    Else
-                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
+                                                       If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
+                                                           row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
+                                                           Interlocked.Increment(intNumberOfCompressedFiles)
+                                                       Else
+                                                           Interlocked.Add(longUsedDiskSpace, file.Length)
+                                                       End If
                                                    End If
 
                                                    threadSafeListOfDataGridViewRows.Add(row)
@@ -383,29 +418,33 @@ Public Class ViewLogBackups
                                           Dim myDataGridRow As MyDataGridViewRow
 
                                           Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
-                                                                                 Using fileStream As New StreamReader(file.FullName)
-                                                                                     dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
+                                                                                 If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                                                     dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
+                                                                                 Else
+                                                                                     Using fileStream As New StreamReader(file.FullName)
+                                                                                         dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
+                                                                                     End Using
+                                                                                 End If
 
-                                                                                     For Each item As SavedData In dataFromFile
-                                                                                         If strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                                                                                             boolDoesLogMatchLimitedSearch = String.Equals(item.logType, strLimiter, StringComparison.OrdinalIgnoreCase)
-                                                                                         ElseIf strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                                                                                             boolDoesLogMatchLimitedSearch = String.Equals(item.appName, strLimiter, StringComparison.OrdinalIgnoreCase)
-                                                                                         Else
-                                                                                             boolDoesLogMatchLimitedSearch = True
-                                                                                         End If
+                                                                                 For Each item As SavedData In dataFromFile
+                                                                                     If strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                                                                                         boolDoesLogMatchLimitedSearch = String.Equals(item.logType, strLimiter, StringComparison.OrdinalIgnoreCase)
+                                                                                     ElseIf strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                                                                                         boolDoesLogMatchLimitedSearch = String.Equals(item.appName, strLimiter, StringComparison.OrdinalIgnoreCase)
+                                                                                     Else
+                                                                                         boolDoesLogMatchLimitedSearch = True
+                                                                                     End If
 
-                                                                                         If regexCompiledObject.IsMatch(item.log) And boolDoesLogMatchLimitedSearch Then
-                                                                                             myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
-                                                                                             myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
-                                                                                             myDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+                                                                                     If regexCompiledObject.IsMatch(item.log) And boolDoesLogMatchLimitedSearch Then
+                                                                                         myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
+                                                                                         myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
+                                                                                         myDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
 
-                                                                                             SyncLock listOfSearchResults ' Ensure thread safety
-                                                                                                 listOfSearchResults.Add(myDataGridRow)
-                                                                                             End SyncLock
-                                                                                         End If
-                                                                                     Next
-                                                                                 End Using
+                                                                                         SyncLock listOfSearchResults ' Ensure thread safety
+                                                                                             listOfSearchResults.Add(myDataGridRow)
+                                                                                         End SyncLock
+                                                                                     End If
+                                                                                 Next
                                                                              End Sub)
 
                                           For Each item As MyDataGridViewRow In listOfSearchResults
@@ -485,8 +524,9 @@ Public Class ViewLogBackups
             ViewToolStripMenuItem.Enabled = FileList.SelectedRows.Count <= 1
 
             Dim fileName As String = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
+            Dim fileInfo As New FileInfo(fileName)
 
-            If (New FileInfo(fileName).Attributes And FileAttributes.Hidden) = FileAttributes.Hidden Then
+            If (fileInfo.Attributes And FileAttributes.Hidden) = FileAttributes.Hidden Then
                 UnhideToolStripMenuItem.Visible = True
                 HideToolStripMenuItem.Visible = False
             Else
@@ -494,12 +534,20 @@ Public Class ViewLogBackups
                 HideToolStripMenuItem.Visible = True
             End If
 
-            If (New FileInfo(fileName).Attributes And FileAttributes.Compressed) = FileAttributes.Compressed Then
+            If (fileInfo.Attributes And FileAttributes.Compressed) = FileAttributes.Compressed Then
                 UncompressFileToolStripMenuItem.Visible = True
                 CompressFileToolStripMenuItem.Visible = False
             Else
                 UncompressFileToolStripMenuItem.Visible = False
                 CompressFileToolStripMenuItem.Visible = True
+            End If
+
+            If fileInfo.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                GZIPCompressFileToolStripMenuItem.Visible = False
+                UncompressFileToolStripMenuItem.Visible = True
+                CompressFileToolStripMenuItem.Visible = False
+            Else
+                GZIPCompressFileToolStripMenuItem.Visible = True
             End If
         Else
             DeleteToolStripMenuItem.Enabled = False
@@ -524,6 +572,88 @@ Public Class ViewLogBackups
         ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
     End Sub
 
+    Private Sub UncompressGZIPFile(strFilePath As String)
+        If String.IsNullOrWhiteSpace(strFilePath) Then Exit Sub
+        If Not File.Exists(strFilePath) Then Exit Sub
+
+        Try
+            If Not strFilePath.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) Then
+                ' File isn't a GZIP file based on extension.
+                Exit Sub
+            End If
+
+            Dim strUncompressedFilePath As String = strFilePath.Substring(0, strFilePath.Length - 3)
+            Dim strUncompressedData As String = GetTextContentsFromGZIPedLogFile(strFilePath)
+
+            WriteFileAtomically(strUncompressedFilePath, strUncompressedData)
+
+            ' Preserve timestamps (best-effort)
+            Try
+                File.SetCreationTimeUtc(strUncompressedFilePath, File.GetCreationTimeUtc(strFilePath))
+                File.SetLastWriteTimeUtc(strUncompressedFilePath, File.GetLastWriteTimeUtc(strFilePath))
+            Catch
+                ' Ignore timestamp preservation failures
+            End Try
+
+            ' Remove the original file after successful compression
+            File.Delete(strFilePath)
+        Catch ex As Exception
+            Try
+                If InvokeRequired Then
+                    Invoke(Sub() MsgBox($"Error compressing file ""{Path.GetFileName(strFilePath)}"": {ex.Message}", MsgBoxStyle.Critical, Text))
+                Else
+                    MsgBox($"Error compressing file ""{Path.GetFileName(strFilePath)}"": {ex.Message}", MsgBoxStyle.Critical, Text)
+                End If
+            Catch
+                ' Swallow any exceptions raised while reporting the error
+            End Try
+        End Try
+    End Sub
+
+    Private Sub GZIPCompressFile(strFilePath As String)
+        If String.IsNullOrWhiteSpace(strFilePath) Then Exit Sub
+        If Not File.Exists(strFilePath) Then Exit Sub
+
+        Try
+            If strFilePath.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) Then
+                ' Already compressed with .gz extension
+                Exit Sub
+            End If
+
+            Dim strCompressedFilePath As String = strFilePath & ".gz"
+
+            ' Compress source file into .gz
+            Using sourceStream As FileStream = File.Open(strFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
+                Using destinationStream As FileStream = File.Create(strCompressedFilePath)
+                    Using gzipStream As New Compression.GZipStream(destinationStream, Compression.CompressionLevel.Optimal)
+                        sourceStream.CopyTo(gzipStream)
+                    End Using
+                End Using
+            End Using
+
+            ' Preserve timestamps (best-effort)
+            Try
+                File.SetCreationTimeUtc(strCompressedFilePath, File.GetCreationTimeUtc(strFilePath))
+                File.SetLastWriteTimeUtc(strCompressedFilePath, File.GetLastWriteTimeUtc(strFilePath))
+            Catch
+                ' Ignore timestamp preservation failures
+            End Try
+
+            ' Remove the original file after successful compression
+            File.Delete(strFilePath)
+        Catch ex As Exception
+            Try
+                If InvokeRequired Then
+                    Invoke(Sub() MsgBox($"Error compressing file ""{Path.GetFileName(strFilePath)}"": {ex.Message}", MsgBoxStyle.Critical, Text))
+                Else
+                    MsgBox($"Error compressing file ""{Path.GetFileName(strFilePath)}"": {ex.Message}", MsgBoxStyle.Critical, Text)
+                End If
+            Catch
+                ' Swallow any exceptions raised while reporting the error
+            End Try
+        End Try
+    End Sub
+
     Private Sub UncompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles UncompressFileToolStripMenuItem.Click
         Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim fileName As String
@@ -536,6 +666,23 @@ Public Class ViewLogBackups
         Else
             fileName = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
             UncompressFile(fileName)
+        End If
+
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
+    End Sub
+
+    Private Sub GZIPCompressFileToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles GZIPCompressFileToolStripMenuItem.Click
+        Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
+        Dim fileName As String
+
+        If FileList.SelectedRows.Count > 1 Then
+            For Each item As DataGridViewRow In FileList.SelectedRows
+                fileName = Path.Combine(strPathToDataBackupFolder, item.Cells(0).Value)
+                GZIPCompressFile(fileName)
+            Next
+        Else
+            fileName = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
+            GZIPCompressFile(fileName)
         End If
 
         ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
@@ -619,15 +766,19 @@ Public Class ViewLogBackups
 
     Private Sub UncompressFile(fileName As String)
         If File.Exists(fileName) Then
-            Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
-                Dim comp As UShort = NativeMethod.NativeMethods.COMPRESSION_FORMAT_NONE
-                Dim ptr As IntPtr = Marshal.AllocHGlobal(2)
-                Marshal.WriteInt16(ptr, comp)
+            If New FileInfo(fileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                UncompressGZIPFile(fileName)
+            Else
+                Using handle As FileStream = File.Open(fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+                    Dim comp As UShort = NativeMethod.NativeMethods.COMPRESSION_FORMAT_NONE
+                    Dim ptr As IntPtr = Marshal.AllocHGlobal(2)
+                    Marshal.WriteInt16(ptr, comp)
 
-                NativeMethod.NativeMethods.DeviceIoControl(handle.SafeFileHandle, NativeMethod.NativeMethods.FSCTL_SET_COMPRESSION, ptr, 2, IntPtr.Zero, 0, Nothing, IntPtr.Zero)
+                    NativeMethod.NativeMethods.DeviceIoControl(handle.SafeFileHandle, NativeMethod.NativeMethods.FSCTL_SET_COMPRESSION, ptr, 2, IntPtr.Zero, 0, Nothing, IntPtr.Zero)
 
-                Marshal.FreeHGlobal(ptr)
-            End Using
+                    Marshal.FreeHGlobal(ptr)
+                End Using
+            End If
         End If
     End Sub
 
@@ -757,33 +908,37 @@ Public Class ViewLogBackups
                                       Dim boolDidWeHaveAMatch As Boolean = False
 
                                       Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
-                                                                             Using fileStream As New StreamReader(file.FullName)
-                                                                                 dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
+                                                                             If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                                                 dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
+                                                                             Else
+                                                                                 Using fileStream As New StreamReader(file.FullName)
+                                                                                     dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
+                                                                                 End Using
+                                                                             End If
 
-                                                                                 For Each item As SavedData In dataFromFile
-                                                                                     If strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                                                                                         boolDidWeHaveAMatch = String.Equals(item.logType, strLimiter, StringComparison.OrdinalIgnoreCase)
-                                                                                     ElseIf strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                                                                                         boolDidWeHaveAMatch = String.Equals(item.appName, strLimiter, StringComparison.OrdinalIgnoreCase)
-                                                                                     ElseIf strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-                                                                                         boolDidWeHaveAMatch = String.Equals(item.hostname, strLimiter, StringComparison.OrdinalIgnoreCase)
-                                                                                     ElseIf strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
-                                                                                         boolDidWeHaveAMatch = String.Equals(item.ip, strLimiter, StringComparison.OrdinalIgnoreCase)
-                                                                                     End If
+                                                                             For Each item As SavedData In dataFromFile
+                                                                                 If strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                                                                                     boolDidWeHaveAMatch = String.Equals(item.logType, strLimiter, StringComparison.OrdinalIgnoreCase)
+                                                                                 ElseIf strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                                                                                     boolDidWeHaveAMatch = String.Equals(item.appName, strLimiter, StringComparison.OrdinalIgnoreCase)
+                                                                                 ElseIf strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                                                                                     boolDidWeHaveAMatch = String.Equals(item.hostname, strLimiter, StringComparison.OrdinalIgnoreCase)
+                                                                                 ElseIf strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
+                                                                                     boolDidWeHaveAMatch = String.Equals(item.ip, strLimiter, StringComparison.OrdinalIgnoreCase)
+                                                                                 End If
 
-                                                                                     If boolDidWeHaveAMatch Then
-                                                                                         myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
-                                                                                         myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
-                                                                                         myDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+                                                                                 If boolDidWeHaveAMatch Then
+                                                                                     myDataGridRow = item.MakeDataGridRow(searchResultsWindow.Logs)
+                                                                                     myDataGridRow.Cells(ColumnIndex_FileName).Value = file.Name
+                                                                                     myDataGridRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
 
-                                                                                         SyncLock listOfSearchResults ' Ensure thread safety
-                                                                                             listOfSearchResults.Add(myDataGridRow)
-                                                                                         End SyncLock
-                                                                                     End If
+                                                                                     SyncLock listOfSearchResults ' Ensure thread safety
+                                                                                         listOfSearchResults.Add(myDataGridRow)
+                                                                                     End SyncLock
+                                                                                 End If
 
-                                                                                     boolDidWeHaveAMatch = False
-                                                                                 Next
-                                                                             End Using
+                                                                                 boolDidWeHaveAMatch = False
+                                                                             Next
                                                                          End Sub)
 
                                       For Each item As MyDataGridViewRow In listOfSearchResults
@@ -852,8 +1007,14 @@ Public Class ViewLogBackups
     Private Sub RenameToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles RenameToolStripMenuItem.Click
         Dim intOldIndex As Integer = FileList.SelectedRows(0).Index
         Dim strOldFileName As String = FileList.SelectedRows(0).Cells(0).Value.ToString()
-        Dim strOldFileNameFullPath As String = Path.Combine(strPathToDataBackupFolder, strOldFileName)
+        Dim boolIsGZIPFile As Boolean = False
 
+        If strOldFileName.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) Then
+            boolIsGZIPFile = True
+            strOldFileName = strOldFileName.Substring(0, strOldFileName.Length - 3)
+        End If
+
+        Dim strOldFileNameFullPath As String = Path.Combine(strPathToDataBackupFolder, strOldFileName)
         Dim strNewFileName As String = InputBox("Enter the new name for the selected file:", "Rename File", strOldFileName)
 
         If String.IsNullOrWhiteSpace(strNewFileName) Then
@@ -876,6 +1037,10 @@ Public Class ViewLogBackups
             Exit Sub
         End If
 
+        If boolIsGZIPFile AndAlso Not strNewFileName.EndsWith(".gz", StringComparison.OrdinalIgnoreCase) Then
+            strNewFileName &= ".gz"
+        End If
+
         Dim strNewFileNameFullPath As String = Path.Combine(strPathToDataBackupFolder, strNewFileName)
 
         ' Ensure user didn't re-enter the same name
@@ -891,7 +1056,11 @@ Public Class ViewLogBackups
         End If
 
         ' Finally rename
-        File.Move(strOldFileNameFullPath, strNewFileNameFullPath)
+        If boolIsGZIPFile Then
+            File.Move(strOldFileNameFullPath & ".gz", strNewFileNameFullPath)
+        Else
+            File.Move(strOldFileNameFullPath, strNewFileNameFullPath)
+        End If
 
         MsgBox("File renamed successfully.", MsgBoxStyle.Information, Text)
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -194,7 +194,7 @@ Public Class ViewLogBackups
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
                                                    Else
                                                        If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
-                                                           row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"
+                                                           row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
                                                            Interlocked.Increment(intNumberOfCompressedFiles)
                                                        Else
                                                            Interlocked.Add(longUsedDiskSpace, file.Length)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -157,7 +157,18 @@ Public Class ViewLogBackups
                                                        .Cells(1).Value = $"{file.LastWriteTime:D} {file.LastWriteTime:T}"
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
-                                                       .Cells(2).Value = FileSizeToHumanSize(file.Length)
+                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                           intCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
+
+                                                           If intCompresedSize <> -1 Then
+                                                               row.Cells(2).Value = FileSizeToHumanSize(intCompresedSize)
+                                                           Else
+                                                               row.Cells(2).Value = "Error"
+                                                           End If
+                                                       Else
+                                                           .Cells(2).Value = FileSizeToHumanSize(file.Length)
+                                                       End If
+
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        .Cells(3).Value = $"{intCount:N0}"
@@ -178,19 +189,12 @@ Public Class ViewLogBackups
                                                    row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
                                                    If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                                                       intCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
-
-                                                       If intCompresedSize <> -1 Then
-                                                           row.Cells(2).Value &= $" ({FileSizeToHumanSize(intCompresedSize)})"
-                                                           Interlocked.Increment(intNumberOfCompressedFiles)
-                                                           Interlocked.Add(longUsedDiskSpace, file.Length)
-                                                       Else
-                                                           row.Cells(2).Value &= " (Error)"
-                                                           Interlocked.Add(longUsedDiskSpace, file.Length)
-                                                       End If
+                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"
+                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
+                                                       Interlocked.Increment(intNumberOfCompressedFiles)
                                                    Else
                                                        If boolIsCompressed AndAlso ChkShowNTFSCompressionSizeDifference.Checked Then
-                                                           row.Cells(2).Value &= $" ({GetNTFSFileCompressionInfo(file, longUsedDiskSpace)})"
+                                                           row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"
                                                            Interlocked.Increment(intNumberOfCompressedFiles)
                                                        Else
                                                            Interlocked.Add(longUsedDiskSpace, file.Length)

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -338,10 +338,10 @@
             <setting name="IncludeCommasInDHMS" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="ShowNTFSCompressionSizeDifference" serializeAs="String">
+            <setting name="ShowCompressionSizeDifference" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="ShowNTFSCompressionSizeDifferencePercentage" serializeAs="String">
+            <setting name="ShowCompressionSizeDifferencePercentage" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="CompressBackupLogFiles" serializeAs="String">


### PR DESCRIPTION
- Added support for a {NewLine} command for alerts. This function supports both {CrLf} and {NL}.
- Fixed placement of windows when opening it with the StartPosition equal to FormStartPosition.CenterParent. This was fixed by loading the previous window size before opening the window.
- Added a call to CenterFormOverParent() to the Open Explorer dialog box.
- Completely replaced NTFS compression with GZIP-based compression resulting in much better compression, sometimes north of 90% compression ratios.
- Tweaked some code used in the FindKeyInDictionaryAndReturnIt() function that's used by the program when importing settings from a setting JSON export file.
- Added the ability to export selected items when searching the log data to the "Ignored Logs and Search Results" window.
- Added a label at the bottom of the "Ignored Logs and Search Results" window to indicate how many items in the logs list you have selected.

Anyone that once used the "Compress Log Backups" setting will need to set that setting again since the back-end variable used to store that preference was changed in the program's setting data.