### PR TITLE
Version 5.3 Build 2

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -58,12 +58,6 @@ Namespace My
                 Settings.logFileLocation = Nothing
             End If
 
-            If IO.File.Exists(strUpdaterEXE) Then
-                ProcessHandling.SearchForProcessAndKillIt(strUpdaterEXE, False)
-                IO.File.Delete(strUpdaterEXE)
-                If IO.File.Exists(strUpdaterPDB) Then IO.File.Delete(strUpdaterPDB)
-            End If
-
             mutex = New Threading.Mutex(True, strMutexName, boolDoWeOwnTheMutex)
 
             If Not boolDoWeOwnTheMutex And Not Debugger.IsAttached Then

--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -30,12 +30,6 @@ Namespace My
                 ' Mark as not the first run
                 My.Settings.FirstRun = False
                 My.Settings.Save()
-
-                ' Delete the backup file if it exists
-                If IO.File.Exists(strPathToConfigBackupFile) Then IO.File.Delete(strPathToConfigBackupFile)
-            Else
-                ' If not the first run, delete the backup file if it exists
-                If IO.File.Exists(strPathToConfigBackupFile) Then IO.File.Delete(strPathToConfigBackupFile)
             End If
 
             If Not Debugger.IsAttached Then

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.3.1.120")>
+<Assembly: AssemblyFileVersion("5.3.2.121")>

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1722,6 +1722,13 @@ Public Class Form1
                     listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting temporary settings backup file.", Logs))
                 End If
 
+                If File.Exists(strUpdaterEXE) Then
+                    ProcessHandling.SearchForProcessAndKillIt(strUpdaterEXE, False)
+                    File.Delete(strUpdaterEXE)
+                    If File.Exists(strUpdaterPDB) Then File.Delete(strUpdaterPDB)
+                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting updater module.", Logs))
+                End If
+
                 SyncLock dataGridLockObject
                     Invoke(Sub()
                                Logs.SuspendLayout()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1716,6 +1716,12 @@ Public Class Form1
                     listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry($"Free SysLog Server Started. Data loaded in {MyRoundingFunction(stopwatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds.", Logs))
                 End If
 
+                ' Delete the backup file if it exists
+                If File.Exists(strPathToConfigBackupFile) Then
+                    File.Delete(strPathToConfigBackupFile)
+                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting temporary settings backup file.", Logs))
+                End If
+
                 SyncLock dataGridLockObject
                     Invoke(Sub()
                                Logs.SuspendLayout()


### PR DESCRIPTION
Minor tweaks to the code.

Anyone that once used the "Compress Log Backups" setting will need to set that setting again since the back-end variable used to store that preference was changed in the program's setting data.