### PR TITLE
Version 5.3 Build 3

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.3.2.121")>
+<Assembly: AssemblyFileVersion("5.3.3.122")>

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1716,18 +1716,26 @@ Public Class Form1
                     listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry($"Free SysLog Server Started. Data loaded in {MyRoundingFunction(stopwatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds.", Logs))
                 End If
 
-                ' Delete the backup file if it exists
-                If File.Exists(strPathToConfigBackupFile) Then
-                    File.Delete(strPathToConfigBackupFile)
-                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting temporary settings backup file.", Logs))
-                End If
+                Try
+                    ' Delete the backup file if it exists
+                    If File.Exists(strPathToConfigBackupFile) Then
+                        File.Delete(strPathToConfigBackupFile)
+                        listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting temporary settings backup file.", Logs))
+                    End If
+                Catch ex As Exception
+                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Unable to delete the temporary settings backup file.", Logs))
+                End Try
 
-                If File.Exists(strUpdaterEXE) Then
-                    ProcessHandling.SearchForProcessAndKillIt(strUpdaterEXE, False)
-                    File.Delete(strUpdaterEXE)
-                    If File.Exists(strUpdaterPDB) Then File.Delete(strUpdaterPDB)
-                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting updater module.", Logs))
-                End If
+                Try
+                    If File.Exists(strUpdaterEXE) Then
+                        ProcessHandling.SearchForProcessAndKillIt(strUpdaterEXE, False)
+                        File.Delete(strUpdaterEXE)
+                        If File.Exists(strUpdaterPDB) Then File.Delete(strUpdaterPDB)
+                        listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting updater module.", Logs))
+                    End If
+                Catch ex As Exception
+                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Unable to delete the updater module.", Logs))
+                End Try
 
                 SyncLock dataGridLockObject
                     Invoke(Sub()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1716,27 +1716,6 @@ Public Class Form1
                     listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry($"Free SysLog Server Started. Data loaded in {MyRoundingFunction(stopwatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds.", Logs))
                 End If
 
-                Try
-                    ' Delete the backup file if it exists
-                    If File.Exists(strPathToConfigBackupFile) Then
-                        File.Delete(strPathToConfigBackupFile)
-                        listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting temporary settings backup file.", Logs))
-                    End If
-                Catch ex As Exception
-                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Unable to delete the temporary settings backup file.", Logs))
-                End Try
-
-                Try
-                    If File.Exists(strUpdaterEXE) Then
-                        ProcessHandling.SearchForProcessAndKillIt(strUpdaterEXE, False)
-                        File.Delete(strUpdaterEXE)
-                        If File.Exists(strUpdaterPDB) Then File.Delete(strUpdaterPDB)
-                        listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting updater module.", Logs))
-                    End If
-                Catch ex As Exception
-                    listOfLogEntries.Add(SyslogParser.MakeLocalDataGridRowEntry("Unable to delete the updater module.", Logs))
-                End Try
-
                 SyncLock dataGridLockObject
                     Invoke(Sub()
                                Logs.SuspendLayout()
@@ -2321,6 +2300,37 @@ Public Class Form1
                 MsgBox(strLogText, MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
             End If
         End If
+
+        Try
+            ' Delete the backup file if it exists
+            If File.Exists(strPathToConfigBackupFile) Then
+                File.Delete(strPathToConfigBackupFile)
+
+                SyncLock dataGridLockObject
+                    Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting temporary settings backup file.", Logs))
+                End SyncLock
+            End If
+        Catch ex As Exception
+            SyncLock dataGridLockObject
+                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Unable to delete the temporary settings backup file.", Logs))
+            End SyncLock
+        End Try
+
+        Try
+            If File.Exists(strUpdaterEXE) Then
+                ProcessHandling.SearchForProcessAndKillIt(strUpdaterEXE, False)
+                File.Delete(strUpdaterEXE)
+                If File.Exists(strUpdaterPDB) Then File.Delete(strUpdaterPDB)
+
+                SyncLock dataGridLockObject
+                    Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Deleting updater module.", Logs))
+                End SyncLock
+            End If
+        Catch ex As Exception
+            SyncLock dataGridLockObject
+                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry("Unable to delete the updater module.", Logs))
+            End SyncLock
+        End Try
     End Sub
 #End Region
 End Class


### PR DESCRIPTION
Minor tweaks to the code.

Anyone that once used the "Compress Log Backups" setting will need to set that setting again since the back-end variable used to store that preference was changed in the program's setting data.