### PR TITLE
Version 5.3 Build 4

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.3.3.122")>
+<Assembly: AssemblyFileVersion("5.3.4.123")>

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -150,7 +150,7 @@ Namespace SyslogParser
 
                 Return (facilityDescription, severityDescription)
             Else
-                Return (Nothing, Nothing)
+                Return ("No Facility", "No Severity")
             End If
         End Function
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -119,6 +119,10 @@ Namespace SyslogParser
         End Sub
 
         Private Function GetSeverityAndFacility(strPriority As String) As (Facility As String, Severity As String)
+            If String.IsNullOrWhiteSpace(strPriority) Then
+                Return ("No Facility", "No Severity")
+            End If
+
             strPriority = strPriority.Replace("<", "").Replace(">", "").Trim
 
             Dim priorityNumber As Integer


### PR DESCRIPTION
This is a minor update that fixes an edge case where an incoming log message does not contain a severity flag.

- Added a null check to the GetSeverityAndFacility() function that returns a ("No Facility", "No Severity") tuple.
- The GetSeverityAndFacility() function now returns a proper tuple value if it can't parse the Integer, namely ("No Facility", "No Severity").