### PR TITLE
Version 5.4 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.3.4.123")>
+<Assembly: AssemblyFileVersion("5.4.1.124")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1424,6 +1424,18 @@ Namespace My
                 Me("CompressBackupLogFiles") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property ClearIgnoredStatsAtMidnight() As Boolean
+            Get
+                Return CType(Me("ClearIgnoredStatsAtMidnight"),Boolean)
+            End Get
+            Set
+                Me("ClearIgnoredStatsAtMidnight") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -347,5 +347,8 @@
     <Setting Name="CompressBackupLogFiles" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ClearIgnoredStatsAtMidnight" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -36,8 +36,6 @@ Public Class SavedData
                 .Cells(ColumnIndex_ComputedTime).Style = DataGridViewCellStyle_ComputedCell
                 .Cells(ColumnIndex_Alerted).Style = DataGridViewCellStyle_AlertedCell
             End If
-
-            .DefaultCellStyle.Padding = DataGridViewPadding
         End With
 
         Return MyDataGridViewRow

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -147,7 +147,7 @@ Public Class IgnoredClass
             sinceLastEvent = currentDate - dateLastEvent
             listViewItem.timeSpanOfLastOccurrence = sinceLastEvent
             listViewItem.dateOfLastOccurrence = dateLastEvent
-            listViewItem.SubItems.Add($"{dateLastEvent.ToLocalTime.ToLongDateString} {dateLastEvent.ToLocalTime.ToLongTimeString}")
+            listViewItem.SubItems.Add($"{dateLastEvent.ToLocalTime:D} {dateLastEvent.ToLocalTime:T}")
             listViewItem.SubItems.Add(TimespanToHMS(sinceLastEvent))
         Else
             listViewItem.SubItems.Add("")

--- a/Free SysLog/Support Code/My Data Classes.vb
+++ b/Free SysLog/Support Code/My Data Classes.vb
@@ -17,15 +17,12 @@ Public Class SavedData
         With MyDataGridViewRow
             .CreateCells(dataGrid)
             .Cells(ColumnIndex_ComputedTime).Value = Date.Parse(time)
-            .Cells(ColumnIndex_ComputedTime).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
             .Cells(ColumnIndex_LogType).Value = If(String.IsNullOrWhiteSpace(logType), "", logType)
             .Cells(ColumnIndex_IPAddress).Value = ip
             .Cells(ColumnIndex_RemoteProcess).Value = If(String.IsNullOrWhiteSpace(appName), "", appName)
             .Cells(ColumnIndex_Hostname).Value = If(String.IsNullOrWhiteSpace(hostname), "", hostname)
             .Cells(ColumnIndex_LogText).Value = log
             .Cells(ColumnIndex_Alerted).Value = If(BoolAlerted, "Yes", "No")
-            .Cells(ColumnIndex_Alerted).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-            .Cells(ColumnIndex_Alerted).Style.WrapMode = DataGridViewTriState.True
             .Cells(ColumnIndex_ServerTime).Value = If(ServerDate = Date.MinValue, "", ToIso8601Format(ServerDate))
             .DateObject = DateObject
             .BoolAlerted = BoolAlerted
@@ -35,17 +32,12 @@ Public Class SavedData
             .ServerDate = ServerDate
 
             If My.Settings.font IsNot Nothing Then
-                .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_LogType).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_IPAddress).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_RemoteProcess).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_Hostname).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_LogText).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_Alerted).Style.Font = My.Settings.font
-                .Cells(ColumnIndex_ServerTime).Style.Font = My.Settings.font
+                .DefaultCellStyle = DataGridViewCellStyle
+                .Cells(ColumnIndex_ComputedTime).Style = DataGridViewCellStyle_ComputedCell
+                .Cells(ColumnIndex_Alerted).Style = DataGridViewCellStyle_AlertedCell
             End If
 
-            .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+            .DefaultCellStyle.Padding = DataGridViewPadding
         End With
 
         Return MyDataGridViewRow

--- a/Free SysLog/Support Code/MyDataGridViewRow.vb
+++ b/Free SysLog/Support Code/MyDataGridViewRow.vb
@@ -8,6 +8,7 @@
     Public Property AlertText As String
     Public Property alertType As AlertType
     Public Property IgnoredPattern As String
+    Public Property GUID As Guid
 
     Public Sub UncheckRow()
         Me.Cells("colDelete").Value = False

--- a/Free SysLog/Support Code/Namespace Code/Data Handling.vb
+++ b/Free SysLog/Support Code/Namespace Code/Data Handling.vb
@@ -58,7 +58,7 @@ Namespace DataHandling
                         Using memoryStream As New MemoryStream
                             Dim xmlSerializerObject As New Xml.Serialization.XmlSerializer(collectionOfSavedData.GetType)
                             xmlSerializerObject.Serialize(memoryStream, collectionOfSavedData)
-                            WriteFileAtomically(saveFileDialog.FileName, memoryStream.ToArray())
+                            WriteFileAtomically(saveFileDialog.FileName, memoryStream)
                         End Using
                     ElseIf fileInfo.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) Then
                         WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))
@@ -140,7 +140,7 @@ Namespace DataHandling
                         Using memoryStream As New MemoryStream
                             Dim xmlSerializerObject As New Xml.Serialization.XmlSerializer(collectionOfSavedData.GetType)
                             xmlSerializerObject.Serialize(memoryStream, collectionOfSavedData)
-                            WriteFileAtomically(saveFileDialog.FileName, memoryStream.ToArray())
+                            WriteFileAtomically(saveFileDialog.FileName, memoryStream)
                         End Using
                     ElseIf fileInfo.Extension.Equals(".json", StringComparison.OrdinalIgnoreCase) Then
                         WriteFileAtomically(saveFileDialog.FileName, Newtonsoft.Json.JsonConvert.SerializeObject(collectionOfSavedData, Newtonsoft.Json.Formatting.Indented))

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -5,7 +5,7 @@
         ' Time after which an unused entry is considered stale (in minutes)
         Private Const CleanupThresholdInMinutes As Integer = 10
 
-        Public Sub ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
+        Public Sub ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType, rowGUID As Guid)
             ' Get the current time
             Dim currentTime As Date = Date.Now
 
@@ -24,7 +24,7 @@
             ' Update the last shown time for this message
             lastNotificationTime(tipText) = currentTime
 
-            SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alertType)
+            SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alertType, rowGUID)
         End Sub
 
         ' Function to clean up old notification entries

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -102,6 +102,11 @@ Namespace SupportCode
         Public recentUniqueObjects As uniqueObjectsClass
         Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()
 
+        Public DataGridViewCellStyle As DataGridViewCellStyle
+        Public DataGridViewCellStyle_ComputedCell As DataGridViewCellStyle
+        Public DataGridViewCellStyle_AlertedCell As DataGridViewCellStyle
+        Public DataGridViewPadding As New Padding(0, 2, 0, 2)
+
         Public WriteOnly Property AskOpenExplorer As Boolean
             Set(value As Boolean)
                 My.Settings.AskOpenExplorer = value

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -503,7 +503,7 @@ Namespace SupportCode
             End If
         End Function
 
-        Public Sub ShowToastNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType)
+        Public Sub ShowToastNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType, rowGUID As Guid)
             Dim strIconPath As String = Nothing
             Dim notification As New ToastContentBuilder()
 
@@ -519,9 +519,7 @@ Namespace SupportCode
             End If
 
             If My.Settings.IncludeButtonsOnNotifications Then
-                Dim strNotificationPacket As String = Newtonsoft.Json.JsonConvert.SerializeObject(New NotificationDataPacket With {.alerttext = tipText, .logdate = strLogDate, .logtext = strLogText, .sourceip = strSourceIP, .rawlogtext = strRawLogText, .alertType = alertType})
-
-                notification.AddButton(New ToastButton().SetContent("View Log").AddArgument("action", strViewLog).AddArgument("datapacket", strNotificationPacket))
+                notification.AddButton(New ToastButton().SetContent("View Log").AddArgument("action", strViewLog).AddArgument("guid", rowGUID.ToString))
                 notification.AddButton(New ToastButton().SetContent("Open SysLog").AddArgument("action", strOpenSysLog))
                 If My.Settings.ShowCloseButtonOnNotifications Then notification.AddButton(New ToastButton().SetContent("Close").SetDismissActivation())
             Else

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -105,7 +105,6 @@ Namespace SupportCode
         Public DataGridViewCellStyle As DataGridViewCellStyle
         Public DataGridViewCellStyle_ComputedCell As DataGridViewCellStyle
         Public DataGridViewCellStyle_AlertedCell As DataGridViewCellStyle
-        Public DataGridViewPadding As New Padding(0, 2, 0, 2)
 
         Public WriteOnly Property AskOpenExplorer As Boolean
             Set(value As Boolean)

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -198,11 +198,15 @@ Namespace SupportCode
             File.Delete(strFilePath)
         End Sub
 
-        Public Sub WriteFileAtomically(path As String, contents As Byte())
+        Public Sub WriteFileAtomically(path As String, source As Stream)
             Dim tmpPath As String = path & ".tmp"
 
             Try
-                File.WriteAllBytes(tmpPath, contents)
+                If source.CanSeek Then source.Position = 0
+
+                Using fileStream As New FileStream(tmpPath, FileMode.Create, FileAccess.Write, FileShare.None)
+                    source.CopyTo(fileStream)
+                End Using
 
                 If File.Exists(path) Then
                     File.Replace(tmpPath, path, Nothing)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -14,6 +14,8 @@ Namespace SyslogParser
         Private ReadOnly embeddedCommandParsingRegEx As New Regex("([A-Z_][A-Z0-9_]*)\(([^()]*)\)", RegexOptions.Compiled)
         Private ReadOnly embeddedCommandParsingCheck As New Regex("\b(UPPER(?:CASE)?|LOWER(?:CASE)?|TRIM|NSLOOKUP)\(", RegexOptions.Compiled Or RegexOptions.IgnoreCase)
 
+        Private ReadOnly TimeStampOffsetRegexMatch As New Regex("[+-]\d{2}:\d{2}$", RegexOptions.Compiled)
+
         Private ReadOnly NumberRemovingRegex As New Regex("([A-Za-z-]*)\[[0-9]*\]", RegexOptions.Compiled)
         Private ReadOnly SyslogPreProcessor1 As New Regex("\d+ (<\d+>)", RegexOptions.Compiled)
         Private ReadOnly SyslogPreProcessor2 As New Regex("(<\d+>)", RegexOptions.Compiled)
@@ -193,7 +195,7 @@ Namespace SyslogParser
         ''' <summary>Checks if timestamp contains a timezone offset indicator.</summary>
         Private Function HasTimezoneOffset(timestamp As String) As Boolean
             ' Look for timezone offset pattern like +05:30 or -08:00 at the end
-            Return System.Text.RegularExpressions.Regex.IsMatch(timestamp, "[+-]\d{2}:\d{2}$")
+            Return TimeStampOffsetRegexMatch.IsMatch(timestamp)
         End Function
 
         ''' <summary>Parses UTC timestamp ending with 'Z'.</summary>

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -35,7 +35,7 @@ Namespace SyslogParser
                                    AlertType:=AlertType.None,
                                    dataGrid:=dataGrid)
 
-            MyDataGridViewRow.DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+            MyDataGridViewRow.DefaultCellStyle.Padding = DataGridViewPadding
             Return MyDataGridViewRow
         End Function
 
@@ -44,7 +44,6 @@ Namespace SyslogParser
                 With MyDataGridViewRow
                     .CreateCells(dataGrid)
                     .Cells(ColumnIndex_ComputedTime).Value = Date.Parse(strTime)
-                    .Cells(ColumnIndex_ComputedTime).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
                     .Cells(ColumnIndex_LogType).Value = If(String.IsNullOrWhiteSpace(strLogType), "", strLogType)
                     .Cells(ColumnIndex_IPAddress).Value = strSourceAddress
                     .Cells(ColumnIndex_RemoteProcess).Value = If(String.IsNullOrWhiteSpace(strRemoteProcess), "", strRemoteProcess)
@@ -52,8 +51,6 @@ Namespace SyslogParser
                     .Cells(ColumnIndex_ServerTime).Value = ToIso8601Format(serverTimeStamp)
                     .Cells(ColumnIndex_LogText).Value = strLog
                     .Cells(ColumnIndex_Alerted).Value = If(boolAlerted, "Yes", "No")
-                    .Cells(ColumnIndex_Alerted).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-                    .Cells(ColumnIndex_Alerted).Style.WrapMode = DataGridViewTriState.True
                     .DateObject = dateObject
                     .BoolAlerted = boolAlerted
                     .ServerDate = serverTimeStamp
@@ -62,17 +59,12 @@ Namespace SyslogParser
                     .alertType = AlertType
 
                     If My.Settings.font IsNot Nothing Then
-                        .Cells(ColumnIndex_ComputedTime).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_LogType).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_IPAddress).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_RemoteProcess).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_Hostname).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_LogText).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_Alerted).Style.Font = My.Settings.font
-                        .Cells(ColumnIndex_ServerTime).Style.Font = My.Settings.font
+                        .DefaultCellStyle = DataGridViewCellStyle
+                        .Cells(ColumnIndex_Alerted).Style = DataGridViewCellStyle_AlertedCell
+                        .Cells(ColumnIndex_ComputedTime).Style = DataGridViewCellStyle_ComputedCell
                     End If
 
-                    .DefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+                    .DefaultCellStyle.Padding = DataGridViewPadding
                 End With
 
                 Return MyDataGridViewRow

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -35,40 +35,37 @@ Namespace SyslogParser
                                    AlertType:=AlertType.None,
                                    dataGrid:=dataGrid)
 
-            MyDataGridViewRow.DefaultCellStyle.Padding = DataGridViewPadding
             Return MyDataGridViewRow
         End Function
 
         Public Function MakeDataGridRow(serverTimeStamp As Date, dateObject As Date, strTime As String, strSourceAddress As String, strHostname As String, strRemoteProcess As String, strLog As String, strLogType As String, boolAlerted As Boolean, strRawLogText As String, strAlertText As String, AlertType As AlertType, ByRef dataGrid As DataGridView) As MyDataGridViewRow
-            Using MyDataGridViewRow As New MyDataGridViewRow
-                With MyDataGridViewRow
-                    .CreateCells(dataGrid)
-                    .Cells(ColumnIndex_ComputedTime).Value = Date.Parse(strTime)
-                    .Cells(ColumnIndex_LogType).Value = If(String.IsNullOrWhiteSpace(strLogType), "", strLogType)
-                    .Cells(ColumnIndex_IPAddress).Value = strSourceAddress
-                    .Cells(ColumnIndex_RemoteProcess).Value = If(String.IsNullOrWhiteSpace(strRemoteProcess), "", strRemoteProcess)
-                    .Cells(ColumnIndex_Hostname).Value = If(String.IsNullOrWhiteSpace(strHostname), "", strHostname)
-                    .Cells(ColumnIndex_ServerTime).Value = ToIso8601Format(serverTimeStamp)
-                    .Cells(ColumnIndex_LogText).Value = strLog
-                    .Cells(ColumnIndex_Alerted).Value = If(boolAlerted, "Yes", "No")
-                    .DateObject = dateObject
-                    .BoolAlerted = boolAlerted
-                    .ServerDate = serverTimeStamp
-                    .RawLogData = strRawLogText
-                    .AlertText = strAlertText
-                    .alertType = AlertType
+            Dim MyDataGridViewRow As New MyDataGridViewRow
 
-                    If My.Settings.font IsNot Nothing Then
-                        .DefaultCellStyle = DataGridViewCellStyle
-                        .Cells(ColumnIndex_Alerted).Style = DataGridViewCellStyle_AlertedCell
-                        .Cells(ColumnIndex_ComputedTime).Style = DataGridViewCellStyle_ComputedCell
-                    End If
+            With MyDataGridViewRow
+                .CreateCells(dataGrid)
+                .Cells(ColumnIndex_ComputedTime).Value = Date.Parse(strTime)
+                .Cells(ColumnIndex_LogType).Value = If(String.IsNullOrWhiteSpace(strLogType), "", strLogType)
+                .Cells(ColumnIndex_IPAddress).Value = strSourceAddress
+                .Cells(ColumnIndex_RemoteProcess).Value = If(String.IsNullOrWhiteSpace(strRemoteProcess), "", strRemoteProcess)
+                .Cells(ColumnIndex_Hostname).Value = If(String.IsNullOrWhiteSpace(strHostname), "", strHostname)
+                .Cells(ColumnIndex_ServerTime).Value = ToIso8601Format(serverTimeStamp)
+                .Cells(ColumnIndex_LogText).Value = strLog
+                .Cells(ColumnIndex_Alerted).Value = If(boolAlerted, "Yes", "No")
+                .DateObject = dateObject
+                .BoolAlerted = boolAlerted
+                .ServerDate = serverTimeStamp
+                .RawLogData = strRawLogText
+                .AlertText = strAlertText
+                .alertType = AlertType
 
-                    .DefaultCellStyle.Padding = DataGridViewPadding
-                End With
+                If My.Settings.font IsNot Nothing Then
+                    .DefaultCellStyle = DataGridViewCellStyle
+                    .Cells(ColumnIndex_Alerted).Style = DataGridViewCellStyle_AlertedCell
+                    .Cells(ColumnIndex_ComputedTime).Style = DataGridViewCellStyle_ComputedCell
+                End If
+            End With
 
-                Return MyDataGridViewRow
-            End Using
+            Return MyDataGridViewRow
         End Function
 
         Public Sub AddToLogList(strTimeStampFromServer As String, strLogText As String)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -59,6 +59,7 @@ Namespace SyslogParser
                 .RawLogData = strRawLogText
                 .AlertText = strAlertText
                 .alertType = AlertType
+                .GUID = Guid.NewGuid()
 
                 If My.Settings.font IsNot Nothing Then
                     .DefaultCellStyle = DataGridViewCellStyle
@@ -360,8 +361,6 @@ Namespace SyslogParser
                         End If
                     End If
 
-                    If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType)
-
                     If Not boolIgnored Then
                         Dim strLimitBy As String = Nothing
 
@@ -388,9 +387,13 @@ Namespace SyslogParser
                         End With
                     End If
 
+                    Dim rowGUID As Guid = Guid.NewGuid
+
+                    If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType, rowGUID)
+
                     ' Step 4: Add to log list, separating header and message
                     If Not My.Settings.OnlySaveAlertedLogs OrElse boolAlerted Then
-                        AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog)
+                        AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog, rowGUID)
                     End If
                 End If
             Catch ex As Exception
@@ -469,7 +472,7 @@ Namespace SyslogParser
             End Try
         End Function
 
-        Private Sub AddToLogList(strTimeStampFromServer As String, strSourceIP As String, strHostname As String, strRemoteProcess As String, strLogText As String, boolIgnored As Boolean, boolAlerted As Boolean, priority As (Facility As String, Severity As String), strRawLogText As String, strAlertText As String, alertType As AlertType, strIgnoredPattern As String, boolRecordIgnoredLog As Boolean)
+        Private Sub AddToLogList(strTimeStampFromServer As String, strSourceIP As String, strHostname As String, strRemoteProcess As String, strLogText As String, boolIgnored As Boolean, boolAlerted As Boolean, priority As (Facility As String, Severity As String), strRawLogText As String, strAlertText As String, alertType As AlertType, strIgnoredPattern As String, boolRecordIgnoredLog As Boolean, rowGUID As Guid)
             Dim currentDate As Date = Now.ToLocalTime
             Dim serverDate As Date
 
@@ -487,20 +490,22 @@ Namespace SyslogParser
             If Not boolIgnored Then
                 SyncLock ParentForm.dataGridLockObject
                     ParentForm.Logs.Invoke(Sub()
-                                               ParentForm.Logs.Rows.Add(MakeDataGridRow(serverTimeStamp:=serverDate,
-                                                                                        dateObject:=currentDate,
-                                                                                        strTime:=currentDate.ToString,
-                                                                                        strSourceAddress:=strSourceIP,
-                                                                                        strHostname:=strHostname,
-                                                                                        strRemoteProcess:=strRemoteProcess,
-                                                                                        strLog:=strLogText,
-                                                                                        strLogType:=$"{priority.Severity}, {priority.Facility}",
-                                                                                        boolAlerted:=boolAlerted,
-                                                                                        strRawLogText:=strRawLogText.Trim,
-                                                                                        strAlertText:=strAlertText,
-                                                                                        AlertType:=alertType,
-                                                                                        dataGrid:=ParentForm.Logs)
-                                                                                       )
+                                               Dim newItem As MyDataGridViewRow = MakeDataGridRow(serverTimeStamp:=serverDate,
+                                                             dateObject:=currentDate,
+                                                             strTime:=currentDate.ToString,
+                                                             strSourceAddress:=strSourceIP,
+                                                             strHostname:=strHostname,
+                                                             strRemoteProcess:=strRemoteProcess,
+                                                             strLog:=strLogText,
+                                                             strLogType:=$"{priority.Severity}, {priority.Facility}",
+                                                             boolAlerted:=boolAlerted,
+                                                             strRawLogText:=strRawLogText.Trim,
+                                                             strAlertText:=strAlertText,
+                                                             AlertType:=alertType,
+                                                             dataGrid:=ParentForm.Logs)
+
+                                               newItem.GUID = rowGUID
+                                               ParentForm.Logs.Rows.Add(newItem)
                                            End Sub)
                     If ParentForm.intSortColumnIndex = 0 And ParentForm.sortOrder = SortOrder.Descending Then ParentForm.SortLogsByDateObjectNoLocking(ParentForm.intSortColumnIndex, ListSortDirection.Descending)
                 End SyncLock
@@ -687,7 +692,7 @@ Namespace SyslogParser
             End Try
         End Function
 
-        Private Function ProcessAlerts(strLogText As String, ByRef strOutgoingAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, ByRef alertTypeAsAlertType As AlertType) As Boolean
+        Private Function ProcessAlerts(strLogText As String, ByRef strOutgoingAlertText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, ByRef alertTypeAsAlertType As AlertType, rowGUID As Guid) As Boolean
             Dim ToolTipIcon As ToolTipIcon = ToolTipIcon.None
             Dim RegExObject As Regex
             Dim strAlertText As String
@@ -732,9 +737,9 @@ Namespace SyslogParser
                     strAlertText = ProcessEmbeddedCommands(strAlertText)
 
                     If alert.BoolLimited Then
-                        NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType)
+                        NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)
                     Else
-                        ShowToastNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType)
+                        ShowToastNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)
                     End If
 
                     strOutgoingAlertText = strAlertText

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -445,7 +445,7 @@ Namespace SyslogParser
                                                                                                boolInternalRecordLog = ignoredClassInstance.BoolRecordLog
 
                                                                                                IgnoredStats.AddOrUpdate(strRegexPattern, Function(key As String) New IgnoredStatsEntry With {.Hits = 1, .LastEvent = Now}, Function(key As String, oldValue As IgnoredStatsEntry)
-                                                                                                                                                                                                                               oldValue.Hits += 1
+                                                                                                                                                                                                                               Interlocked.Increment(oldValue.Hits)
                                                                                                                                                                                                                                oldValue.LastEvent = Now
                                                                                                                                                                                                                                Return oldValue
                                                                                                                                                                                                                            End Function)

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -46,7 +46,6 @@ Partial Class Form1
         Me.AutomaticallyCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
         Me.AskToOpenExplorerWhenSavingData = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
-        Me.SaveTimer = New System.Windows.Forms.Timer(Me.components)
         Me.ChkEnableAutoSave = New System.Windows.Forms.ToolStripMenuItem()
         Me.DeleteOldLogsAtMidnight = New System.Windows.Forms.ToolStripMenuItem()
         Me.BackupOldLogsAfterClearingAtMidnight = New System.Windows.Forms.ToolStripMenuItem()
@@ -328,10 +327,6 @@ Partial Class Form1
         Me.BtnCheckForUpdates.Name = "BtnCheckForUpdates"
         Me.BtnCheckForUpdates.Size = New System.Drawing.Size(338, 22)
         Me.BtnCheckForUpdates.Text = "Check for Updates"
-        '
-        'SaveTimer
-        '
-        Me.SaveTimer.Interval = 300000
         '
         'ChkEnableAutoSave
         '
@@ -1073,7 +1068,6 @@ Partial Class Form1
     Friend WithEvents AlertsHistory As ToolStripMenuItem
     Friend WithEvents BtnSaveLogsToDisk As ToolStripMenuItem
     Friend WithEvents BtnCheckForUpdates As ToolStripMenuItem
-    Friend WithEvents SaveTimer As Timer
     Friend WithEvents ChkEnableAutoSave As ToolStripMenuItem
     Friend WithEvents DeleteOldLogsAtMidnight As ToolStripMenuItem
     Friend WithEvents BackupOldLogsAfterClearingAtMidnight As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -124,6 +124,7 @@ Partial Class Form1
         Me.DonationStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.StopServerStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChangeSyslogServerPortToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ClearIgnoredStatsAtMidnight = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChangeLogAutosaveIntervalToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.CreateIgnoredLogToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.CreateReplacementToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -485,7 +486,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.CompressBackupLogFilesToolStripMenuItem, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ClearIgnoredStatsAtMidnight, Me.CompressBackupLogFilesToolStripMenuItem, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -879,6 +880,13 @@ Partial Class Form1
         Me.ChangeSyslogServerPortToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
         Me.ChangeSyslogServerPortToolStripMenuItem.Text = "Change Syslog Server Port"
         '
+        'ClearIgnoredStatsAtMidnight
+        '
+        Me.ClearIgnoredStatsAtMidnight.CheckOnClick = True
+        Me.ClearIgnoredStatsAtMidnight.Name = "ClearIgnoredStatsAtMidnight"
+        Me.ClearIgnoredStatsAtMidnight.Size = New System.Drawing.Size(319, 22)
+        Me.ClearIgnoredStatsAtMidnight.Text = "Clear Ignored Log Stats at Midnight"
+        '
         'ChangeLogAutosaveIntervalToolStripMenuItem
         '
         Me.ChangeLogAutosaveIntervalToolStripMenuItem.Name = "ChangeLogAutosaveIntervalToolStripMenuItem"
@@ -1147,6 +1155,7 @@ Partial Class Form1
     Friend WithEvents OpenWindowsExplorerToAppConfigFile As ToolStripMenuItem
     Friend WithEvents CreateAlertToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ChangeSyslogServerPortToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents ClearIgnoredStatsAtMidnight As ToolStripMenuItem
     Friend WithEvents ChangeLogAutosaveIntervalToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CreateIgnoredLogToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents CreateReplacementToolStripMenuItem As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.resx
+++ b/Free SysLog/Windows/Form1.resx
@@ -120,9 +120,6 @@
   <metadata name="StatusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>133, 17</value>
   </metadata>
-  <metadata name="SaveTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>249, 17</value>
-  </metadata>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>357, 17</value>
   </metadata>

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -159,7 +159,7 @@ Public Class Form1
 
         TaskHandling.ConvertRegistryRunCommandToTask()
 
-        If My.Settings.DeleteOldLogsAtMidnight Then CreateNewMidnightTimer()
+        If My.Settings.DeleteOldLogsAtMidnight Then StartMidnightScheduler()
 
         ChangeLogAutosaveIntervalToolStripMenuItem.Text = $"        Change Log Autosave Interval ({My.Settings.autoSaveMinutes} Minutes)"
         ChangeSyslogServerPortToolStripMenuItem.Text = $"Change Syslog Server Port (Port Number {My.Settings.sysLogPort})"
@@ -427,19 +427,12 @@ Public Class Form1
 
         RemoveHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
 
-        If MyMidnightTimer IsNot Nothing Then
-            RemoveHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
-
-            MyMidnightTimer.Stop()
-            MyMidnightTimer.Dispose()
-            MyMidnightTimer = Nothing
-        End If
+        StopMidnightScheduler()
 
         My.Settings.logsColumnOrder = SaveColumnOrders(Logs.Columns)
         My.Settings.Save()
         WriteLogsToDisk()
         processUptimeTimer?.Dispose()
-        MyMidnightTimer?.Dispose()
 
         If My.Settings.saveIgnoredLogCount Then
             NumberOfIgnoredLogs = longNumberOfIgnoredLogs
@@ -1165,7 +1158,7 @@ Public Class Form1
             If TaskHandling.GetTaskObject(taskService, $"Free SysLog for {Environment.UserName}", task) Then
                 If task.Definition.Triggers.Any() Then
                     Dim trigger As TaskScheduler.Trigger = task.Definition.Triggers(0)
-                    If trigger.TriggerType = TaskScheduler.TaskTriggerType.Logon Then dblSeconds = DirectCast(trigger, TaskScheduler.LogonTrigger).Delay.TotalSeconds
+                    If trigger.TriggerType = Microsoft.Win32.TaskScheduler.TaskTriggerType.Logon Then dblSeconds = DirectCast(trigger, TaskScheduler.LogonTrigger).Delay.TotalSeconds
                 End If
             End If
         End Using
@@ -1187,7 +1180,7 @@ Public Class Form1
                             If task.Definition.Triggers.Any() Then
                                 Dim trigger As TaskScheduler.Trigger = task.Definition.Triggers(0)
 
-                                If trigger.TriggerType = TaskScheduler.TaskTriggerType.Logon Then
+                                If trigger.TriggerType = Microsoft.Win32.TaskScheduler.TaskTriggerType.Logon Then
                                     DirectCast(trigger, TaskScheduler.LogonTrigger).Delay = New TimeSpan(0, 0, IntegerInputForm.intResult)
                                     task.RegisterChanges()
                                 End If
@@ -1206,7 +1199,7 @@ Public Class Form1
                         If task.Definition.Triggers.Any() Then
                             Dim trigger As TaskScheduler.Trigger = task.Definition.Triggers(0)
 
-                            If trigger.TriggerType = TaskScheduler.TaskTriggerType.Logon Then
+                            If trigger.TriggerType = Microsoft.Win32.TaskScheduler.TaskTriggerType.Logon Then
                                 DirectCast(trigger, TaskScheduler.LogonTrigger).Delay = Nothing
                                 task.RegisterChanges()
                             End If
@@ -2157,37 +2150,149 @@ Public Class Form1
     End Sub
 #End Region
 
-#Region "--== Midnight Timer Code ==--"
-    ' This implementation is based on code found at https://www.codeproject.com/Articles/18201/Midnight-Timer-A-Way-to-Detect-When-it-is-Midnight.
-    ' I have rewritten the code to ensure that I fully understand it and to avoid blatantly copying someone else's work.
-    ' Using their code as-is without making an effort to learn from it or to create my own implementation doesn't sit well with me.
+#Region "--== Midnight Task Code ==--"
+    ' Holds the cancellation token source for the scheduler loop.
+    ' We keep this at class/module scope so we can stop and restart
+    ' the scheduler from multiple methods.
+    Private MidnightCancellation As Threading.CancellationTokenSource
 
-    Private MyMidnightTimer As Timers.Timer
+    ' Starts a background async loop that waits until the next midnight,
+    ' then runs whatever "midnight work" you want to perform.
+    '
+    ' Important behavior:
+    ' * Any existing scheduler is stopped first, so only one loop runs at a time.
+    ' * A cancellation token is created so the loop can be stopped cleanly.
+    ' * We subscribe to the Windows system clock change event so that if the user
+    '   or OS changes the time, we can recalculate the next midnight correctly.
+    Private Async Sub StartMidnightScheduler()
+        ' Defensive reset:
+        ' If a previous scheduler is already running, stop it before starting a new one.
+        ' This prevents duplicate loops and duplicate event handlers.
+        StopMidnightScheduler()
 
-    Private Sub CreateNewMidnightTimer()
-        ' Calculate the time span until midnight
-        Dim ts As TimeSpan = GetMidnight(1).Subtract(Date.Now)
-        Dim tsMidnight As New TimeSpan(ts.Hours, ts.Minutes, ts.Seconds)
+        ' Create a fresh cancellation token source for this new scheduler instance.
+        MidnightCancellation = New Threading.CancellationTokenSource()
 
-        If MyMidnightTimer Is Nothing Then
-            ' Create and start the new timer
-            MyMidnightTimer = New Timers.Timer(tsMidnight.TotalMilliseconds)
+        ' Listen for system time changes.
+        ' Example: manual clock adjustment, daylight saving changes, sync corrections, etc.
+        ' If the system time changes, our current delay may no longer be correct, so we restart the scheduler.
+        AddHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
 
-            AddHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
-            AddHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
-        Else
-            MyMidnightTimer.Stop()
-            MyMidnightTimer.Interval = tsMidnight.TotalMilliseconds
-            MyMidnightTimer.Start()
+        Try
+            ' Keep looping until cancellation is requested.
+            ' Each loop:
+            '   1. Calculates the next midnight
+            '   2. Waits until then
+            '   3. Runs the midnight task
+            While Not MidnightCancellation.Token.IsCancellationRequested
+                ' Calculate the next midnight.
+                ' Date.Today = today's date at 12:00:00 AM
+                ' AddDays(1) = tomorrow at 12:00:00 AM
+                Dim nextMidnight As Date = Date.Today.AddDays(1)
+
+                ' Figure out how long from "right now" until the next midnight.
+                ' Example: If now is 10:30 PM, delay will be 1 hour 30 minutes.
+                Dim delay As TimeSpan = nextMidnight - Date.Now
+
+                ' Asynchronously wait until midnight, unless cancellation happens first.
+                '
+                ' Why use Task.Delay with a cancellation token?
+                ' * It doesn't block the UI thread while waiting.
+                ' * It can be interrupted immediately when stopping/restarting.
+                Await Threading.Tasks.Task.Delay(delay, MidnightCancellation.Token)
+
+                ' It's possible cancellation happened during or immediately after the delay.
+                ' Double-check before running the midnight work.
+                If MidnightCancellation.Token.IsCancellationRequested Then Exit While
+
+                ' Run the code that should execute at midnight.
+                ' This is your actual scheduled work.
+                RunMidnightWork()
+            End While
+        Catch ex As Threading.Tasks.TaskCanceledException
+            ' Expected / normal behavior.
+            '
+            ' Task.Delay throws TaskCanceledException when the token is canceled.
+            ' That usually happens when:
+            ' * the app is shutting down
+            ' * the scheduler is being restarted
+            ' * the system time changed and we want to recalculate the wait
+            '
+            ' Since cancellation here is intentional, we silently ignore it.
+        End Try
+    End Sub
+
+    ' Stops the midnight scheduler and cleans up resources.
+    '
+    ' Important behavior:
+    ' * Unsubscribes from the system time change event
+    ' * Cancels any active delay in StartMidnightScheduler
+    ' * Disposes the token source to release resources
+    ' * Clears the field so we know no scheduler is active
+    Private Sub StopMidnightScheduler()
+        ' Always remove the event handler when stopping.
+        ' This prevents duplicate subscriptions and avoids memory/resource leaks.
+        RemoveHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
+
+        ' Only do cleanup if a scheduler token source actually exists.
+        If MidnightCancellation IsNot Nothing Then
+            ' Signal cancellation to the running scheduler loop.
+            ' If it's currently inside Task.Delay, that delay will be canceled immediately.
+            MidnightCancellation.Cancel()
+
+            ' Release unmanaged/internal resources used by the token source.
+            MidnightCancellation.Dispose()
+
+            ' Clear the reference so this old token source can't be reused accidentally.
+            MidnightCancellation = Nothing
         End If
     End Sub
 
-    Private Sub MidnightEvent(sender As Object, e As Timers.ElapsedEventArgs)
-        If Logs.InvokeRequired Then
-            Logs.Invoke(New Action(Of Object, Timers.ElapsedEventArgs)(AddressOf MidnightEvent), sender, e)
-            Return
-        End If
+    ' Handles changes to the Windows system clock.
+    '
+    ' Why restart?
+    ' The scheduler calculates a fixed delay until the next midnight.
+    ' If the system time changes after that calculation, the delay may be wrong.
+    ' Restarting forces a fresh recalculation based on the new current time.
+    Private Sub WindowsTimeChangeHandler(sender As Object, e As EventArgs)
+        ' Rebuild the scheduler timing from scratch whenever the system time changes.
+        StartMidnightScheduler()
+    End Sub
 
+    ' Entry point for whatever work needs to happen at midnight.
+    '
+    ' This method is designed to be SAFE to call from any thread.
+    ' Why this matters:
+    ' * Your scheduler runs asynchronously (likely on a background thread)
+    ' * UI updates (WinForms/WPF controls) MUST run on the UI thread
+    '
+    ' So this method checks whether we're on the UI thread and, if not, marshals the call over to it.
+    Private Sub RunMidnightWork()
+        ' InvokeRequired:
+        ' Returns TRUE if the current thread is NOT the UI thread.
+        ' Returns FALSE if we are already on the UI thread.
+        '
+        ' In WinForms, only the thread that created a control (the UI thread)
+        ' is allowed to interact with it. Violating this causes exceptions.
+        If InvokeRequired Then
+            ' We are on a background thread → switch to UI thread.
+            '
+            ' Invoke():
+            ' * Executes the delegate synchronously on the UI thread
+            ' * Blocks this thread until the UI thread finishes the work
+            '
+            ' We're wrapping the actual logic (RunMidnightWorkSubRoutine)
+            ' inside a lambda so it runs on the correct thread.
+            Invoke(Sub() RunMidnightWorkSubRoutine())
+        Else
+            ' We are already on the UI thread → safe to run directly.
+            '
+            ' No need to Invoke, which avoids unnecessary overhead and prevents potential deadlocks.
+            RunMidnightWorkSubRoutine()
+        End If
+    End Sub
+
+    Private Sub RunMidnightWorkSubRoutine()
         SyncLock dataGridLockObject
             If My.Settings.BackupOldLogsAfterClearingAtMidnight Then MakeLogBackup()
 
@@ -2204,18 +2309,7 @@ Public Class Form1
 
             NumberOfLogs.Text = $"Number of Log Entries: {Logs.Rows.Count:N0}"
         End SyncLock
-
-        CreateNewMidnightTimer()
     End Sub
-
-    Private Sub WindowsTimeChangeHandler(sender As Object, e As EventArgs)
-        CreateNewMidnightTimer()
-    End Sub
-
-    Private Function GetMidnight(minutesAfterMidnight As Integer) As Date
-        Dim tomorrow As Date = Date.Now.AddDays(1)
-        Return New Date(tomorrow.Year, tomorrow.Month, tomorrow.Day, 0, minutesAfterMidnight, 0)
-    End Function
 
     Private Sub BackupOldLogsAfterClearingAtMidnight_Click(sender As Object, e As EventArgs) Handles BackupOldLogsAfterClearingAtMidnight.Click
         My.Settings.DeleteOldLogsAtMidnight = BackupOldLogsAfterClearingAtMidnight.Checked
@@ -2231,13 +2325,9 @@ Public Class Form1
         End If
 
         If DeleteOldLogsAtMidnight.Checked Then
-            CreateNewMidnightTimer()
+            StartMidnightScheduler()
         Else
-            If MyMidnightTimer IsNot Nothing Then
-                MyMidnightTimer.Stop()
-                MyMidnightTimer.Dispose()
-                MyMidnightTimer = Nothing
-            End If
+            StopMidnightScheduler()
         End If
     End Sub
 #End Region

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -427,6 +427,16 @@ Public Class Form1
             End SyncLock
         End If
 
+        RemoveHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
+
+        If MyMidnightTimer IsNot Nothing Then
+            RemoveHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
+
+            MyMidnightTimer.Stop()
+            MyMidnightTimer.Dispose()
+            MyMidnightTimer = Nothing
+        End If
+
         My.Settings.logsColumnOrder = SaveColumnOrders(Logs.Columns)
         My.Settings.Save()
         WriteLogsToDisk()
@@ -2158,10 +2168,14 @@ Public Class Form1
 
     Private Sub CreateNewMidnightTimer()
         If MyMidnightTimer IsNot Nothing Then
+            RemoveHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
+
             MyMidnightTimer.Stop()
             MyMidnightTimer.Dispose()
             MyMidnightTimer = Nothing
         End If
+
+        RemoveHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
 
         ' Calculate the time span until midnight
         Dim ts As TimeSpan = GetMidnight(1).Subtract(Date.Now)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -218,6 +218,10 @@ Public Class Form1
         If My.Settings.font IsNot Nothing Then
             Logs.DefaultCellStyle.Font = My.Settings.font
             Logs.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
+
+            DataGridViewCellStyle = New DataGridViewCellStyle With {.Font = My.Settings.font}
+            DataGridViewCellStyle_ComputedCell = New DataGridViewCellStyle With {.Font = My.Settings.font, .Alignment = DataGridViewContentAlignment.MiddleCenter}
+            DataGridViewCellStyle_AlertedCell = New DataGridViewCellStyle With {.Font = My.Settings.font, .Alignment = DataGridViewContentAlignment.MiddleCenter, .WrapMode = DataGridViewTriState.True}
         End If
 
         boolDoneLoading = True
@@ -1261,6 +1265,10 @@ Public Class Form1
 
                 Logs.DefaultCellStyle.Font = My.Settings.font
                 Logs.ColumnHeadersDefaultCellStyle.Font = My.Settings.font
+
+                DataGridViewCellStyle = New DataGridViewCellStyle With {.Font = My.Settings.font}
+                DataGridViewCellStyle_ComputedCell = New DataGridViewCellStyle With {.Font = My.Settings.font, .Alignment = DataGridViewContentAlignment.MiddleCenter}
+                DataGridViewCellStyle_AlertedCell = New DataGridViewCellStyle With {.Font = My.Settings.font, .Alignment = DataGridViewContentAlignment.MiddleCenter, .WrapMode = DataGridViewTriState.True}
 
                 WriteLogsToDisk()
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -309,8 +309,6 @@ Public Class Form1
 
                 Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"The user deleted {rowsToDelete.Count:N0} log {If(rowsToDelete.Count = 1, "entry", "entries")}.", Logs))
 
-                BtnSaveLogsToDisk.Enabled = True
-
                 SelectLatestLogEntry()
             End SyncLock
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -27,6 +27,8 @@ Public Class Form1
     Private boolTCPServerRunning As Boolean = False
     Private lastFirstDisplayedRowIndex As Integer = -1
     Private processUptimeTimer As Timer
+    Private AutoSaveCancellation As Threading.CancellationTokenSource
+    Private AutoSaveTaskInterval As TimeSpan
     Private dateProcessStarted As Date = Process.GetCurrentProcess.StartTime
 
     Private HostNamesInstance As Hostnames
@@ -94,14 +96,36 @@ Public Class Form1
     End Sub
 
     Private Sub ChkAutoSave_Click(sender As Object, e As EventArgs) Handles ChkEnableAutoSave.Click
-        SaveTimer.Enabled = ChkEnableAutoSave.Checked
+        If ChkEnableAutoSave.Checked Then
+            StartAutoSaveTask()
+        Else
+            StopAutoSaveTask()
+        End If
+
         ChangeLogAutosaveIntervalToolStripMenuItem.Visible = ChkEnableAutoSave.Checked
         LblAutoSaved.Visible = ChkEnableAutoSave.Checked
     End Sub
 
-    Private Sub SaveTimer_Tick(sender As Object, e As EventArgs) Handles SaveTimer.Tick
-        WriteLogsToDisk()
-        LblAutoSaved.Text = $"Last Auto-Saved At: {Date.Now:h:mm:ss tt}"
+    Private Async Sub StartAutoSaveTask()
+        AutoSaveCancellation = New Threading.CancellationTokenSource()
+
+        Try
+            While Not AutoSaveCancellation.Token.IsCancellationRequested
+                Await Threading.Tasks.Task.Delay(AutoSaveTaskInterval, AutoSaveCancellation.Token)
+
+                WriteLogsToDisk()
+                LblAutoSaved.Text = $"Last Auto-Saved At: {Date.Now:h:mm:ss tt}"
+            End While
+        Catch ex As Threading.Tasks.TaskCanceledException
+        End Try
+    End Sub
+
+    Private Sub StopAutoSaveTask()
+        If AutoSaveCancellation IsNot Nothing Then
+            AutoSaveCancellation.Cancel()
+            AutoSaveCancellation.Dispose()
+            AutoSaveCancellation = Nothing
+        End If
     End Sub
 
     Private Sub NotifyIcon_DoubleClick(sender As Object, e As EventArgs) Handles NotifyIcon.DoubleClick
@@ -195,8 +219,8 @@ Public Class Form1
         LoadColumnOrders(Logs.Columns, My.Settings.logsColumnOrder)
 
         If My.Settings.autoSave Then
-            SaveTimer.Interval = TimeSpan.FromMinutes(My.Settings.autoSaveMinutes).TotalMilliseconds
-            SaveTimer.Enabled = True
+            AutoSaveTaskInterval = TimeSpan.FromMinutes(My.Settings.autoSaveMinutes)
+            StartAutoSaveTask()
         End If
 
         Size = My.Settings.mainWindowSize
@@ -1054,7 +1078,9 @@ Public Class Form1
 
             If IntegerInputForm.DialogResult = DialogResult.OK Then
                 ChangeLogAutosaveIntervalToolStripMenuItem.Text = $"Change Log Autosave Interval ({IntegerInputForm.intResult} Minutes)"
-                SaveTimer.Interval = TimeSpan.FromMinutes(IntegerInputForm.intResult).TotalMilliseconds
+                AutoSaveTaskInterval = TimeSpan.FromMinutes(IntegerInputForm.intResult)
+                StopAutoSaveTask()
+                StartAutoSaveTask()
                 My.Settings.autoSaveMinutes = IntegerInputForm.intResult
 
                 MsgBox("Done.", MsgBoxStyle.Information, Text)
@@ -1970,8 +1996,8 @@ Public Class Form1
     Public Sub SaveLogsToDiskSub()
         WriteLogsToDisk()
         LblAutoSaved.Text = $"Last Saved At: {Date.Now:h:mm:ss tt}"
-        SaveTimer.Enabled = False
-        SaveTimer.Enabled = True
+        StopAutoSaveTask()
+        StartAutoSaveTask()
     End Sub
 
     Private Sub SortLogsByDateObject(columnIndex As Integer, order As ListSortDirection)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -189,6 +189,8 @@ Public Class Form1
         Logs.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 
+        Logs.RowsDefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+
         LoadAndDeserializeArrays()
         LoadColumnOrders(Logs.Columns, My.Settings.logsColumnOrder)
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -2268,11 +2268,21 @@ Public Class Form1
                                                                    If argsDictionary.ContainsKey("action") Then
                                                                        If argsDictionary("action").ToString.Equals(strOpenSysLog, StringComparison.OrdinalIgnoreCase) Then
                                                                            Invoke(Sub() RestoreWindow())
-                                                                       ElseIf argsDictionary("action").ToString.Equals(strViewLog, StringComparison.OrdinalIgnoreCase) AndAlso argsDictionary.ContainsKey("datapacket") Then
+                                                                       ElseIf argsDictionary("action").ToString.Equals(strViewLog, StringComparison.OrdinalIgnoreCase) AndAlso argsDictionary.ContainsKey("guid") Then
                                                                            Try
-                                                                               Dim NotificationDataPacket As NotificationDataPacket = Newtonsoft.Json.JsonConvert.DeserializeObject(Of NotificationDataPacket)(argsDictionary("datapacket").ToString, JSONDecoderSettingsForSettingsFiles)
+                                                                               Dim rowGUID As Guid
 
-                                                                               OpenLogViewerWindow(NotificationDataPacket.logtext, NotificationDataPacket.alerttext, NotificationDataPacket.logdate, NotificationDataPacket.sourceip, NotificationDataPacket.rawlogtext, NotificationDataPacket.alertType)
+                                                                               If Guid.TryParse(argsDictionary("guid").ToString, rowGUID) Then
+                                                                                   Dim selectedRow As MyDataGridViewRow = Logs.Rows.Cast(Of MyDataGridViewRow).FirstOrDefault(Function(r As MyDataGridViewRow) r.GUID = rowGUID)
+
+                                                                                   If selectedRow Is Nothing Then
+                                                                                       Invoke(Sub() Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Unable to find a corresponding log with a GUID of ""{argsDictionary("guid")}"".", Logs)))
+                                                                                   Else
+                                                                                       OpenLogViewerWindow(selectedRow.Cells(ColumnIndex_LogText).Value, selectedRow.AlertText, selectedRow.Cells(ColumnIndex_ComputedTime).Value, selectedRow.Cells(ColumnIndex_IPAddress).Value, selectedRow.RawLogData, selectedRow.alertType)
+                                                                                   End If
+                                                                               Else
+                                                                                   Invoke(Sub() Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Unable to parse incoming GUID string, the incoming GUID string was ""{argsDictionary("guid")}"".", Logs)))
+                                                                               End If
                                                                            Catch ex As Exception
                                                                            End Try
                                                                        End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1224,6 +1224,10 @@ Public Class Form1
         End If
     End Sub
 
+    Private Sub ClearIgnoredStatsAtMidnight_Click(sender As Object, e As EventArgs) Handles ClearIgnoredStatsAtMidnight.Click
+        My.Settings.ClearIgnoredStatsAtMidnight = ClearIgnoredStatsAtMidnight.Checked
+    End Sub
+
     Private Sub RemoveNumbersFromRemoteApp_Click(sender As Object, e As EventArgs) Handles RemoveNumbersFromRemoteApp.Click
         My.Settings.RemoveNumbersFromRemoteApp = RemoveNumbersFromRemoteApp.Checked
     End Sub
@@ -2086,6 +2090,7 @@ Public Class Form1
         ShowCloseButtonOnNotifications.Checked = My.Settings.ShowCloseButtonOnNotifications
         IncludeCommasInDHMS.Checked = My.Settings.IncludeCommasInDHMS
         CompressBackupLogFilesToolStripMenuItem.Checked = My.Settings.CompressBackupLogFiles
+        ClearIgnoredStatsAtMidnight.Checked = My.Settings.ClearIgnoredStatsAtMidnight
     End Sub
 
     Private Sub LoadAndDeserializeArrays()
@@ -2295,6 +2300,16 @@ Public Class Form1
     Private Sub RunMidnightWorkSubRoutine()
         SyncLock dataGridLockObject
             If My.Settings.BackupOldLogsAfterClearingAtMidnight Then MakeLogBackup()
+
+            If My.Settings.ClearIgnoredStatsAtMidnight Then
+                IgnoredStats.Clear()
+                longNumberOfIgnoredLogs = 0
+
+                If My.Settings.saveIgnoredLogCount Then
+                    NumberOfIgnoredLogs = longNumberOfIgnoredLogs
+                    WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+                End If
+            End If
 
             Dim oldLogCount As Integer = Logs.Rows.Count
             Logs.Rows.Clear()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -2165,27 +2165,21 @@ Public Class Form1
     Private MyMidnightTimer As Timers.Timer
 
     Private Sub CreateNewMidnightTimer()
-        If MyMidnightTimer IsNot Nothing Then
-            RemoveHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
-
-            MyMidnightTimer.Stop()
-            MyMidnightTimer.Dispose()
-            MyMidnightTimer = Nothing
-        End If
-
-        RemoveHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
-
         ' Calculate the time span until midnight
         Dim ts As TimeSpan = GetMidnight(1).Subtract(Date.Now)
         Dim tsMidnight As New TimeSpan(ts.Hours, ts.Minutes, ts.Seconds)
 
-        ' Create and start the new timer
-        MyMidnightTimer = New Timers.Timer(tsMidnight.TotalMilliseconds)
+        If MyMidnightTimer Is Nothing Then
+            ' Create and start the new timer
+            MyMidnightTimer = New Timers.Timer(tsMidnight.TotalMilliseconds)
 
-        AddHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
-        AddHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
-
-        MyMidnightTimer.Start()
+            AddHandler SystemEvents.TimeChanged, AddressOf WindowsTimeChangeHandler
+            AddHandler MyMidnightTimer.Elapsed, AddressOf MidnightEvent
+        Else
+            MyMidnightTimer.Stop()
+            MyMidnightTimer.Interval = tsMidnight.TotalMilliseconds
+            MyMidnightTimer.Start()
+        End If
     End Sub
 
     Private Sub MidnightEvent(sender As Object, e As Timers.ElapsedEventArgs)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -543,7 +543,7 @@ Public Class Form1
                                                       searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
                                                       searchResultsWindow.ShowDialog(Me)
                                                   Else
-                                                      MsgBox("Search terms not found.", MsgBoxStyle.Information, Text)
+                                                      MsgBox($"Search terms not found.{vbCrLf}{vbCrLf}The search took {MyRoundingFunction(stopWatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds.", MsgBoxStyle.Information, Text)
                                                   End If
 
                                                   Invoke(Sub() BtnSearch.Enabled = True)

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -139,6 +139,8 @@ Public Class IgnoredLogsAndSearchResults
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
         Logs.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
 
+        Logs.RowsDefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+
         If _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.ignored Then
             BtnClearIgnoredLogs.Visible = True
             BtnViewMainWindow.Visible = True

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -104,10 +104,8 @@ Public Class IgnoredWordsAndPhrases
                     .BackColor = If(.BoolEnabled, Color.LightGreen, Color.Pink)
                     .strComment = txtComment.Text
 
-                    If .dateCreated = Date.MinValue Then ' Just in case it was never set
-                        .dateCreated = Date.Now
-                        .SubItems(colDateCreated.Index).Text = Date.Now.ToLongDateString
-                    End If
+                    .dateCreated = Date.Now
+                    .SubItems(colDateCreated.Index).Text = Date.Now.ToLongDateString
 
                     If Not strOldRuleText.Equals(TxtIgnored.Text, StringComparison.OrdinalIgnoreCase) Then
                         IgnoredStats.TryRemove(.SubItems(Ignored.Index).Text, Nothing)

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -1,5 +1,4 @@
 ﻿Imports Free_SysLog.SupportCode
-Imports Windows.UI.Xaml.Controls.Primitives
 
 Public Class IgnoredWordsAndPhrases
     Private boolDoneLoading As Boolean = False
@@ -9,11 +8,34 @@ Public Class IgnoredWordsAndPhrases
     Public strIgnoredPattern As String = Nothing
     Private draggedItem As ListViewItem
     Private m_SortingColumn As ColumnHeader
-    Private AutoRefreshTimer As Timer
     Private _boolCurrentlyEditing As Boolean = False
     Private boolF1KeyDown As Boolean = False
     Private Const strWindowTitle As String = "Ignored Words and Phrases"
     Private strOldRuleText As String
+    Private StatUpdateCancellation As Threading.CancellationTokenSource
+
+    Private Async Sub StartStatUpdater()
+        StatUpdateCancellation = New Threading.CancellationTokenSource()
+
+        Try
+            While Not StatUpdateCancellation.Token.IsCancellationRequested
+                If StatUpdateCancellation.Token.IsCancellationRequested Then Exit While
+
+                UpdateStats()
+
+                Await Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(5), StatUpdateCancellation.Token)
+            End While
+        Catch ex As Threading.Tasks.TaskCanceledException
+        End Try
+    End Sub
+
+    Private Sub StopStatUpdater()
+        If StatUpdateCancellation IsNot Nothing Then
+            StatUpdateCancellation.Cancel()
+            StatUpdateCancellation.Dispose()
+            StatUpdateCancellation = Nothing
+        End If
+    End Sub
 
     Private Sub ListViewMenu_Closed(sender As Object, e As ToolStripDropDownClosedEventArgs) Handles ListViewMenu.Closed
         boolCurrentlyEditing = False
@@ -195,7 +217,7 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
-        AutoRefreshTimer?.Dispose()
+        StopStatUpdater()
 
         If boolColumnOrderChanged Then
             My.Settings.IgnoredWordsAndPhrasesColumnOrder = SaveColumnOrders(IgnoredListView.Columns)
@@ -259,12 +281,7 @@ Public Class IgnoredWordsAndPhrases
         End Try
     End Sub
 
-    Private Sub InitializeAutoRefreshTimer()
-        AutoRefreshTimer = New Timer() With {.Interval = 5000, .Enabled = ChkAutoRefresh.Checked}
-        AddHandler AutoRefreshTimer.Tick, AddressOf AutoRefreshTimer_Tick
-    End Sub
-
-    Private Sub AutoRefreshTimer_Tick(sender As Object, e As EventArgs)
+    Private Sub UpdateStats()
         If _boolCurrentlyEditing Or boolF1KeyDown OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
         btnUpdateHits.PerformClick()
     End Sub
@@ -307,7 +324,7 @@ Public Class IgnoredWordsAndPhrases
 
         Text = If(ChkAutoRefresh.Checked, $"{strWindowTitle} — Auto Refresh Enabled", $"{strWindowTitle} — Auto Refresh Paused")
 
-        InitializeAutoRefreshTimer()
+        StartStatUpdater()
 
         Size = My.Settings.ConfigureIgnoredSize
 
@@ -824,7 +841,13 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub ChkAutoRefresh_Click(sender As Object, e As EventArgs) Handles ChkAutoRefresh.Click
         My.Settings.AutomaticStatRefreshOnIgnoredWordsAndPhrases = ChkAutoRefresh.Checked
-        AutoRefreshTimer.Enabled = ChkAutoRefresh.Checked
+
+        If ChkAutoRefresh.Checked Then
+            StartStatUpdater()
+        Else
+            StopStatUpdater()
+        End If
+
         ChkRefreshOnlyIfActive.Enabled = ChkAutoRefresh.Checked
         Text = If(ChkAutoRefresh.Checked, $"{strWindowTitle} — Auto Refresh Enabled", $"{strWindowTitle} — Auto Refresh Paused")
     End Sub

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -214,7 +214,7 @@ Public Class ViewLogBackups
                    lblNumberOfFiles.Text = $"Number of Files: {intFileCount:N0}"
 
                    If intNumberOfCompressedFiles = 0 Then
-                       LblTotalDiskSpace.Text = $"Total File Size: {FileSizeToHumanSize(longUsedDiskSpace)}"
+                       LblTotalDiskSpace.Text = $"Total Disk Space Used on Disk: {FileSizeToHumanSize(longUsedDiskSpace)}"
                    Else
                        LblTotalDiskSpace.Text = $"Total Disk Space Used on Disk: {FileSizeToHumanSize(longUsedDiskSpace)}"
                    End If

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -40,7 +40,7 @@ Public Class ViewLogBackups
         End If
     End Sub
 
-    Private Function GetEstimatedUncompressedSizeOfGZIPedFile(strPathToGZIPedLogFile As String) As Long
+    Private Function GetUncompressedSizeOfGZIPedLogFile(strPathToGZIPedLogFile As String) As Long
         Try
             Using fs As New FileStream(strPathToGZIPedLogFile, FileMode.Open, FileAccess.Read, FileShare.Read)
                 If fs.Length < 4 Then Return -1
@@ -138,7 +138,7 @@ Public Class ViewLogBackups
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                                                           longUnCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
+                                                           longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
 
                                                            If ChkShowCompressionSizeDifference.Checked Then
                                                                If longUnCompresedSize = -1 Then

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -48,7 +48,9 @@ Public Class ViewLogBackups
                 fs.Seek(-4, SeekOrigin.End)
 
                 Dim sizeBytes(3) As Byte
-                fs.Read(sizeBytes, 0, 4)
+                Dim bytesRead As Integer = fs.Read(sizeBytes, 0, 4)
+
+                If bytesRead <> 4 Then Return -1 ' Return -1 to indicate an error occurred
 
                 ' GZIP stores ISIZE as little-endian UInt32
                 Return BitConverter.ToUInt32(sizeBytes, 0)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -111,7 +111,7 @@ Public Class ViewLogBackups
         Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
                                                Dim boolIsHidden As Boolean = (file.Attributes And FileAttributes.Hidden) = FileAttributes.Hidden
                                                Dim intCount As Integer = GetEntryCount(file.FullName)
-                                               Dim intUnCompresedSize As Long = -1
+                                               Dim longUnCompresedSize As Long = -1
 
                                                If intCount <> -1 Then
                                                    If boolIsHidden Then
@@ -136,13 +136,13 @@ Public Class ViewLogBackups
                                                        .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                                                           intUnCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
+                                                           longUnCompresedSize = GetEstimatedUncompressedSizeOfGZIPedFile(file.FullName)
 
                                                            If ChkShowCompressionSizeDifference.Checked Then
-                                                               If intUnCompresedSize = -1 Then
+                                                               If longUnCompresedSize = -1 Then
                                                                    row.Cells(2).Value = "Error"
                                                                Else
-                                                                   row.Cells(2).Value = FileSizeToHumanSize(intUnCompresedSize)
+                                                                   row.Cells(2).Value = FileSizeToHumanSize(longUnCompresedSize)
                                                                End If
                                                            Else
                                                                row.Cells(2).Value = FileSizeToHumanSize(file.Length)
@@ -174,7 +174,7 @@ Public Class ViewLogBackups
                                                        If ChkShowCompressionSizeDifference.Checked Then
                                                            If ChkShowCompressionSizeDifferencePercentage.Checked Then
                                                                row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)}"
-                                                               If intUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / intUnCompresedSize * 100):F2}% smaller"
+                                                               If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% smaller"
                                                                row.Cells(2).Value &= $")"
                                                            Else
                                                                row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -387,6 +387,7 @@ Public Class ViewLogBackups
         BtnSearch.Enabled = False
 
         Dim worker As New BackgroundWorker()
+        Dim stopwatch As Stopwatch = Stopwatch.StartNew
 
         AddHandler worker.DoWork, Sub()
                                       Try
@@ -489,9 +490,11 @@ Public Class ViewLogBackups
                                                           searchResultsWindow.LogsToBeDisplayed = listOfSearchResults2
                                                           searchResultsWindow.ColFileName.Visible = True
                                                           searchResultsWindow.OpenLogFileForViewingToolStripMenuItem.Visible = True
+                                                          searchResultsWindow.LogsLoadedInLabel.Visible = True
+                                                          searchResultsWindow.LogsLoadedInLabel.Text = $"Search Took: {MyRoundingFunction(stopwatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds"
                                                           searchResultsWindow.ShowDialog(Me)
                                                       Else
-                                                          MsgBox("Search terms not found.", MsgBoxStyle.Information, Text)
+                                                          MsgBox($"Search terms not found.{vbCrLf}{vbCrLf}The search took {MyRoundingFunction(stopwatch.Elapsed.TotalMilliseconds / 1000, 2)} seconds.", MsgBoxStyle.Information, Text)
                                                       End If
                                                   End If
 

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -347,6 +347,9 @@
             <setting name="CompressBackupLogFiles" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="ClearIgnoredStatsAtMidnight" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- Refactored the WriteFileAtomically() function to accept a Stream Object as the source. 641bc6e4fb35c6f0b44e8051806a2841bdf89232
- Centralized the creations of DataGridView styles. 54b555c9bc2060c1e60bc5f3fb7d6951f2d0be0d
- DataGridViewRow padding is now set globally. 18ed79bde7dd3bded079a6e26312877fdd942123
- Incrementing the value of oldValue.Hits in the IgnoredStatsEntry Object is now incremented using the Interlocked.Increment() method. 9b54a4d06290d395261c23a53712b18eab2b3af0
- Changed the HasTimezoneOffset() function to use a stored and compiled RegEx Object instead of recreating a RegEx every time that it's run. 62c21560e8384c997472e1ffe7f9ad2d95afcd23
- Removed the call to re-enable the "Save Logs to Disk" menu option after deleting logs because the deletion routine automatically saves the data to disk after the logs are deleted. be4fbe994dbb5cb637cdb53cb1ea6737e6fb3df6
- Instead of passing all of the log data as a JSON encoded data array in the notification data, we now only send a GUID for the log. a64e687a44f94ff139243c37670e14b55e468700
- Completely reworked the midnight timer code. e5db24d3ce2a5134333e5d5bc6f292f6bdffd1c5
- Made it so that setting the created data is always done when editing an ignore rule on the "Ignored Words and Phrases" window. 2c7abb8626102b300d9acb1bb84edccb0881c81a
- Added the ability to clear ignored log statistics at midnight. 977cae26b272d7725b80f0f754017163644050d6
- Converted the timer-based code that's used to refresh ignore rule stats on the "Ignored Words and Phrases" window to use an Await Task similar to what's used on the main window to handle the midnight event. 25b8ad623d1a6a6fca79026405b775750ceec33a
- Changed the timer-based code responsible for auto saving to an async task. b4d6f99da6400bfb35b2952c4fe7a95d8d9d62d4
- Added some additional error checking to the GetEstimatedUncompressedSizeOfGZIPedFile() function. 56848ba817de21d9100f87f8f8b17d99e64c9734
- Renamed GetEstimatedUncompressedSizeOfGZIPedFile() to GetUncompressedSizeOfGZIPedLogFile(). 65242ac20723b50ad2d5d2db755434785daf0fed
- Added an indication of how long the log search took when searching logs from the "View Log Backups" window. f41bc0c2b9611f1f412c3b721a8384a4dfcf1d1b
- The search tool on the main window now shows how long the search took when there are no search results to show. 5046a8cef8ee6dcda2e5e8029c83e9872d910f0d