### PR TITLE
Version 5.4 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.4.1.124")>
+<Assembly: AssemblyFileVersion("5.4.2.125")>

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -762,17 +762,30 @@ Public Class IgnoredWordsAndPhrases
     Private Sub btnResetHits_Click(sender As Object, e As EventArgs) Handles btnResetHits.Click
         longNumberOfIgnoredLogs = 0
 
+        If My.Settings.saveIgnoredLogCount Then
+            NumberOfIgnoredLogs = longNumberOfIgnoredLogs
+        End If
+
         If IgnoredListView.SelectedItems.Count > 0 Then
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
                 If IgnoredStats.TryRemove(item.SubItems(Ignored.Index).Text, Nothing) Then
+                    longNumberOfIgnoredLogs -= item.intHits
                     item.SubItems(colHits.Index).Text = "0"
                     item.intHits = 0
                     item.SubItems(colDateOfLastEvent.Index).Text = ""
                     item.SubItems(colSinceLastEvent.Index).Text = ""
                 End If
             Next
+
+            If My.Settings.saveIgnoredLogCount Then
+                WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+            End If
         Else
             IgnoredStats.Clear()
+
+            If My.Settings.saveIgnoredLogCount Then
+                WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+            End If
 
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
                 item.SubItems(colHits.Index).Text = "0"

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -766,6 +766,7 @@ Public Class IgnoredWordsAndPhrases
             For Each item As MyIgnoredListViewItem In IgnoredListView.SelectedItems
                 If IgnoredStats.TryRemove(item.SubItems(Ignored.Index).Text, Nothing) Then
                     item.SubItems(colHits.Index).Text = "0"
+                    item.intHits = 0
                     item.SubItems(colDateOfLastEvent.Index).Text = ""
                     item.SubItems(colSinceLastEvent.Index).Text = ""
                 End If
@@ -775,6 +776,7 @@ Public Class IgnoredWordsAndPhrases
 
             For Each item As MyIgnoredListViewItem In IgnoredListView.Items
                 item.SubItems(colHits.Index).Text = "0"
+                item.intHits = 0
                 item.SubItems(colDateOfLastEvent.Index).Text = ""
                 item.SubItems(colSinceLastEvent.Index).Text = ""
             Next


### PR DESCRIPTION
This is a minor update to fix a minor issue...
- Fixed sorting by hits on the "Ignored Words and Phrases" window after resetting hits. 9c394e0d109ff34402550e9a4f86513f84ed87bb
- Added code to save the ignored stat data to disk after resetting hits data on the "Ignored Words and Phrases" window. e1859f1ecc25bf925091605572babf05e2c36749