### PR TITLE
Version 5.5 Build 1

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -76,13 +76,12 @@ Namespace My
 
         Private Function LoadUniqueLogTypesAndProcesses(boolProcessAllFiles As Boolean) As uniqueObjectsClass
             Dim filesInDirectory As IO.FileInfo() = New IO.DirectoryInfo(strPathToDataBackupFolder).GetFiles()
-            Dim collectionOfSavedData As List(Of SavedData)
-            Dim lockObject As New Object
-
             Dim uniqueObjects As New uniqueObjectsClass
 
             If boolProcessAllFiles Then
                 Threading.Tasks.Parallel.ForEach(filesInDirectory, Sub(file As IO.FileInfo)
+                                                                       Dim collectionOfSavedData As List(Of SavedData)
+
                                                                        If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
                                                                            collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                        Else
@@ -103,6 +102,8 @@ Namespace My
             End If
 
             If IO.File.Exists(strPathToDataFile) Then
+                Dim collectionOfSavedData As List(Of SavedData)
+
                 Using fileStream As New IO.StreamReader(strPathToDataFile)
                     collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(fileStream.ReadToEnd.Trim, JSONDecoderSettingsForLogFiles)
 

--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -138,6 +138,12 @@
     <Compile Include="Windows\Alerts.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Windows\Calendar.Designer.vb">
+      <DependentUpon>Calendar.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\Calendar.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Windows\Clear logs older than.Designer.vb">
       <DependentUpon>Clear logs older than.vb</DependentUpon>
     </Compile>
@@ -255,6 +261,9 @@
     <EmbeddedResource Include="Windows\Alerts.resx">
       <DependentUpon>Alerts.vb</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Windows\Calendar.resx">
+      <DependentUpon>Calendar.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Windows\Clear logs older than.resx">
       <DependentUpon>Clear logs older than.vb</DependentUpon>

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.4.2.125")>
+<Assembly: AssemblyFileVersion("5.5.1.126")>

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -312,13 +312,13 @@ Namespace SyslogParser
                 If Not String.IsNullOrWhiteSpace(strRawLogText) AndAlso Not String.IsNullOrWhiteSpace(strSourceIP) Then
                     Dim boolIgnored As Boolean = False
                     Dim boolAlerted As Boolean = False
-                    Dim priorityObject As (Facility As String, Severity As String) = (Nothing, Nothing)
-                    Dim priority As String = Nothing
-                    Dim message As String = Nothing
-                    Dim timestamp As String = Nothing
-                    Dim hostname As String = Nothing
-                    Dim customHostname As String = Nothing
-                    Dim appName As String = Nothing
+                    Dim strTuplePriority As (Facility As String, Severity As String) = (Nothing, Nothing)
+                    Dim strPriority As String = Nothing
+                    Dim strMessage As String = Nothing
+                    Dim strTimeStamp As String = Nothing
+                    Dim strHostname As String = Nothing
+                    Dim strCustomHostname As String = Nothing
+                    Dim strAppName As String = Nothing
                     Dim strAlertText As String = Nothing
                     Dim AlertType As AlertType = AlertType.None
                     Dim strIgnoredPattern As String = Nothing
@@ -334,41 +334,41 @@ Namespace SyslogParser
 
                     If IsRegexMatch(rfc5424TransformRegex, strRawLogText, match) OrElse IsRegexMatch(rfc5424Regex, strRawLogText, match) Then
                         ' Handling the transformation to RFC 5424 format
-                        priority = If(String.IsNullOrWhiteSpace(match.Groups("priority").Value), "", match.Groups("priority").Value)
-                        timestamp = If(String.IsNullOrWhiteSpace(match.Groups("timestamp").Value), "", match.Groups("timestamp").Value)
-                        hostname = If(String.IsNullOrWhiteSpace(match.Groups("hostname").Value), "", match.Groups("hostname").Value)
-                        appName = If(String.IsNullOrWhiteSpace(match.Groups("appname").Value), "", match.Groups("appname").Value)
-                        message = If(String.IsNullOrWhiteSpace(match.Groups("message").Value), "", match.Groups("message").Value)
+                        strPriority = If(String.IsNullOrWhiteSpace(match.Groups("priority").Value), "", match.Groups("priority").Value)
+                        strTimeStamp = If(String.IsNullOrWhiteSpace(match.Groups("timestamp").Value), "", match.Groups("timestamp").Value)
+                        strHostname = If(String.IsNullOrWhiteSpace(match.Groups("hostname").Value), "", match.Groups("hostname").Value)
+                        strAppName = If(String.IsNullOrWhiteSpace(match.Groups("appname").Value), "", match.Groups("appname").Value)
+                        strMessage = If(String.IsNullOrWhiteSpace(match.Groups("message").Value), "", match.Groups("message").Value)
 
-                        If SupportCode.hostnames.TryGetValue(strSourceIP, customHostname) Then hostname = customHostname
+                        If SupportCode.hostnames.TryGetValue(strSourceIP, strCustomHostname) Then strHostname = strCustomHostname
 
-                        If Not String.IsNullOrWhiteSpace(priority) Then priorityObject = GetSeverityAndFacility(priority)
+                        If Not String.IsNullOrWhiteSpace(strPriority) Then strTuplePriority = GetSeverityAndFacility(strPriority)
                     Else
-                        timestamp = Now.ToString
-                        hostname = ""
-                        appName = ""
-                        priorityObject = ("Local", "Error")
-                        message = $"The log entry did not match a supported syslog format. Below is the raw entry:{vbCrLf}{strRawLogText}" ' Something went wrong, we couldn't parse the entry so we're going to just pass the raw log entry to the program.
+                        strTimeStamp = Now.ToString
+                        strHostname = ""
+                        strAppName = ""
+                        strTuplePriority = ("Local", "Error")
+                        strMessage = $"The log entry did not match a supported syslog format. Below is the raw entry:{vbCrLf}{strRawLogText}" ' Something went wrong, we couldn't parse the entry so we're going to just pass the raw log entry to the program.
                     End If
 
-                    If Not String.IsNullOrWhiteSpace(message) AndAlso message.CaseInsensitiveContains(strNewLine) Then message = message.Replace(strNewLine, vbCrLf).Trim
+                    If Not String.IsNullOrWhiteSpace(strMessage) AndAlso strMessage.CaseInsensitiveContains(strNewLine) Then strMessage = strMessage.Replace(strNewLine, vbCrLf).Trim
 
-                    If My.Settings.RemoveNumbersFromRemoteApp Then appName = NumberRemovingRegex.Replace(appName, "$1")
+                    If My.Settings.RemoveNumbersFromRemoteApp Then strAppName = NumberRemovingRegex.Replace(strAppName, "$1")
 
                     ' Step 3: Handle the ignored logs and alerts
                     If Not My.Settings.ProcessReplacementsInSyslogDataFirst Then
                         If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then
-                            boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, appName, strIgnoredPattern, boolRecordIgnoredLog)
+                            boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, strAppName, strIgnoredPattern, boolRecordIgnoredLog)
                         End If
 
-                        If replacementsList IsNot Nothing AndAlso replacementsList.Any() Then message = ProcessReplacements(message)
+                        If replacementsList IsNot Nothing AndAlso replacementsList.Any() Then strMessage = ProcessReplacements(strMessage)
                     Else
                         If ignoredList IsNot Nothing AndAlso ignoredList.Any() Then
-                            boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, appName, strIgnoredPattern, boolRecordIgnoredLog)
+                            boolIgnored = ProcessIgnoredLogPreferences(strRawLogText, strAppName, strIgnoredPattern, boolRecordIgnoredLog)
                         End If
                     End If
 
-                    If Not String.IsNullOrWhiteSpace(priority) Then strPriorityString = $"{priorityObject.Severity}, {priorityObject.Facility}"
+                    If Not String.IsNullOrWhiteSpace(strPriority) Then strPriorityString = $"{strTuplePriority.Severity}, {strTuplePriority.Facility}"
 
                     If Not boolIgnored Then
                         Dim strLimitBy As String = Nothing
@@ -380,12 +380,12 @@ Namespace SyslogParser
                                 ParentForm.boxLimiter.Items.Add(strPriorityString)
                             End If
 
-                            If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(appName)
+                            If .processes.Add(strAppName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(strAppName)
                             End If
 
-                            If .hostNames.Add(hostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(hostname)
+                            If .hostNames.Add(strHostname) AndAlso strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(strHostname)
                             End If
 
                             If .ipAddresses.Add(strSourceIP) AndAlso strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) Then
@@ -396,11 +396,11 @@ Namespace SyslogParser
 
                     Dim rowGUID As Guid = Guid.NewGuid
 
-                    If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(message, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType, rowGUID)
+                    If alertsList IsNot Nothing AndAlso alertsList.Any() Then boolAlerted = ProcessAlerts(strMessage, strAlertText, Now.ToString, strSourceIP, strRawLogText, AlertType, rowGUID)
 
                     ' Step 4: Add to log list, separating header and message
                     If Not My.Settings.OnlySaveAlertedLogs OrElse boolAlerted Then
-                        AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, strPriorityString, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog, rowGUID)
+                        AddToLogList(strTimeStamp, strSourceIP, strHostname, strAppName, strMessage, boolIgnored, boolAlerted, strPriorityString, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog, rowGUID)
                     End If
                 End If
             Catch ex2 As FormatException

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -142,6 +142,16 @@ Namespace SyslogParser
 
                 Return (facilityDescription, severityDescription)
             Else
+                If Not Integer.TryParse(strPriority, priorityNumber) Then
+                    AddToLogList(Nothing, $"Invalid PRI: not a valid 32-bit integer: {strPriority}")
+                    Return ("No Facility", "No Severity")
+                End If
+
+                If priorityNumber < 0 OrElse priorityNumber > 191 Then
+                    AddToLogList(Nothing, $"Invalid PRI: out of range (0–191): {priorityNumber}")
+                    Return ("No Facility", "No Severity")
+                End If
+
                 Return ("No Facility", "No Severity")
             End If
         End Function

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -341,7 +341,7 @@ Namespace SyslogParser
                         hostname = ""
                         appName = ""
                         priorityObject = ("Local", "Error")
-                        message = $"An error occured while attempting to parse the log entry. Below is the log entry that failed...{vbCrLf}{strRawLogText}" ' Something went wrong, we couldn't parse the entry so we're going to just pass the raw log entry to the program.
+                        message = $"The log entry did not match a supported syslog format. Below is the raw entry:{vbCrLf}{strRawLogText}" ' Something went wrong, we couldn't parse the entry so we're going to just pass the raw log entry to the program.
                     End If
 
                     If Not String.IsNullOrWhiteSpace(message) AndAlso message.CaseInsensitiveContains(strNewLine) Then message = message.Replace(strNewLine, vbCrLf).Trim

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -110,21 +110,33 @@ Namespace SyslogParser
                               End Sub)
         End Sub
 
+        ''' <summary>
+        ''' Parses the priority value from the syslog message and returns the corresponding facility and severity as per RFC 5424.
+        ''' </summary>
+        ''' <param name="strPriority">The String representation of the PRI.</param>
+        ''' <returns>A Tuple representing what the PRI string means.</returns>
+        ''' <exception cref="FormatException" />
         Private Function GetSeverityAndFacility(strPriority As String) As (Facility As String, Severity As String)
             If String.IsNullOrWhiteSpace(strPriority) Then
-                Return ("No Facility", "No Severity")
+                Throw New FormatException("Empty PRI input")
             End If
 
             strPriority = strPriority.Replace("<", "").Replace(">", "").Trim
 
             Dim priorityNumber As Integer
 
-            If Integer.TryParse(strPriority, priorityNumber) Then
-                ' Define the severity levels as per RFC 5424
-                Dim severityLevels() As String = {"Emergency", "Alert", "Critical", "Error", "Warning", "Notice", "Informational", "Debug"}
+            If Not Integer.TryParse(strPriority, priorityNumber) Then
+                Throw New FormatException($"Invalid PRI: not a valid 32-bit integer: {strPriority}")
+            End If
 
-                ' Define the facility levels as per RFC 5424
-                Dim facilityLevels() As String = {"Kernel messages", "User-level messages", "Mail system", "System daemons",
+            If priorityNumber < 0 OrElse priorityNumber > 191 Then
+                Throw New FormatException($"Invalid PRI: out of range (0–191): {priorityNumber}")
+            End If
+
+            Dim severityLevels() As String = {"Emergency", "Alert", "Critical", "Error", "Warning", "Notice", "Informational", "Debug"}
+
+            ' Define the facility levels as per RFC 5424
+            Dim facilityLevels() As String = {"Kernel messages", "User-level messages", "Mail system", "System daemons",
                                                "Security/authorization messages", "Messages generated internally by syslogd",
                                                "Line printer subsystem", "Network news subsystem", "UUCP subsystem",
                                                "Clock daemon", "Security/authorization messages", "FTP daemon",
@@ -132,28 +144,12 @@ Namespace SyslogParser
                                                "Local use 0", "Local use 1", "Local use 2", "Local use 3", "Local use 4",
                                                "Local use 5", "Local use 6", "Local use 7"}
 
-                ' Calculate facility and severity
-                Dim facility As Integer = priorityNumber \ 8
-                Dim severity As Integer = priorityNumber Mod 8
+            ' Calculate facility and severity
+            Dim facility As Integer = priorityNumber \ 8
+            Dim severity As Integer = priorityNumber Mod 8
 
-                ' Get facility and severity descriptions
-                Dim facilityDescription As String = If(facility >= 0 And facility < facilityLevels.Length, facilityLevels(facility), "Unknown Facility")
-                Dim severityDescription As String = If(severity >= 0 And severity < severityLevels.Length, severityLevels(severity), "Unknown Severity")
-
-                Return (facilityDescription, severityDescription)
-            Else
-                If Not Integer.TryParse(strPriority, priorityNumber) Then
-                    AddToLogList(Nothing, $"Invalid PRI: not a valid 32-bit integer: {strPriority}")
-                    Return ("No Facility", "No Severity")
-                End If
-
-                If priorityNumber < 0 OrElse priorityNumber > 191 Then
-                    AddToLogList(Nothing, $"Invalid PRI: out of range (0–191): {priorityNumber}")
-                    Return ("No Facility", "No Severity")
-                End If
-
-                Return ("No Facility", "No Severity")
-            End If
+            ' Return facility and severity descriptions
+            Return (facilityLevels(facility), severityLevels(severity))
         End Function
 
         ''' <summary>Parses a date timestamp in String format to a Date Object.</summary>
@@ -406,6 +402,8 @@ Namespace SyslogParser
                         AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog, rowGUID)
                     End If
                 End If
+            Catch ex2 As FormatException
+                AddToLogList(Nothing, $"{ex2.Message}{vbCrLf}The log that failed parsing was...{vbCrLf}{strRawLogText}")
             Catch ex As Exception
                 AddToLogList(Nothing, $"{ex.Message} -- {ex.StackTrace}{vbCrLf}Data from Server: {strRawLogText}")
             End Try

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -8,7 +8,7 @@ Imports Free_SysLog.SupportCode
 
 Namespace SyslogParser
     Public Module SyslogParser
-        Private ReadOnly rfc5424Regex As New Regex("<(?<priority>[0-9]+)>(?:\d ){0,1}(?<timestamp>[0-9]{4}[-.](?:1[0-2]|0[1-9])[-.](?:3[01]|[12][0-9]|0[1-9])T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]\.[0-9]+Z)(?: -){0,1} (?<hostname>(?:\\.|[^\n\r ])+) (?:\d+ ){0,1}(?<appname>(?:\\.|[^\n\r:]+?)(?: \d*){0,1}):{0,1} (?:- - %% ){0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
+        Private ReadOnly rfc5424Regex As New Regex("<(?<priority>[0-9]+)>(?:\d ){0,1}(?<timestamp>[0-9]{4}[-.](?:1[0-2]|0[1-9])[-.](?:3[01]|[12][0-9]|0[1-9])T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9](?:\.[0-9]+)?Z)(?: -){0,1} (?<hostname>(?:\\.|[^\n\r ])+) (?:\d+ ){0,1}(?<appname>(?:\\.|[^\n\r:]+?)(?: \d*){0,1}):{0,1} (?:- - %% ){0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
         Private ReadOnly rfc5424TransformRegex As New Regex("<{0,1}(?<priority>[0-9]{0,})>{0,1}(?<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) {1,2}[0-9]{1,2} [0-2][0-9]:[0-5][0-9]:[0-5][0-9]) (?<hostname>(?:\\.|[^\n\r ])+)(?: \:){0,1} \[{0,1}(?<appname>(?:\\.|[^\n\r:]+))\]{0,1}:{0,1} {0,1}(?<message>.+?)(?=\s*<\d+>|$)", RegexOptions.Compiled) ' PERFECT!
 
         Private ReadOnly embeddedCommandParsingRegEx As New Regex("([A-Z_][A-Z0-9_]*)\(([^()]*)\)", RegexOptions.Compiled)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -323,7 +323,7 @@ Namespace SyslogParser
                     Dim AlertType As AlertType = AlertType.None
                     Dim strIgnoredPattern As String = Nothing
                     Dim boolRecordIgnoredLog As Boolean = False
-                    Dim logType As String = Nothing
+                    Dim strPriorityString As String = Nothing
 
                     If My.Settings.ProcessReplacementsInSyslogDataFirst AndAlso replacementsList IsNot Nothing AndAlso replacementsList.Any() Then
                         strRawLogText = ProcessReplacements(strRawLogText)
@@ -368,16 +368,16 @@ Namespace SyslogParser
                         End If
                     End If
 
+                    If Not String.IsNullOrWhiteSpace(priority) Then strPriorityString = $"{priorityObject.Severity}, {priorityObject.Facility}"
+
                     If Not boolIgnored Then
                         Dim strLimitBy As String = Nothing
 
                         ParentForm.boxLimitBy.Invoke(Sub() strLimitBy = ParentForm.boxLimitBy.Text)
 
-                        If Not String.IsNullOrWhiteSpace(priority) Then logType = $"{priorityObject.Severity}, {priorityObject.Facility}"
-
                         With recentUniqueObjects
-                            If Not String.IsNullOrWhiteSpace(logType) AndAlso .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
-                                ParentForm.boxLimiter.Items.Add(logType)
+                            If Not String.IsNullOrWhiteSpace(strPriorityString) AndAlso .logTypes.Add(strPriorityString) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                                ParentForm.boxLimiter.Items.Add(strPriorityString)
                             End If
 
                             If .processes.Add(appName) AndAlso strLimitBy.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
@@ -400,7 +400,7 @@ Namespace SyslogParser
 
                     ' Step 4: Add to log list, separating header and message
                     If Not My.Settings.OnlySaveAlertedLogs OrElse boolAlerted Then
-                        AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, priorityObject, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog, rowGUID)
+                        AddToLogList(timestamp, strSourceIP, hostname, appName, message, boolIgnored, boolAlerted, strPriorityString, strRawLogText, strAlertText, AlertType, strIgnoredPattern, boolRecordIgnoredLog, rowGUID)
                     End If
                 End If
             Catch ex2 As FormatException
@@ -481,12 +481,9 @@ Namespace SyslogParser
             End Try
         End Function
 
-        Private Sub AddToLogList(strTimeStampFromServer As String, strSourceIP As String, strHostname As String, strRemoteProcess As String, strLogText As String, boolIgnored As Boolean, boolAlerted As Boolean, priority As (Facility As String, Severity As String), strRawLogText As String, strAlertText As String, alertType As AlertType, strIgnoredPattern As String, boolRecordIgnoredLog As Boolean, rowGUID As Guid)
+        Private Sub AddToLogList(strTimeStampFromServer As String, strSourceIP As String, strHostname As String, strRemoteProcess As String, strLogText As String, boolIgnored As Boolean, boolAlerted As Boolean, strPriorityString As String, strRawLogText As String, strAlertText As String, alertType As AlertType, strIgnoredPattern As String, boolRecordIgnoredLog As Boolean, rowGUID As Guid)
             Dim currentDate As Date = Now.ToLocalTime
             Dim serverDate As Date
-            Dim strPriorityString As String = Nothing
-
-            If Not String.IsNullOrWhiteSpace(priority.Severity) AndAlso Not String.IsNullOrWhiteSpace(priority.Facility) Then strPriorityString = $"{priority.Severity}, {priority.Facility}"
 
             If String.IsNullOrWhiteSpace(strTimeStampFromServer) Then
                 serverDate = currentDate

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -323,6 +323,7 @@ Namespace SyslogParser
                     Dim AlertType As AlertType = AlertType.None
                     Dim strIgnoredPattern As String = Nothing
                     Dim boolRecordIgnoredLog As Boolean = False
+                    Dim logType As String = Nothing
 
                     If My.Settings.ProcessReplacementsInSyslogDataFirst AndAlso replacementsList IsNot Nothing AndAlso replacementsList.Any() Then
                         strRawLogText = ProcessReplacements(strRawLogText)
@@ -341,7 +342,7 @@ Namespace SyslogParser
 
                         If SupportCode.hostnames.TryGetValue(strSourceIP, customHostname) Then hostname = customHostname
 
-                        priorityObject = GetSeverityAndFacility(priority)
+                        If Not String.IsNullOrWhiteSpace(priority) Then priorityObject = GetSeverityAndFacility(priority)
                     Else
                         timestamp = Now.ToString
                         hostname = ""
@@ -372,10 +373,10 @@ Namespace SyslogParser
 
                         ParentForm.boxLimitBy.Invoke(Sub() strLimitBy = ParentForm.boxLimitBy.Text)
 
-                        Dim logType As String = $"{priorityObject.Severity}, {priorityObject.Facility}"
+                        If Not String.IsNullOrWhiteSpace(priority) Then logType = $"{priorityObject.Severity}, {priorityObject.Facility}"
 
                         With recentUniqueObjects
-                            If .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
+                            If Not String.IsNullOrWhiteSpace(logType) AndAlso .logTypes.Add(logType) AndAlso strLimitBy.Equals("Log Type", StringComparison.OrdinalIgnoreCase) Then
                                 ParentForm.boxLimiter.Items.Add(logType)
                             End If
 
@@ -483,6 +484,9 @@ Namespace SyslogParser
         Private Sub AddToLogList(strTimeStampFromServer As String, strSourceIP As String, strHostname As String, strRemoteProcess As String, strLogText As String, boolIgnored As Boolean, boolAlerted As Boolean, priority As (Facility As String, Severity As String), strRawLogText As String, strAlertText As String, alertType As AlertType, strIgnoredPattern As String, boolRecordIgnoredLog As Boolean, rowGUID As Guid)
             Dim currentDate As Date = Now.ToLocalTime
             Dim serverDate As Date
+            Dim strPriorityString As String = Nothing
+
+            If Not String.IsNullOrWhiteSpace(priority.Severity) AndAlso Not String.IsNullOrWhiteSpace(priority.Facility) Then strPriorityString = $"{priority.Severity}, {priority.Facility}"
 
             If String.IsNullOrWhiteSpace(strTimeStampFromServer) Then
                 serverDate = currentDate
@@ -505,7 +509,7 @@ Namespace SyslogParser
                                                              strHostname:=strHostname,
                                                              strRemoteProcess:=strRemoteProcess,
                                                              strLog:=strLogText,
-                                                             strLogType:=$"{priority.Severity}, {priority.Facility}",
+                                                             strLogType:=strPriorityString,
                                                              boolAlerted:=boolAlerted,
                                                              strRawLogText:=strRawLogText.Trim,
                                                              strAlertText:=strAlertText,
@@ -535,7 +539,7 @@ Namespace SyslogParser
                                                                                   strHostname:=strHostname,
                                                                                   strRemoteProcess:=strRemoteProcess,
                                                                                   strLog:=strLogText,
-                                                                                  strLogType:=$"{priority.Severity}, {priority.Facility}",
+                                                                                  strLogType:=strPriorityString,
                                                                                   boolAlerted:=boolAlerted,
                                                                                   strRawLogText:=strRawLogText.Trim,
                                                                                   strAlertText:=strAlertText,

--- a/Free SysLog/Windows/Calendar.Designer.vb
+++ b/Free SysLog/Windows/Calendar.Designer.vb
@@ -1,0 +1,126 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class frmCalendar
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.startDateTimePicker = New System.Windows.Forms.DateTimePicker()
+        Me.lblStarting = New System.Windows.Forms.Label()
+        Me.lblEnding = New System.Windows.Forms.Label()
+        Me.endDateTimePicker = New System.Windows.Forms.DateTimePicker()
+        Me.btnOK = New System.Windows.Forms.Button()
+        Me.TableLayoutPanel1 = New System.Windows.Forms.TableLayoutPanel()
+        Me.btnCancel = New System.Windows.Forms.Button()
+        Me.TableLayoutPanel1.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'startDateTimePicker
+        '
+        Me.startDateTimePicker.Location = New System.Drawing.Point(61, 4)
+        Me.startDateTimePicker.Name = "startDateTimePicker"
+        Me.startDateTimePicker.Size = New System.Drawing.Size(200, 20)
+        Me.startDateTimePicker.TabIndex = 1
+        '
+        'lblStarting
+        '
+        Me.lblStarting.AutoSize = True
+        Me.lblStarting.Location = New System.Drawing.Point(12, 10)
+        Me.lblStarting.Name = "lblStarting"
+        Me.lblStarting.Size = New System.Drawing.Size(43, 13)
+        Me.lblStarting.TabIndex = 2
+        Me.lblStarting.Text = "Starting"
+        '
+        'lblEnding
+        '
+        Me.lblEnding.AutoSize = True
+        Me.lblEnding.Location = New System.Drawing.Point(15, 36)
+        Me.lblEnding.Name = "lblEnding"
+        Me.lblEnding.Size = New System.Drawing.Size(40, 13)
+        Me.lblEnding.TabIndex = 4
+        Me.lblEnding.Text = "Ending"
+        '
+        'endDateTimePicker
+        '
+        Me.endDateTimePicker.Location = New System.Drawing.Point(61, 30)
+        Me.endDateTimePicker.Name = "endDateTimePicker"
+        Me.endDateTimePicker.Size = New System.Drawing.Size(200, 20)
+        Me.endDateTimePicker.TabIndex = 3
+        '
+        'btnOK
+        '
+        Me.btnOK.Location = New System.Drawing.Point(3, 3)
+        Me.btnOK.Name = "btnOK"
+        Me.btnOK.Size = New System.Drawing.Size(118, 23)
+        Me.btnOK.TabIndex = 5
+        Me.btnOK.Text = "OK"
+        Me.btnOK.UseVisualStyleBackColor = True
+        '
+        'TableLayoutPanel1
+        '
+        Me.TableLayoutPanel1.ColumnCount = 2
+        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
+        Me.TableLayoutPanel1.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
+        Me.TableLayoutPanel1.Controls.Add(Me.btnCancel, 1, 0)
+        Me.TableLayoutPanel1.Controls.Add(Me.btnOK, 0, 0)
+        Me.TableLayoutPanel1.Location = New System.Drawing.Point(12, 56)
+        Me.TableLayoutPanel1.Name = "TableLayoutPanel1"
+        Me.TableLayoutPanel1.RowCount = 1
+        Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50.0!))
+        Me.TableLayoutPanel1.Size = New System.Drawing.Size(249, 31)
+        Me.TableLayoutPanel1.TabIndex = 6
+        '
+        'btnCancel
+        '
+        Me.btnCancel.Location = New System.Drawing.Point(127, 3)
+        Me.btnCancel.Name = "btnCancel"
+        Me.btnCancel.Size = New System.Drawing.Size(118, 23)
+        Me.btnCancel.TabIndex = 6
+        Me.btnCancel.Text = "Cancel"
+        Me.btnCancel.UseVisualStyleBackColor = True
+        '
+        'frmCalendar
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(271, 93)
+        Me.Controls.Add(Me.TableLayoutPanel1)
+        Me.Controls.Add(Me.lblEnding)
+        Me.Controls.Add(Me.endDateTimePicker)
+        Me.Controls.Add(Me.lblStarting)
+        Me.Controls.Add(Me.startDateTimePicker)
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.Name = "frmCalendar"
+        Me.Text = "Calendar"
+        Me.TableLayoutPanel1.ResumeLayout(False)
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+    Friend WithEvents startDateTimePicker As DateTimePicker
+    Friend WithEvents lblStarting As Label
+    Friend WithEvents lblEnding As Label
+    Friend WithEvents endDateTimePicker As DateTimePicker
+    Friend WithEvents btnOK As Button
+    Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
+    Friend WithEvents btnCancel As Button
+End Class

--- a/Free SysLog/Windows/Calendar.resx
+++ b/Free SysLog/Windows/Calendar.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Free SysLog/Windows/Calendar.vb
+++ b/Free SysLog/Windows/Calendar.vb
@@ -1,0 +1,39 @@
+﻿Public Class frmCalendar
+    Public Property startDate As Date
+        Get
+            Return startDateTimePicker.Value
+        End Get
+        Set(value As Date)
+            If Not value.Equals(Date.MinValue) Then startDateTimePicker.Value = value
+        End Set
+    End Property
+
+    Public Property endDate As Date
+        Get
+            Return endDateTimePicker.Value
+        End Get
+        Set(value As Date)
+            If Not value.Equals(Date.MaxValue) Then endDateTimePicker.Value = value
+        End Set
+    End Property
+
+    Public WriteOnly Property minDate As Date
+        Set(value As Date)
+            startDateTimePicker.MinDate = value
+        End Set
+    End Property
+
+    Private Sub btnOK_Click(sender As Object, e As EventArgs) Handles btnOK.Click
+        startDate = startDateTimePicker.Value
+        endDate = endDateTimePicker.Value
+        Close()
+    End Sub
+
+    Private Sub btnCancel_Click(sender As Object, e As EventArgs) Handles btnCancel.Click
+        Close()
+    End Sub
+
+    Private Sub frmCalendar_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        endDateTimePicker.MaxDate = Date.Now.AddDays(-1)
+    End Sub
+End Class

--- a/Free SysLog/Windows/Calendar.vb
+++ b/Free SysLog/Windows/Calendar.vb
@@ -1,4 +1,6 @@
 ﻿Public Class frmCalendar
+    Public Property results As MsgBoxResult = MsgBoxResult.Cancel
+
     Public Property startDate As Date
         Get
             Return startDateTimePicker.Value
@@ -26,6 +28,7 @@
     Private Sub btnOK_Click(sender As Object, e As EventArgs) Handles btnOK.Click
         startDate = startDateTimePicker.Value
         endDate = endDateTimePicker.Value
+        results = MsgBoxResult.Ok
         Close()
     End Sub
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -1,9 +1,10 @@
 ﻿Imports System.ComponentModel
+Imports System.Data.Common
 Imports System.IO
 Imports System.Text.RegularExpressions
+Imports System.Threading.Tasks
 Imports System.Xml.Serialization
 Imports Free_SysLog.SupportCode
-Imports System.Threading.Tasks
 
 Public Class IgnoredLogsAndSearchResults
     Public LogsToBeDisplayed As List(Of MyDataGridViewRow)
@@ -242,7 +243,10 @@ Public Class IgnoredLogsAndSearchResults
                                                                                                         End Sub)
 
 
-                                                           Invoke(Sub() Logs.ResumeLayout())
+                                                           Invoke(Sub()
+                                                                      Logs.ResumeLayout()
+                                                                      SortLogsByDateObject(0, sortOrder)
+                                                                  End Sub)
                                                        End SyncLock
                                                    End Sub)
         ElseIf _WindowDisplayMode = IgnoreOrSearchWindowDisplayMode.viewer AndAlso boolLoadExternalData AndAlso Not String.IsNullOrEmpty(strFileToLoad) Then

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -62,6 +62,7 @@ Partial Class ViewLogBackups
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
         Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.RenameToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.btnLimitByDate = New System.Windows.Forms.Button()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.StatusStrip1.SuspendLayout()
         CType(Me.FileList, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -84,7 +85,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(953, 243)
+        Me.FileList.Size = New System.Drawing.Size(1068, 243)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -182,7 +183,7 @@ Partial Class ViewLogBackups
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.LblTotalDiskSpace})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(978, 22)
+        Me.StatusStrip1.Size = New System.Drawing.Size(1093, 22)
         Me.StatusStrip1.TabIndex = 5
         Me.StatusStrip1.Text = "StatusStrip1"
         '
@@ -232,7 +233,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowCompressionSizeDifference.AutoSize = True
-        Me.ChkShowCompressionSizeDifference.Location = New System.Drawing.Point(554, 292)
+        Me.ChkShowCompressionSizeDifference.Location = New System.Drawing.Point(670, 292)
         Me.ChkShowCompressionSizeDifference.Name = "ChkShowCompressionSizeDifference"
         Me.ChkShowCompressionSizeDifference.Size = New System.Drawing.Size(196, 17)
         Me.ChkShowCompressionSizeDifference.TabIndex = 43
@@ -243,7 +244,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowCompressionSizeDifferencePercentage.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowCompressionSizeDifferencePercentage.AutoSize = True
-        Me.ChkShowCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(554, 319)
+        Me.ChkShowCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(670, 319)
         Me.ChkShowCompressionSizeDifferencePercentage.Name = "ChkShowCompressionSizeDifferencePercentage"
         Me.ChkShowCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(254, 17)
         Me.ChkShowCompressionSizeDifferencePercentage.TabIndex = 44
@@ -289,7 +290,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHidden.AutoSize = True
-        Me.ChkShowHidden.Location = New System.Drawing.Point(814, 292)
+        Me.ChkShowHidden.Location = New System.Drawing.Point(930, 292)
         Me.ChkShowHidden.Name = "ChkShowHidden"
         Me.ChkShowHidden.Size = New System.Drawing.Size(114, 17)
         Me.ChkShowHidden.TabIndex = 34
@@ -307,7 +308,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHiddenAsGray.AutoSize = True
-        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(814, 319)
+        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(930, 319)
         Me.ChkShowHiddenAsGray.Name = "ChkShowHiddenAsGray"
         Me.ChkShowHiddenAsGray.Size = New System.Drawing.Size(153, 17)
         Me.ChkShowHiddenAsGray.TabIndex = 35
@@ -333,7 +334,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkIgnoreSearchResultsLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkIgnoreSearchResultsLimits.AutoSize = True
-        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(814, 265)
+        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(930, 265)
         Me.ChkIgnoreSearchResultsLimits.Name = "ChkIgnoreSearchResultsLimits"
         Me.ChkIgnoreSearchResultsLimits.Size = New System.Drawing.Size(160, 17)
         Me.ChkIgnoreSearchResultsLimits.TabIndex = 37
@@ -351,7 +352,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkLogFileDeletions.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkLogFileDeletions.AutoSize = True
-        Me.ChkLogFileDeletions.Location = New System.Drawing.Point(554, 265)
+        Me.ChkLogFileDeletions.Location = New System.Drawing.Point(670, 265)
         Me.ChkLogFileDeletions.Name = "ChkLogFileDeletions"
         Me.ChkLogFileDeletions.Size = New System.Drawing.Size(127, 17)
         Me.ChkLogFileDeletions.TabIndex = 38
@@ -408,11 +409,21 @@ Partial Class ViewLogBackups
         Me.ShowInWindowsExplorerToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.ShowInWindowsExplorerToolStripMenuItem.Text = "Show in Windows Explorer"
         '
+        'btnLimitByDate
+        '
+        Me.btnLimitByDate.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnLimitByDate.Location = New System.Drawing.Point(554, 288)
+        Me.btnLimitByDate.Name = "btnLimitByDate"
+        Me.btnLimitByDate.Size = New System.Drawing.Size(110, 23)
+        Me.btnLimitByDate.TabIndex = 45
+        Me.btnLimitByDate.Text = "Limit by Date"
+        Me.btnLimitByDate.UseVisualStyleBackColor = True
+        '
         'ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(978, 364)
+        Me.ClientSize = New System.Drawing.Size(1093, 364)
         Me.Controls.Add(Me.btnViewLogsWithLimits)
         Me.Controls.Add(Me.boxLimiter)
         Me.Controls.Add(Me.boxLimitBy)
@@ -433,10 +444,11 @@ Partial Class ViewLogBackups
         Me.Controls.Add(Me.ChkLogFileDeletions)
         Me.Controls.Add(Me.ChkShowCompressionSizeDifference)
         Me.Controls.Add(Me.ChkShowCompressionSizeDifferencePercentage)
+        Me.Controls.Add(Me.btnLimitByDate)
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(994, 403)
+        Me.MinimumSize = New System.Drawing.Size(1109, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)
@@ -487,4 +499,5 @@ Partial Class ViewLogBackups
     Friend WithEvents UncompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ChkShowCompressionSizeDifference As CheckBox
     Friend WithEvents ChkShowCompressionSizeDifferencePercentage As CheckBox
+    Friend WithEvents btnLimitByDate As Button
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -53,7 +53,6 @@ Partial Class ViewLogBackups
         Me.ChkIgnoreSearchResultsLimits = New System.Windows.Forms.CheckBox()
         Me.ChkLogFileDeletions = New System.Windows.Forms.CheckBox()
         Me.lblNumberOfHiddenFiles = New System.Windows.Forms.ToolStripStatusLabel()
-        Me.lblTotalNumberOfHiddenLogs = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
@@ -180,7 +179,7 @@ Partial Class ViewLogBackups
         '
         'StatusStrip1
         '
-        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.lblTotalNumberOfHiddenLogs, Me.LblTotalDiskSpace})
+        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.LblTotalDiskSpace})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
         Me.StatusStrip1.Name = "StatusStrip1"
         Me.StatusStrip1.Size = New System.Drawing.Size(978, 22)
@@ -322,14 +321,6 @@ Partial Class ViewLogBackups
         Me.lblNumberOfHiddenFiles.Size = New System.Drawing.Size(136, 17)
         Me.lblNumberOfHiddenFiles.Text = "Number of Hidden Files:"
         Me.lblNumberOfHiddenFiles.Visible = False
-        '
-        'lblTotalNumberOfHiddenLogs
-        '
-        Me.lblTotalNumberOfHiddenLogs.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
-        Me.lblTotalNumberOfHiddenLogs.Name = "lblTotalNumberOfHiddenLogs"
-        Me.lblTotalNumberOfHiddenLogs.Size = New System.Drawing.Size(138, 17)
-        Me.lblTotalNumberOfHiddenLogs.Text = "Number of Hidden Logs:"
-        Me.lblTotalNumberOfHiddenLogs.Visible = False
         '
         'LblTotalDiskSpace
         '
@@ -481,7 +472,6 @@ Partial Class ViewLogBackups
     Friend WithEvents colHidden As DataGridViewTextBoxColumn
     Friend WithEvents ChkShowHiddenAsGray As CheckBox
     Friend WithEvents lblNumberOfHiddenFiles As ToolStripStatusLabel
-    Friend WithEvents lblTotalNumberOfHiddenLogs As ToolStripStatusLabel
     Friend WithEvents LblTotalDiskSpace As ToolStripStatusLabel
     Friend WithEvents colEntryCount As DataGridViewTextBoxColumn
     Friend WithEvents ToolTip As ToolTip

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -86,7 +86,7 @@ Partial Class ViewLogBackups
         Me.FileList.ReadOnly = True
         Me.FileList.RowHeadersVisible = False
         Me.FileList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
-        Me.FileList.Size = New System.Drawing.Size(1068, 243)
+        Me.FileList.Size = New System.Drawing.Size(954, 243)
         Me.FileList.TabIndex = 36
         '
         'ColFileName
@@ -184,7 +184,7 @@ Partial Class ViewLogBackups
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.LblTotalDiskSpace})
         Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(1093, 22)
+        Me.StatusStrip1.Size = New System.Drawing.Size(979, 22)
         Me.StatusStrip1.TabIndex = 5
         Me.StatusStrip1.Text = "StatusStrip1"
         '
@@ -234,7 +234,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowCompressionSizeDifference.AutoSize = True
-        Me.ChkShowCompressionSizeDifference.Location = New System.Drawing.Point(670, 292)
+        Me.ChkShowCompressionSizeDifference.Location = New System.Drawing.Point(554, 292)
         Me.ChkShowCompressionSizeDifference.Name = "ChkShowCompressionSizeDifference"
         Me.ChkShowCompressionSizeDifference.Size = New System.Drawing.Size(196, 17)
         Me.ChkShowCompressionSizeDifference.TabIndex = 43
@@ -245,7 +245,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowCompressionSizeDifferencePercentage.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowCompressionSizeDifferencePercentage.AutoSize = True
-        Me.ChkShowCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(670, 319)
+        Me.ChkShowCompressionSizeDifferencePercentage.Location = New System.Drawing.Point(554, 319)
         Me.ChkShowCompressionSizeDifferencePercentage.Name = "ChkShowCompressionSizeDifferencePercentage"
         Me.ChkShowCompressionSizeDifferencePercentage.Size = New System.Drawing.Size(254, 17)
         Me.ChkShowCompressionSizeDifferencePercentage.TabIndex = 44
@@ -291,7 +291,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHidden.AutoSize = True
-        Me.ChkShowHidden.Location = New System.Drawing.Point(930, 292)
+        Me.ChkShowHidden.Location = New System.Drawing.Point(814, 292)
         Me.ChkShowHidden.Name = "ChkShowHidden"
         Me.ChkShowHidden.Size = New System.Drawing.Size(114, 17)
         Me.ChkShowHidden.TabIndex = 34
@@ -309,7 +309,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkShowHiddenAsGray.AutoSize = True
-        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(930, 319)
+        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(814, 319)
         Me.ChkShowHiddenAsGray.Name = "ChkShowHiddenAsGray"
         Me.ChkShowHiddenAsGray.Size = New System.Drawing.Size(153, 17)
         Me.ChkShowHiddenAsGray.TabIndex = 35
@@ -335,7 +335,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkIgnoreSearchResultsLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkIgnoreSearchResultsLimits.AutoSize = True
-        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(930, 265)
+        Me.ChkIgnoreSearchResultsLimits.Location = New System.Drawing.Point(814, 265)
         Me.ChkIgnoreSearchResultsLimits.Name = "ChkIgnoreSearchResultsLimits"
         Me.ChkIgnoreSearchResultsLimits.Size = New System.Drawing.Size(160, 17)
         Me.ChkIgnoreSearchResultsLimits.TabIndex = 37
@@ -353,7 +353,7 @@ Partial Class ViewLogBackups
         '
         Me.ChkLogFileDeletions.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkLogFileDeletions.AutoSize = True
-        Me.ChkLogFileDeletions.Location = New System.Drawing.Point(670, 265)
+        Me.ChkLogFileDeletions.Location = New System.Drawing.Point(554, 265)
         Me.ChkLogFileDeletions.Name = "ChkLogFileDeletions"
         Me.ChkLogFileDeletions.Size = New System.Drawing.Size(127, 17)
         Me.ChkLogFileDeletions.TabIndex = 38
@@ -413,7 +413,7 @@ Partial Class ViewLogBackups
         'btnLimitByDate
         '
         Me.btnLimitByDate.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.btnLimitByDate.Location = New System.Drawing.Point(554, 288)
+        Me.btnLimitByDate.Location = New System.Drawing.Point(322, 261)
         Me.btnLimitByDate.Name = "btnLimitByDate"
         Me.btnLimitByDate.Size = New System.Drawing.Size(110, 23)
         Me.btnLimitByDate.TabIndex = 45
@@ -424,7 +424,7 @@ Partial Class ViewLogBackups
         '
         Me.btnClearDateLimit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.btnClearDateLimit.Enabled = False
-        Me.btnClearDateLimit.Location = New System.Drawing.Point(554, 315)
+        Me.btnClearDateLimit.Location = New System.Drawing.Point(438, 261)
         Me.btnClearDateLimit.Name = "btnClearDateLimit"
         Me.btnClearDateLimit.Size = New System.Drawing.Size(110, 23)
         Me.btnClearDateLimit.TabIndex = 46
@@ -435,7 +435,7 @@ Partial Class ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(1093, 364)
+        Me.ClientSize = New System.Drawing.Size(979, 364)
         Me.Controls.Add(Me.btnViewLogsWithLimits)
         Me.Controls.Add(Me.boxLimiter)
         Me.Controls.Add(Me.boxLimitBy)
@@ -461,7 +461,7 @@ Partial Class ViewLogBackups
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
-        Me.MinimumSize = New System.Drawing.Size(1109, 403)
+        Me.MinimumSize = New System.Drawing.Size(995, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
         Me.ContextMenuStrip1.ResumeLayout(False)

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -51,6 +51,7 @@ Partial Class ViewLogBackups
         Me.UnhideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
         Me.ChkIgnoreSearchResultsLimits = New System.Windows.Forms.CheckBox()
+        Me.btnClearDateLimit = New System.Windows.Forms.Button()
         Me.ChkLogFileDeletions = New System.Windows.Forms.CheckBox()
         Me.lblNumberOfHiddenFiles = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
@@ -419,6 +420,17 @@ Partial Class ViewLogBackups
         Me.btnLimitByDate.Text = "Limit by Date"
         Me.btnLimitByDate.UseVisualStyleBackColor = True
         '
+        'btnClearDateLimit
+        '
+        Me.btnClearDateLimit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnClearDateLimit.Enabled = False
+        Me.btnClearDateLimit.Location = New System.Drawing.Point(554, 315)
+        Me.btnClearDateLimit.Name = "btnClearDateLimit"
+        Me.btnClearDateLimit.Size = New System.Drawing.Size(110, 23)
+        Me.btnClearDateLimit.TabIndex = 46
+        Me.btnClearDateLimit.Text = "Clear Date Limit"
+        Me.btnClearDateLimit.UseVisualStyleBackColor = True
+        '
         'ViewLogBackups
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
@@ -445,6 +457,7 @@ Partial Class ViewLogBackups
         Me.Controls.Add(Me.ChkShowCompressionSizeDifference)
         Me.Controls.Add(Me.ChkShowCompressionSizeDifferencePercentage)
         Me.Controls.Add(Me.btnLimitByDate)
+        Me.Controls.Add(Me.btnClearDateLimit)
         Me.KeyPreview = True
         Me.MaximizeBox = False
         Me.MinimizeBox = False
@@ -500,4 +513,5 @@ Partial Class ViewLogBackups
     Friend WithEvents ChkShowCompressionSizeDifference As CheckBox
     Friend WithEvents ChkShowCompressionSizeDifferencePercentage As CheckBox
     Friend WithEvents btnLimitByDate As Button
+    Friend WithEvents btnClearDateLimit As Button
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -1,6 +1,5 @@
 ﻿Imports System.ComponentModel
 Imports System.IO
-Imports System.Runtime.InteropServices
 Imports System.Text.RegularExpressions
 Imports System.Threading
 Imports System.Threading.Tasks

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -41,23 +41,19 @@ Public Class ViewLogBackups
     End Sub
 
     Private Function GetUncompressedSizeOfGZIPedLogFile(strPathToGZIPedLogFile As String) As Long
-        Try
-            Using fs As New FileStream(strPathToGZIPedLogFile, FileMode.Open, FileAccess.Read, FileShare.Read)
-                If fs.Length < 4 Then Return -1
+        Using fs As New FileStream(strPathToGZIPedLogFile, FileMode.Open, FileAccess.Read, FileShare.Read)
+            If fs.Length < 4 Then Return -1
 
-                fs.Seek(-4, SeekOrigin.End)
+            fs.Seek(-4, SeekOrigin.End)
 
-                Dim sizeBytes(3) As Byte
-                Dim bytesRead As Integer = fs.Read(sizeBytes, 0, 4)
+            Dim sizeBytes(3) As Byte
+            Dim bytesRead As Integer = fs.Read(sizeBytes, 0, 4)
 
-                If bytesRead <> 4 Then Return -1 ' Return -1 to indicate an error occurred
+            If bytesRead <> 4 Then Return -1 ' Return -1 to indicate an error occurred
 
-                ' GZIP stores ISIZE as little-endian UInt32
-                Return BitConverter.ToUInt32(sizeBytes, 0)
-            End Using
-        Catch ex As Exception
-            Return -1 ' Return -1 to indicate an error occurred
-        End Try
+            ' GZIP stores ISIZE as little-endian UInt32
+            Return BitConverter.ToUInt32(sizeBytes, 0)
+        End Using
     End Function
 
     Private Sub SortLogsByDateObject(columnIndex As Integer, order As SortOrder)
@@ -156,19 +152,22 @@ Public Class ViewLogBackups
                                                    If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
                                                        row.Cells(2).Value = FileSizeToHumanSize(file.Length)
 
-                                                       If ChkShowCompressionSizeDifference.Checked Then
-                                                           longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
+                                                       Try
+                                                           If ChkShowCompressionSizeDifference.Checked Then
+                                                               longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
 
-                                                           If longUnCompresedSize <> -1 Then
-                                                               If ChkShowCompressionSizeDifferencePercentage.Checked Then
-                                                                   row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)}"
-                                                                   If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% smaller"
-                                                                   row.Cells(2).Value &= ")"
-                                                               Else
-                                                                   row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)})"
+                                                               If longUnCompresedSize <> -1 Then
+                                                                   If ChkShowCompressionSizeDifferencePercentage.Checked Then
+                                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)}"
+                                                                       If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% smaller"
+                                                                       row.Cells(2).Value &= ")"
+                                                                   Else
+                                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)})"
+                                                                   End If
                                                                End If
                                                            End If
-                                                       End If
+                                                       Catch ex As Exception
+                                                       End Try
 
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
                                                    Else

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -106,6 +106,8 @@ Public Class ViewLogBackups
         startDate = Date.MinValue
         endDate = Date.MaxValue
 
+        btnClearDateLimit.Enabled = False
+
         Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
                                                Interlocked.Add(longUsedDiskSpaceIncludingHidden, file.Length)
 
@@ -991,9 +993,19 @@ Public Class ViewLogBackups
 
         frmCalendar.ShowDialog(Me)
 
-        startDate = frmCalendar.startDate
-        endDate = frmCalendar.endDate
+        If frmCalendar.results = MsgBoxResult.Ok Then
+            startDate = frmCalendar.startDate
+            endDate = frmCalendar.endDate
+
+            btnClearDateLimit.Enabled = True
+        End If
 
         frmCalendar.Dispose()
+    End Sub
+
+    Private Sub btnClearDateLimit_Click(sender As Object, e As EventArgs) Handles btnClearDateLimit.Click
+        startDate = Date.MinValue
+        endDate = Date.MaxValue
+        btnClearDateLimit.Enabled = False
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -12,6 +12,9 @@ Public Class ViewLogBackups
     Private boolDoneLoading As Boolean = False
     Public intSortColumnIndex As Integer = 0 ' Define intColumnNumber at class level
     Public sortOrder As SortOrder = SortOrder.Ascending ' Define soSortOrder at class level
+    Private startDate As Date = Date.MinValue
+    Private endDate As Date = Date.MaxValue
+    Private dateMinimumFromLoadingFiles As Date = Date.MinValue
 
     Private Sub Logs_ColumnHeaderMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles FileList.ColumnHeaderMouseClick
         If e.Button = MouseButtons.Left Then
@@ -97,6 +100,11 @@ Public Class ViewLogBackups
         Dim intFileCount, intHiddenFileCount As Integer
         Dim longTotalLogCount, longUsedDiskSpace, longUsedDiskSpaceIncludingHidden As Long
         Dim intNumberOfCompressedFiles As Integer = 0
+        Dim dateMinimumLockObject As New Object
+
+        dateMinimumFromLoadingFiles = Date.MinValue
+        startDate = Date.MinValue
+        endDate = Date.MaxValue
 
         Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
                                                Interlocked.Add(longUsedDiskSpaceIncludingHidden, file.Length)
@@ -108,6 +116,12 @@ Public Class ViewLogBackups
                                                If Not ChkShowHidden.Checked And boolIsHidden Then
                                                    Exit Sub
                                                End If
+
+                                               SyncLock dateMinimumLockObject
+                                                   If dateMinimumFromLoadingFiles = Date.MinValue OrElse file.LastWriteTime < dateMinimumFromLoadingFiles Then
+                                                       dateMinimumFromLoadingFiles = file.LastWriteTime
+                                                   End If
+                                               End SyncLock
 
                                                Interlocked.Add(longUsedDiskSpace, file.Length)
 
@@ -394,8 +408,13 @@ Public Class ViewLogBackups
 
                                           Dim dataFromFile As List(Of SavedData)
                                           Dim myDataGridRow As MyDataGridViewRow
+                                          Dim boolSearchByDate As Boolean = Not startDate.Equals(Date.MinValue) And Not endDate.Equals(Date.MaxValue)
 
                                           Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
+                                                                                 If boolSearchByDate AndAlso (file.LastWriteTime < startDate OrElse file.LastWriteTime > endDate) Then
+                                                                                     Exit Sub
+                                                                                 End If
+
                                                                                  If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
                                                                                      dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                                  Else
@@ -783,8 +802,13 @@ Public Class ViewLogBackups
                                       Dim dataFromFile As List(Of SavedData)
                                       Dim myDataGridRow As MyDataGridViewRow
                                       Dim boolDidWeHaveAMatch As Boolean = False
+                                      Dim boolSearchByDate As Boolean = Not startDate.Equals(Date.MinValue) And Not endDate.Equals(Date.MaxValue)
 
                                       Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
+                                                                             If boolSearchByDate AndAlso (file.LastWriteTime < startDate OrElse file.LastWriteTime > endDate) Then
+                                                                                 Exit Sub
+                                                                             End If
+
                                                                              If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
                                                                                  dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                              Else
@@ -953,5 +977,23 @@ Public Class ViewLogBackups
     Private Sub ChkShowCompressionSizeDifferencePercentage_Click(sender As Object, e As EventArgs) Handles ChkShowCompressionSizeDifferencePercentage.Click
         My.Settings.ShowCompressionSizeDifferencePercentage = ChkShowCompressionSizeDifferencePercentage.Checked
         ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+    End Sub
+
+    Private Sub btnLimitByDate_Click(sender As Object, e As EventArgs) Handles btnLimitByDate.Click
+        Dim frmCalendar As New frmCalendar With {
+            .StartPosition = FormStartPosition.CenterParent,
+            .Icon = Icon,
+            .Text = "Select Date Range",
+            .startDate = If(startDate.Equals(Date.MinValue), dateMinimumFromLoadingFiles, startDate),
+            .endDate = If(endDate.Equals(Date.MaxValue), Date.Now.AddDays(-1), endDate),
+            .minDate = dateMinimumFromLoadingFiles
+        }
+
+        frmCalendar.ShowDialog(Me)
+
+        startDate = frmCalendar.startDate
+        endDate = frmCalendar.endDate
+
+        frmCalendar.Dispose()
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -214,13 +214,7 @@ Public Class ViewLogBackups
                    FileList.ResumeLayout()
 
                    lblNumberOfFiles.Text = $"Number of Files: {intFileCount:N0}"
-
-                   If intNumberOfCompressedFiles = 0 Then
-                       LblTotalDiskSpace.Text = $"Total Disk Space Used on Disk: {FileSizeToHumanSize(longUsedDiskSpace)}"
-                   Else
-                       LblTotalDiskSpace.Text = $"Total Disk Space Used on Disk: {FileSizeToHumanSize(longUsedDiskSpace)}"
-                   End If
-
+                   LblTotalDiskSpace.Text = $"Total Disk Space Used: {FileSizeToHumanSize(longUsedDiskSpace)}"
                    lblTotalNumberOfLogs.Text = $"Total Number of Logs: {longTotalLogCount:N0}"
 
                    lblNumberOfHiddenFiles.Visible = intHiddenFileCount > 0

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -159,7 +159,7 @@ Public Class ViewLogBackups
                                                                If longUnCompresedSize <> -1 Then
                                                                    If ChkShowCompressionSizeDifferencePercentage.Checked Then
                                                                        row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)}"
-                                                                       If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% smaller"
+                                                                       If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% larger"
                                                                        row.Cells(2).Value &= ")"
                                                                    Else
                                                                        row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)})"

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -99,7 +99,7 @@ Public Class ViewLogBackups
     Private Sub LoadFileList(Optional intReselectItem As Integer = -1)
         Dim filesInDirectory As FileInfo() = New DirectoryInfo(strPathToDataBackupFolder).GetFiles()
         Dim threadSafeListOfDataGridViewRows As New ThreadSafeList(Of DataGridViewRow)
-        Dim intHiddenTotalLogCount, intFileCount, intHiddenFileCount As Integer
+        Dim intFileCount, intHiddenFileCount As Integer
         Dim longTotalLogCount, longUsedDiskSpace, longUsedDiskSpaceIncludingHidden As Long
         Dim intNumberOfCompressedFiles As Integer = 0
 
@@ -107,6 +107,8 @@ Public Class ViewLogBackups
                                                Interlocked.Add(longUsedDiskSpaceIncludingHidden, file.Length)
 
                                                Dim boolIsHidden As Boolean = (file.Attributes And FileAttributes.Hidden) = FileAttributes.Hidden
+
+                                               If boolIsHidden Then Interlocked.Increment(intHiddenFileCount)
 
                                                If Not ChkShowHidden.Checked And boolIsHidden Then
                                                    Exit Sub
@@ -118,13 +120,9 @@ Public Class ViewLogBackups
                                                Dim longUnCompresedSize As Long = -1
 
                                                If intCount <> -1 Then
-                                                   If boolIsHidden Then
-                                                       Interlocked.Increment(intHiddenFileCount)
-                                                       Interlocked.Add(intHiddenTotalLogCount, intCount)
-                                                   Else
-                                                       Interlocked.Increment(intFileCount)
-                                                       Interlocked.Add(longTotalLogCount, intCount)
-                                                   End If
+                                                   If Not boolIsHidden Then Interlocked.Add(longTotalLogCount, intCount)
+
+                                                   Interlocked.Increment(intFileCount)
 
                                                    Dim row As New MyDataGridViewFileRow()
 
@@ -222,10 +220,12 @@ Public Class ViewLogBackups
 
                    lblTotalNumberOfLogs.Text = $"Total Number of Logs: {longTotalLogCount:N0}"
 
-                   lblNumberOfHiddenFiles.Visible = intHiddenFileCount > 0
-                   lblTotalNumberOfHiddenLogs.Visible = intHiddenFileCount > 0
-                   lblNumberOfHiddenFiles.Text = $"Number of Hidden Files: {intHiddenFileCount:N0}"
-                   lblTotalNumberOfHiddenLogs.Text = $"Number of Hidden Logs: {intHiddenTotalLogCount:N0}"
+                   If ChkShowHidden.Checked Then
+                       lblNumberOfHiddenFiles.Visible = False
+                   Else
+                       lblNumberOfHiddenFiles.Visible = intHiddenFileCount > 0
+                       lblNumberOfHiddenFiles.Text = $"Number of Hidden Files: {intHiddenFileCount:N0}"
+                   End If
 
                    If intReselectItem <> -1 AndAlso intReselectItem < FileList.Rows.Count Then
                        FileList.ClearSelection()

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -113,7 +113,7 @@ Public Class ViewLogBackups
                                                Interlocked.Add(longUsedDiskSpace, file.Length)
 
                                                Dim intCount As Integer = GetEntryCount(file.FullName)
-                                               Dim longUnCompresedSize As Long = -1
+                                               Dim longUnCompressedSize As Long = -1
 
                                                If intCount <> -1 Then
                                                    If Not boolIsHidden Then Interlocked.Add(longTotalLogCount, intCount)
@@ -154,15 +154,15 @@ Public Class ViewLogBackups
 
                                                        Try
                                                            If ChkShowCompressionSizeDifference.Checked Then
-                                                               longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
+                                                               longUnCompressedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
 
-                                                               If longUnCompresedSize <> -1 Then
+                                                               If longUnCompressedSize <> -1 Then
                                                                    If ChkShowCompressionSizeDifferencePercentage.Checked Then
-                                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)}"
-                                                                       If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% larger"
+                                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompressedSize)}"
+                                                                       If longUnCompressedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompressedSize * 100):F2}% larger"
                                                                        row.Cells(2).Value &= ")"
                                                                    Else
-                                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)})"
+                                                                       row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompressedSize)})"
                                                                    End If
                                                                End If
                                                            End If

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -135,7 +135,6 @@ Public Class ViewLogBackups
                                                        .Cells(0).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        .Cells(1).Value = $"{file.LastWriteTime:D} {file.LastWriteTime:T}"
-                                                       .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
                                                            longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
@@ -152,8 +151,6 @@ Public Class ViewLogBackups
                                                        Else
                                                            .Cells(2).Value = FileSizeToHumanSize(file.Length)
                                                        End If
-
-                                                       .Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleLeft
 
                                                        .Cells(3).Value = $"{intCount:N0}"
                                                        .Cells(3).Style.Alignment = DataGridViewContentAlignment.MiddleCenter

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -107,6 +107,7 @@ Public Class ViewLogBackups
         endDate = Date.MaxValue
 
         btnClearDateLimit.Enabled = False
+        ToolTip.SetToolTip(btnLimitByDate, "")
 
         Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
                                                Interlocked.Add(longUsedDiskSpaceIncludingHidden, file.Length)
@@ -997,6 +998,8 @@ Public Class ViewLogBackups
             startDate = frmCalendar.startDate
             endDate = frmCalendar.endDate
 
+            ToolTip.SetToolTip(btnLimitByDate, $"{startDate:d} through {endDate:d}")
+
             btnClearDateLimit.Enabled = True
         End If
 
@@ -1007,5 +1010,6 @@ Public Class ViewLogBackups
         startDate = Date.MinValue
         endDate = Date.MaxValue
         btnClearDateLimit.Enabled = False
+        ToolTip.SetToolTip(btnLimitByDate, "")
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -97,21 +97,23 @@ Public Class ViewLogBackups
     End Function
 
     Private Sub LoadFileList(Optional intReselectItem As Integer = -1)
-        Dim filesInDirectory As FileInfo()
-
-        If ChkShowHidden.Checked Then
-            filesInDirectory = New DirectoryInfo(strPathToDataBackupFolder).GetFiles()
-        Else
-            filesInDirectory = New DirectoryInfo(strPathToDataBackupFolder).GetFiles().Where(Function(fileinfo As FileInfo) (fileinfo.Attributes And FileAttributes.Hidden) <> FileAttributes.Hidden).ToArray
-        End If
-
+        Dim filesInDirectory As FileInfo() = New DirectoryInfo(strPathToDataBackupFolder).GetFiles()
         Dim threadSafeListOfDataGridViewRows As New ThreadSafeList(Of DataGridViewRow)
         Dim intHiddenTotalLogCount, intFileCount, intHiddenFileCount As Integer
-        Dim longTotalLogCount, longUsedDiskSpace As Long
+        Dim longTotalLogCount, longUsedDiskSpace, longUsedDiskSpaceIncludingHidden As Long
         Dim intNumberOfCompressedFiles As Integer = 0
 
         Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
+                                               Interlocked.Add(longUsedDiskSpaceIncludingHidden, file.Length)
+
                                                Dim boolIsHidden As Boolean = (file.Attributes And FileAttributes.Hidden) = FileAttributes.Hidden
+
+                                               If Not ChkShowHidden.Checked And boolIsHidden Then
+                                                   Exit Sub
+                                               End If
+
+                                               Interlocked.Add(longUsedDiskSpace, file.Length)
+
                                                Dim intCount As Integer = GetEntryCount(file.FullName)
                                                Dim longUnCompresedSize As Long = -1
 
@@ -183,10 +185,7 @@ Public Class ViewLogBackups
                                                            End If
                                                        End If
 
-                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
-                                                   Else
-                                                       Interlocked.Add(longUsedDiskSpace, file.Length)
                                                    End If
 
                                                    threadSafeListOfDataGridViewRows.Add(row)
@@ -214,7 +213,13 @@ Public Class ViewLogBackups
                    FileList.ResumeLayout()
 
                    lblNumberOfFiles.Text = $"Number of Files: {intFileCount:N0}"
-                   LblTotalDiskSpace.Text = $"Total Disk Space Used: {FileSizeToHumanSize(longUsedDiskSpace)}"
+
+                   If longUsedDiskSpace = longUsedDiskSpaceIncludingHidden Then
+                       LblTotalDiskSpace.Text = $"Total Disk Space Used: {FileSizeToHumanSize(longUsedDiskSpace)}"
+                   Else
+                       LblTotalDiskSpace.Text = $"Total Disk Space Used: {FileSizeToHumanSize(longUsedDiskSpace)} (Including Hidden Files: {FileSizeToHumanSize(longUsedDiskSpaceIncludingHidden)})"
+                   End If
+
                    lblTotalNumberOfLogs.Text = $"Total Number of Logs: {longTotalLogCount:N0}"
 
                    lblNumberOfHiddenFiles.Visible = intHiddenFileCount > 0

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -116,8 +116,7 @@ Public Class ViewLogBackups
                                                Dim longUnCompressedSize As Long = -1
 
                                                If intCount <> -1 Then
-                                                   If Not boolIsHidden Then Interlocked.Add(longTotalLogCount, intCount)
-
+                                                   Interlocked.Add(longTotalLogCount, intCount)
                                                    Interlocked.Increment(intFileCount)
 
                                                    Dim row As New MyDataGridViewFileRow()

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -136,22 +136,6 @@ Public Class ViewLogBackups
 
                                                        .Cells(1).Value = $"{file.LastWriteTime:D} {file.LastWriteTime:T}"
 
-                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
-                                                           longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
-
-                                                           If ChkShowCompressionSizeDifference.Checked Then
-                                                               If longUnCompresedSize = -1 Then
-                                                                   row.Cells(2).Value = "Error"
-                                                               Else
-                                                                   row.Cells(2).Value = FileSizeToHumanSize(longUnCompresedSize)
-                                                               End If
-                                                           Else
-                                                               row.Cells(2).Value = FileSizeToHumanSize(file.Length)
-                                                           End If
-                                                       Else
-                                                           .Cells(2).Value = FileSizeToHumanSize(file.Length)
-                                                       End If
-
                                                        .Cells(3).Value = $"{intCount:N0}"
                                                        .Cells(3).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
@@ -170,17 +154,25 @@ Public Class ViewLogBackups
                                                    row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter
 
                                                    If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then
+                                                       row.Cells(2).Value = FileSizeToHumanSize(file.Length)
+
                                                        If ChkShowCompressionSizeDifference.Checked Then
-                                                           If ChkShowCompressionSizeDifferencePercentage.Checked Then
-                                                               row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)}"
-                                                               If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% smaller"
-                                                               row.Cells(2).Value &= $")"
-                                                           Else
-                                                               row.Cells(2).Value &= $" ({FileSizeToHumanSize(file.Length)})"
+                                                           longUnCompresedSize = GetUncompressedSizeOfGZIPedLogFile(file.FullName)
+
+                                                           If longUnCompresedSize <> -1 Then
+                                                               If ChkShowCompressionSizeDifferencePercentage.Checked Then
+                                                                   row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)}"
+                                                                   If longUnCompresedSize > 0 Then row.Cells(2).Value &= $", {100 - (file.Length / longUnCompresedSize * 100):F2}% smaller"
+                                                                   row.Cells(2).Value &= ")"
+                                                               Else
+                                                                   row.Cells(2).Value &= $" ({FileSizeToHumanSize(longUnCompresedSize)})"
+                                                               End If
                                                            End If
                                                        End If
 
                                                        Interlocked.Increment(intNumberOfCompressedFiles)
+                                                   Else
+                                                       row.Cells(2).Value = FileSizeToHumanSize(file.Length)
                                                    End If
 
                                                    threadSafeListOfDataGridViewRows.Add(row)
@@ -192,7 +184,7 @@ Public Class ViewLogBackups
                    threadSafeListOfDataGridViewRows = Nothing
 
                    If ChkShowCompressionSizeDifference.Checked And intNumberOfCompressedFiles <> 0 Then
-                       ColFileSize.HeaderText = "File Size (Compressed Size)"
+                       ColFileSize.HeaderText = "File Size (Un-Compressed Size)"
                    Else
                        ColFileSize.HeaderText = "File Size"
                    End If


### PR DESCRIPTION
- Improved feedback when attempting to parse invalid incoming syslog data. 474a3458a4d9b95e97774b3dfaffdcc2c30bfe88
- Enhanced PRI parsing with explicit error reporting to the GetSeverityAndFacility() function for invalid and non-parsable values. a2fa9c4d9e379947815f111030247fcfef2c4c90
- Improved RFC 5424 regex parsing to handle optional fractional seconds. 4a28af0876fa08ed9624f7c4edc87510b77557a2
- Refactored the GetSeverityAndFacility() function to enforce strict PRI validation and simplify mapping. 38b2c86a1f99b53a04e6c6c885b90fb4dc9711ed
- Removed some duplicate code on the "View Log Backups" window. cb81d34de75ebe50634ccbbab20ddd7b75ae1055
- Fixed the display of the total file size on disk on the "View Log Backups" when there are hidden files. e825cfa2ca5f29accfd1060eb8f481ffb8cbb129
- Finally got the logic correct when displaying file stats on the "View Log Backups" window when files are hidden. 193430d2bf06888e14155474ed19c021b70a9368
- Changed the order of how the file size is displayed for compressed log files on the "View Log Backups" window. Before it was "File Size (Compressed Size)", now it's "File Size (Un-Compressed Size)". db73787ba77e7174f4ec291bfcd5b03747ca29fd
- Moved the exception handling out of the GetUncompressedSizeOfGZIPedLogFile() function and into the LoadFileList() function. 31afc0a9aec07184376c17afeb103399dc36e778
- Fixed a bug that was causing an incorrect count of the total logs on the "View Log Backups" window. ad85427f286fcc5edda081ee2de86a77269f9fb8
- Added the ability to limit log searches on the "View Log Backups" window by a date range. 38e54d53cc176dab6937d811f33d9a4cd0feb5d6
- Fixed a long standing bug in which the data wasn't being sorted properly when displaying data on the "Ignored Logs and Search Results" window. f336a4b50f5f4e6079c20500be294eb33ccd016a
- Fixed thread safe issue in the LoadUniqueLogTypesAndProcesses() function. 43928e62cc4de8fcbd7b5063c543e1c504c881cc

And a whole lot of other under-the-hood changes to the code.