### PR TITLE
Version 5.5 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.5.1.126")>
+<Assembly: AssemblyFileVersion("5.5.2.127")>

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -796,6 +796,14 @@ Public Class ViewLogBackups
 
         If strLimiter.Equals(strBlank, StringComparison.OrdinalIgnoreCase) Then strLimiter = ""
 
+        If strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) And String.IsNullOrWhiteSpace(strLimiter) Then
+            MsgBox("You must select a hostname to limit by.", MsgBoxStyle.Exclamation, Text)
+            Exit Sub
+        ElseIf strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) And String.IsNullOrWhiteSpace(strLimiter) Then
+            MsgBox("You must select an IP address to limit by.", MsgBoxStyle.Exclamation, Text)
+            Exit Sub
+        End If
+
         BtnSearch.Enabled = False
 
         Dim worker As New BackgroundWorker()

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -15,6 +15,7 @@ Public Class ViewLogBackups
     Private startDate As Date = Date.MinValue
     Private endDate As Date = Date.MaxValue
     Private dateMinimumFromLoadingFiles As Date = Date.MinValue
+    Private Const strBlank As String = "(Blank)"
 
     Private Sub Logs_ColumnHeaderMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles FileList.ColumnHeaderMouseClick
         If e.Button = MouseButtons.Left Then
@@ -756,12 +757,16 @@ Public Class ViewLogBackups
             sortedList = combinedUniqueObjects.logTypes.ToList()
             sortedList.Sort()
 
+            boxLimiter.Items.Add(strBlank)
             boxLimiter.Items.AddRange(sortedList.ToArray)
+            boxLimiter.Text = strBlank
         ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
             sortedList = combinedUniqueObjects.processes.ToList()
             sortedList.Sort()
 
+            boxLimiter.Items.Add(strBlank)
             boxLimiter.Items.AddRange(sortedList.ToArray)
+            boxLimiter.Text = strBlank
         ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
             sortedList = combinedUniqueObjects.hostNames.ToList()
             sortedList.Sort()
@@ -788,6 +793,8 @@ Public Class ViewLogBackups
         searchResultsWindow.ChkColLogsAutoFill.Checked = My.Settings.colLogAutoFill
 
         If My.Settings.font IsNot Nothing Then searchResultsWindow.Logs.DefaultCellStyle.Font = My.Settings.font
+
+        If strLimiter.Equals(strBlank, StringComparison.OrdinalIgnoreCase) Then strLimiter = ""
 
         BtnSearch.Enabled = False
 


### PR DESCRIPTION
This is a minor update that includes some small improvements.

- Put in a way to limit logs by a blank or empty value of both "Log Type" and "Remote Process" on the "View Log Backups" window. b6fdc43d1e987c567fdd88dc05c07b9b21512486
- Put in some checks to make sure you select either a hostname or an IP address when limiting the logs on the "VIew Log Backups" window. 660dda288d99c51945413bbc0f3eb96f97dc26b7