### PR TITLE
Version 5.6 Build 1

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.5.2.127")>
+<Assembly: AssemblyFileVersion("5.6.1.128")>

--- a/Free SysLog/Support Code/Namespace Code/Check for Update.vb
+++ b/Free SysLog/Support Code/Namespace Code/Check for Update.vb
@@ -266,9 +266,9 @@ Namespace checkForUpdates
             Catch ex As Exception
                 Dim strCrashFile As String = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Free SysLog Crash Details.log")
                 If File.Exists(strCrashFile) Then File.Delete(strCrashFile)
-                File.WriteAllText(strCrashFile, $"{ex.Message} -- {ex.StackTrace}")
+                File.WriteAllText(strCrashFile, $"{ex.Message} -- {RemovePathFromExceptionString(ex.StackTrace)}")
 
-                MakeLogEntry($"{ex.Message} -- {ex.StackTrace}", True)
+                MakeLogEntry($"{ex.Message} -- {RemovePathFromExceptionString(ex.StackTrace)}", True)
 
                 MsgBox($"An error occurred while attempting to update the program. Crash data has been written to a file named ""Free SysLog Crash Details.log"".{vbCrLf}{vbCrLf}Windows Explorer will open to the file location.", MsgBoxStyle.Critical, strMessageBoxTitleText)
 
@@ -396,7 +396,7 @@ Namespace checkForUpdates
                     End If
                 Catch ex As Exception
                     ' Ok, we crashed but who cares; but we log it.
-                    MakeLogEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
+                    MakeLogEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}")
                 Finally
                     windowObject.Invoke(Sub()
                                             windowObject.BtnCheckForUpdates.Enabled = True

--- a/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
+++ b/Free SysLog/Support Code/Namespace Code/SaveAppSettings.vb
@@ -124,7 +124,7 @@ Namespace SaveAppSettings
 
                 Return True
             Catch ex As Exception
-                MsgBox($"There was an issue decoding your chosen JSON settings file, import failed.{vbCrLf}{vbCrLf}{ex.Message}{ex.StackTrace.Trim}", MsgBoxStyle.Critical, strMessageBoxTitle)
+                MsgBox($"There was an issue decoding your chosen JSON settings file, import failed.{vbCrLf}{vbCrLf}{ex.Message}{RemovePathFromExceptionString(ex.StackTrace.Trim)}", MsgBoxStyle.Critical, strMessageBoxTitle)
                 Return False
             End Try
         End Function

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -484,16 +484,16 @@ Namespace SupportCode
             Return Nothing
         End Function
 
-        Public Function GetProcessByPort(protocolType As ProtocolType) As Process
+        Public Function GetProcessByPort(protocolType As ProtocolType, intPort As Integer) As Process
             Dim processIPv4 As Process = Nothing
             Dim processIPv6 As Process = Nothing
 
             If protocolType = ProtocolType.Tcp Then
-                processIPv4 = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
-                processIPv6 = GetProcessByTcpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
+                processIPv4 = GetProcessByTcpPort(intPort, AddressFamily.InterNetwork)
+                processIPv6 = GetProcessByTcpPort(intPort, AddressFamily.InterNetworkV6)
             ElseIf protocolType = ProtocolType.Udp Then
-                processIPv4 = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetwork)
-                processIPv6 = GetProcessByUdpPort(My.Settings.sysLogPort, AddressFamily.InterNetworkV6)
+                processIPv4 = GetProcessByUdpPort(intPort, AddressFamily.InterNetwork)
+                processIPv6 = GetProcessByUdpPort(intPort, AddressFamily.InterNetworkV6)
             End If
 
             If processIPv4 IsNot Nothing Then

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -58,6 +58,8 @@ Namespace SupportCode
         Public IgnoredRegexCache As New ConcurrentDictionary(Of String, Regex)
         Public IgnoredStats As New ConcurrentDictionary(Of String, IgnoredStatsEntry)
 
+        Public regexRemovePathFromExceptionString As New Regex("([a-zA-Z]:\\|\\\\)(?:[^\\\/:*?""<>|\r\n]+[\\\/])*[^\\\/:*?""<>|\r\n]*", RegexOptions.Compiled)
+
         Public longNumberOfIgnoredLogs As Long = 0
         Public boolIsProgrammaticScroll As Boolean = False
         Public IgnoredLogsAndSearchResultsInstance As IgnoredLogsAndSearchResults = Nothing
@@ -139,6 +141,11 @@ Namespace SupportCode
             Else
                 Return String.Join(" ", parts)
             End If
+        End Function
+
+        Public Function RemovePathFromExceptionString(strException As String) As String
+            If String.IsNullOrWhiteSpace(strException) Then Return strException
+            Return regexRemovePathFromExceptionString.Replace(strException, Function(m As Match) Path.GetFileName(m.Value))
         End Function
 
         Public Function IsGZipFile(strPath As String) As Boolean

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -98,6 +98,8 @@ Namespace SupportCode
         Public Const strUpdaterEXE As String = "updater.exe"
         Public Const strUpdaterPDB As String = "updater.pdb"
 
+        Public Const strBlank As String = "(Blank)"
+
         Public allUniqueObjects As uniqueObjectsClass
         Public recentUniqueObjects As uniqueObjectsClass
         Public ReadOnly IgnoredLogsAndSearchResultsInstanceLockObject As New Object()

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -406,7 +406,7 @@ Namespace SyslogParser
             Catch ex2 As FormatException
                 AddToLogList(Nothing, $"{ex2.Message}{vbCrLf}The log that failed parsing was...{vbCrLf}{strRawLogText}")
             Catch ex As Exception
-                AddToLogList(Nothing, $"{ex.Message} -- {ex.StackTrace}{vbCrLf}Data from Server: {strRawLogText}")
+                AddToLogList(Nothing, $"{ex.Message} -- {RemovePathFromExceptionString(ex.StackTrace)}{vbCrLf}Data from Server: {strRawLogText}")
             End Try
         End Sub
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -280,31 +280,35 @@ Namespace SyslogParser
         End Function
 
         Public Sub ProcessIncomingLog(strRawLogText As String, strSourceIP As String)
-            If Not String.IsNullOrWhiteSpace(strRawLogText) AndAlso Not String.IsNullOrWhiteSpace(strSourceIP) Then
-                ' Convert all linefeeds.
-                strRawLogText = ConvertLineFeeds(strRawLogText)
+            Try
+                If Not String.IsNullOrWhiteSpace(strRawLogText) AndAlso Not String.IsNullOrWhiteSpace(strSourceIP) Then
+                    ' Convert all linefeeds.
+                    strRawLogText = ConvertLineFeeds(strRawLogText)
 
-                ' Do some pre-processing so that we can separate out the data more easily.
-                strRawLogText = strRawLogText.Replace(vbCrLf, strNewLine).Replace(vbLf, strNewLine)
-                strRawLogText = SyslogPreProcessor1.Replace(strRawLogText, "$1")
-                strRawLogText = SyslogPreProcessor2.Replace(strRawLogText, vbCrLf & "$1")
+                    ' Do some pre-processing so that we can separate out the data more easily.
+                    strRawLogText = strRawLogText.Replace(vbCrLf, strNewLine).Replace(vbLf, strNewLine)
+                    strRawLogText = SyslogPreProcessor1.Replace(strRawLogText, "$1")
+                    strRawLogText = SyslogPreProcessor2.Replace(strRawLogText, vbCrLf & "$1")
 
-                ' Split off each syslog entry by using vbCrLf as a delimiter.
-                Dim matches As String() = strRawLogText.Split(vbCrLf)
+                    ' Split off each syslog entry by using vbCrLf as a delimiter.
+                    Dim matches As String() = strRawLogText.Split(vbCrLf)
 
-                ' Check to see if we have anything to work with before we go into the loop.
-                If matches.Any() Then
-                    ' Now work with each syslog entry.
-                    For Each strMatch As String In matches
-                        If Not String.IsNullOrWhiteSpace(strMatch) Then
-                            ProcessIncomingLog_SubRoutine(strMatch, strSourceIP)
-                        End If
-                    Next
-                Else
-                    ' Nope, log it as unable to be parsed.
-                    AddToLogList(Nothing, $"Unable to parse log {strQuote}{strRawLogText}{strQuote}.")
+                    ' Check to see if we have anything to work with before we go into the loop.
+                    If matches.Any() Then
+                        ' Now work with each syslog entry.
+                        For Each strMatch As String In matches
+                            If Not String.IsNullOrWhiteSpace(strMatch) Then
+                                ProcessIncomingLog_SubRoutine(strMatch, strSourceIP)
+                            End If
+                        Next
+                    Else
+                        ' Nope, log it as unable to be parsed.
+                        AddToLogList(Nothing, $"Unable to parse log {strQuote}{strRawLogText}{strQuote}.")
+                    End If
                 End If
-            End If
+            Catch ex As Exception
+                AddToLogList(Nothing, $"{ex.Message} -- {RemovePathFromExceptionString(ex.StackTrace)}{vbCrLf}Data from Server: {strRawLogText}")
+            End Try
         End Sub
 
         Public Sub ProcessIncomingLog_SubRoutine(strRawLogText As String, strSourceIP As String)

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -39,7 +39,7 @@ Namespace SyslogTcpServer
                 Dim activeProcess As Process = GetProcessByPort(ProtocolType.Tcp, My.Settings.sysLogPort)
 
                 If activeProcess Is Nothing Then
-                    ParentForm.Logs.Invoke(Sub() ParentForm.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", ParentForm.Logs)))
+                    ParentForm.Logs.Invoke(Sub() ParentForm.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}", ParentForm.Logs)))
                 Else
                     ParentForm.Logs.Invoke(Sub() ParentForm.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Unable to start syslog TCP server. A process with a PID of {activeProcess.Id} already has the TCP port open.", ParentForm.Logs)))
                 End If

--- a/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog TCP Server.vb
@@ -36,7 +36,7 @@ Namespace SyslogTcpServer
                     Await HandleClientAsync(tcpClient)
                 End While
             Catch ex As Exception
-                Dim activeProcess As Process = GetProcessByPort(ProtocolType.Tcp)
+                Dim activeProcess As Process = GetProcessByPort(ProtocolType.Tcp, My.Settings.sysLogPort)
 
                 If activeProcess Is Nothing Then
                     ParentForm.Logs.Invoke(Sub() ParentForm.Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", ParentForm.Logs)))

--- a/Free SysLog/Windows/Alerts.vb
+++ b/Free SysLog/Windows/Alerts.vb
@@ -331,7 +331,7 @@ Public Class Alerts
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(
                     SyslogParser.MakeLocalDataGridRowEntry(
-                        $"Unable to save user preferences on ""Alerts"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        $"Unable to save user preferences on ""Alerts"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}",
                         SupportCode.ParentForm.Logs
                     )
                 )

--- a/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
+++ b/Free SysLog/Windows/Configure SysLog Mirror Clients.vb
@@ -205,7 +205,7 @@ Public Class ConfigureSysLogMirrorClients
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(
                     SyslogParser.MakeLocalDataGridRowEntry(
-                        $"Unable to save user preferences on ""Configure Syslog Mirror Servers"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        $"Unable to save user preferences on ""Configure Syslog Mirror Servers"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}",
                         SupportCode.ParentForm.Logs
                     )
                 )

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -36,7 +36,6 @@ Public Class Form1
     Private ReplacementsInstance As Replacements
     Private AlertsInstance As Alerts
     Private ConfigureSysLogMirrorClientsInstance As ConfigureSysLogMirrorClients
-    Private Const strBlank As String = "(Blank)"
 #End Region
 
     Private Sub ChkStartAtUserStartup_Click(sender As Object, e As EventArgs) Handles ChkEnableStartAtUserStartup.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1605,6 +1605,10 @@ Public Class Form1
         LogsMenuHideServerTimeColumn.Text = $"{If(colServerTime.Visible, "Hide", "Show")} Server Time Column"
     End Sub
 
+    Private Sub Logs_MouseClick(sender As Object, e As MouseEventArgs) Handles Logs.MouseClick
+        If Logs.HitTest(e.X, e.Y).Type = DataGridViewHitTestType.None Then Logs.ClearSelection()
+    End Sub
+
 #Region "--== SysLog Server Code ==--"
     Sub SysLogThread()
         Try

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1675,7 +1675,7 @@ Public Class Form1
             ' Does nothing
         Catch e As Exception
             Invoke(Sub()
-                       Dim activeProcess As Process = GetProcessByPort(ProtocolType.Udp)
+                       Dim activeProcess As Process = GetProcessByPort(ProtocolType.Udp, My.Settings.sysLogPort)
 
                        If activeProcess Is Nothing Then
                            MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)
@@ -2453,7 +2453,7 @@ Public Class Form1
 
             boolServerRunning = True
         Else
-            Dim activeProcess As Process = GetProcessByPort(ProtocolType.Udp)
+            Dim activeProcess As Process = GetProcessByPort(ProtocolType.Udp, My.Settings.sysLogPort)
 
             If activeProcess Is Nothing Then
                 MsgBox("Unable to start syslog server, perhaps another instance of this program is running on your system.", MsgBoxStyle.Critical + MsgBoxStyle.ApplicationModal, Text)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -36,6 +36,7 @@ Public Class Form1
     Private ReplacementsInstance As Replacements
     Private AlertsInstance As Alerts
     Private ConfigureSysLogMirrorClientsInstance As ConfigureSysLogMirrorClients
+    Private Const strBlank As String = "(Blank)"
 #End Region
 
     Private Sub ChkStartAtUserStartup_Click(sender As Object, e As EventArgs) Handles ChkEnableStartAtUserStartup.Click
@@ -148,12 +149,16 @@ Public Class Form1
             sortedList = recentUniqueObjects.logTypes.ToList()
             sortedList.Sort()
 
+            boxLimiter.Items.Add(strBlank)
             boxLimiter.Items.AddRange(sortedList.ToArray)
+            boxLimiter.Text = strBlank
         ElseIf boxLimitBy.Text.Equals("Remote Process", StringComparison.OrdinalIgnoreCase) Then
             sortedList = recentUniqueObjects.processes.ToList()
             sortedList.Sort()
 
+            boxLimiter.Items.Add(strBlank)
             boxLimiter.Items.AddRange(sortedList.ToArray)
+            boxLimiter.Text = strBlank
         ElseIf boxLimitBy.Text.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) Then
             sortedList = recentUniqueObjects.hostNames.ToList()
             sortedList.Sort()
@@ -1472,6 +1477,8 @@ Public Class Form1
         Dim listOfSearchResults As New List(Of MyDataGridViewRow)
         Dim stopWatch As Stopwatch = Stopwatch.StartNew
         Dim worker As New BackgroundWorker()
+
+        If strLimiter.Equals(strBlank, StringComparison.OrdinalIgnoreCase) Then strLimiter = ""
 
         AddHandler worker.DoWork, Sub()
                                       Threading.Tasks.Parallel.ForEach(Logs.Rows.Cast(Of MyDataGridViewRow), Sub(item As MyDataGridViewRow)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1605,7 +1605,7 @@ Public Class Form1
         LogsMenuHideServerTimeColumn.Text = $"{If(colServerTime.Visible, "Hide", "Show")} Server Time Column"
     End Sub
 
-#Region "-- SysLog Server Code --"
+#Region "--== SysLog Server Code ==--"
     Sub SysLogThread()
         Try
             ' These are initialized as IPv4 mode.

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1683,7 +1683,7 @@ Public Class Form1
                            Dim strLogText As String = $"Unable to start UDP syslog server. A process with a PID of {activeProcess.Id} already has the UDP port open."
 
                            SyncLock dataGridLockObject
-                               Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {e.GetType}{vbCrLf}Exception Message: {e.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{e.StackTrace}", Logs))
+                               Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {e.GetType}{vbCrLf}Exception Message: {e.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{RemovePathFromExceptionString(e.StackTrace)}", Logs))
                                Logs.Rows.Add(SyslogParser.MakeLocalDataGridRowEntry(strLogText, Logs))
                                SelectLatestLogEntry()
                                UpdateLogCount()
@@ -1890,7 +1890,7 @@ Public Class Form1
                        Dim listOfLogEntries As New List(Of MyDataGridViewRow) From {
                            SyslogParser.MakeLocalDataGridRowEntry("Free SysLog Server Started.", Logs),
                            SyslogParser.MakeLocalDataGridRowEntry("There was an error while decoing the JSON data, existing data was copied to another file and the log file was reset.", Logs),
-                           SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}", Logs)
+                           SyslogParser.MakeLocalDataGridRowEntry($"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}", Logs)
                        }
 
                        Logs.Rows.AddRange(listOfLogEntries.ToArray)

--- a/Free SysLog/Windows/Hostnames.vb
+++ b/Free SysLog/Windows/Hostnames.vb
@@ -143,7 +143,7 @@ Public Class Hostnames
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(
                     SyslogParser.MakeLocalDataGridRowEntry(
-                        $"Unable to save user preferences on ""Hostnames"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        $"Unable to save user preferences on ""Hostnames"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{SupportCode.RemovePathFromExceptionString(ex.StackTrace)}",
                         SupportCode.ParentForm.Logs
                     )
                 )

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -539,10 +539,10 @@ Public Class IgnoredLogsAndSearchResults
                             End Sub)
             End If
         Catch ex As Newtonsoft.Json.JsonSerializationException
-            SyslogParser.AddToLogList(Nothing, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
+            SyslogParser.AddToLogList(Nothing, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}")
             MsgBox("There was an error decoding JSON data.", MsgBoxStyle.Critical, Text)
         Catch ex As Newtonsoft.Json.JsonReaderException
-            SyslogParser.AddToLogList(Nothing, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{ex.StackTrace}")
+            SyslogParser.AddToLogList(Nothing, $"Exception Type: {ex.GetType}{vbCrLf}Exception Message: {ex.Message}{vbCrLf}{vbCrLf}Exception Stack Trace{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}")
             MsgBox("There was an error decoding JSON data.", MsgBoxStyle.Critical, Text)
         End Try
     End Sub

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -270,7 +270,7 @@ Public Class IgnoredWordsAndPhrases
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(
                     SyslogParser.MakeLocalDataGridRowEntry(
-                        $"Unable to save user preferences on ""Ignored Words and Phrases"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        $"Unable to save user preferences on ""Ignored Words and Phrases"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}",
                         SupportCode.ParentForm.Logs
                     )
                 )

--- a/Free SysLog/Windows/Replacements.vb
+++ b/Free SysLog/Windows/Replacements.vb
@@ -190,7 +190,7 @@ Public Class Replacements
             SyncLock SupportCode.ParentForm.dataGridLockObject
                 SupportCode.ParentForm.Logs.Rows.Add(
                     SyslogParser.MakeLocalDataGridRowEntry(
-                        $"Unable to save user preferences on ""Replacements"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{ex.StackTrace}",
+                        $"Unable to save user preferences on ""Replacements"" window to program settings.{vbCrLf}{vbCrLf}Exception: {ex.Message}{vbCrLf}{RemovePathFromExceptionString(ex.StackTrace)}",
                         SupportCode.ParentForm.Logs
                     )
                 )

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -397,6 +397,7 @@ Partial Class ViewLogBackups
         'btnViewLogsWithLimits
         '
         Me.btnViewLogsWithLimits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnViewLogsWithLimits.Enabled = False
         Me.btnViewLogsWithLimits.Location = New System.Drawing.Point(438, 288)
         Me.btnViewLogsWithLimits.Name = "btnViewLogsWithLimits"
         Me.btnViewLogsWithLimits.Size = New System.Drawing.Size(110, 23)

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -59,6 +59,7 @@ Partial Class ViewLogBackups
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
         Me.GZIPCompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UncompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.RefreshToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
         Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -119,7 +120,7 @@ Partial Class ViewLogBackups
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.GZIPCompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.RefreshToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.GZIPCompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
         Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 180)
         '
@@ -218,6 +219,12 @@ Partial Class ViewLogBackups
         Me.UncompressFileToolStripMenuItem.Name = "UncompressFileToolStripMenuItem"
         Me.UncompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.UncompressFileToolStripMenuItem.Text = "Uncompress File"
+        '
+        'RefreshToolStripMenuItem
+        '
+        Me.RefreshToolStripMenuItem.Name = "RefreshToolStripMenuItem"
+        Me.RefreshToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.RefreshToolStripMenuItem.Text = "Refresh File List"
         '
         'ChkRegExSearch
         '
@@ -511,6 +518,7 @@ Partial Class ViewLogBackups
     Friend WithEvents RenameToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents GZIPCompressFileToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents UncompressFileToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents RefreshToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents ChkShowCompressionSizeDifference As CheckBox
     Friend WithEvents ChkShowCompressionSizeDifferencePercentage As CheckBox
     Friend WithEvents btnLimitByDate As Button

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -94,7 +94,7 @@ Public Class ViewLogBackups
         End Try
     End Function
 
-    Private Sub LoadFileList(Optional intReselectItem As Integer = -1)
+    Private Sub LoadFileList(intReselectItem As Integer)
         Dim filesInDirectory As FileInfo() = New DirectoryInfo(strPathToDataBackupFolder).GetFiles()
         Dim threadSafeListOfDataGridViewRows As New ThreadSafeList(Of DataGridViewRow)
         Dim intFileCount, intHiddenFileCount As Integer

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -230,12 +230,11 @@ Public Class ViewLogBackups
                        lblNumberOfHiddenFiles.Text = $"Number of Hidden Files: {intHiddenFileCount:N0}"
                    End If
 
+                   FileList.ClearSelection()
+
                    If intReselectItem <> -1 AndAlso intReselectItem < FileList.Rows.Count Then
-                       FileList.ClearSelection()
                        FileList.Rows(intReselectItem).Selected = True
                        FileList.FirstDisplayedScrollingRowIndex = intReselectItem
-                   Else
-                       FileList.ClearSelection()
                    End If
                End Sub)
     End Sub

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -282,7 +282,7 @@ Public Class ViewLogBackups
         ChkLogFileDeletions.Checked = My.Settings.LogFileDeletions
         Size = My.Settings.ViewLogBackupsSize
         CenterFormOverParent(MyParentForm, Me)
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
         boolDoneLoading = True
     End Sub
 
@@ -323,7 +323,7 @@ Public Class ViewLogBackups
 
                     If ChkLogFileDeletions.Checked Then SyslogParser.AddToLogList(Nothing, $"The user deleted ""{FileList.SelectedRows(0).Cells(0).Value}"" from the log backups folder.")
 
-                    ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+                    ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
                 End If
             Else
                 Dim msgBoxText As String = "Are you sure you want to delete the following files?" & vbCrLf & vbCrLf
@@ -348,7 +348,7 @@ Public Class ViewLogBackups
 
                     If ChkLogFileDeletions.Checked Then SyslogParser.AddToLogList(Nothing, strDeletedFilesLog.ToString)
 
-                    ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+                    ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
                 End If
             End If
         End If
@@ -356,7 +356,7 @@ Public Class ViewLogBackups
 
     Private Sub ViewLogBackups_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
         If e.KeyCode = Keys.F5 Then
-            ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+            ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
         ElseIf e.KeyCode = Keys.Delete Then
             BtnDelete.PerformClick()
         End If
@@ -575,7 +575,7 @@ Public Class ViewLogBackups
         My.Settings.boolShowHiddenFilesOnViewLogBackyupsWindow = ChkShowHidden.Checked
         ChkShowHiddenAsGray.Enabled = ChkShowHidden.Checked
         colHidden.Visible = ChkShowHidden.Checked
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
     End Sub
 
     Private Sub UncompressGZIPFile(strFilePath As String)
@@ -668,7 +668,7 @@ Public Class ViewLogBackups
         If ChkShowHidden.Checked Then
             ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
         Else
-            ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+            ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
         End If
     End Sub
 
@@ -689,7 +689,7 @@ Public Class ViewLogBackups
         If ChkShowHidden.Checked Then
             ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
         Else
-            ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+            ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
         End If
     End Sub
 
@@ -711,7 +711,7 @@ Public Class ViewLogBackups
 
     Private Sub ChkShowHiddenAsGray_Click(sender As Object, e As EventArgs) Handles ChkShowHiddenAsGray.Click
         My.Settings.boolShowHiddenAsGray = ChkShowHiddenAsGray.Checked
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
     End Sub
 
     Private Sub FileList_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles FileList.ColumnWidthChanged
@@ -992,12 +992,12 @@ Public Class ViewLogBackups
     Private Sub ChkShowCompressionSizeDifference_Click(sender As Object, e As EventArgs) Handles ChkShowCompressionSizeDifference.Click
         My.Settings.ShowCompressionSizeDifference = ChkShowCompressionSizeDifference.Checked
         ChkShowCompressionSizeDifferencePercentage.Enabled = ChkShowCompressionSizeDifference.Checked
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
     End Sub
 
     Private Sub ChkShowCompressionSizeDifferencePercentage_Click(sender As Object, e As EventArgs) Handles ChkShowCompressionSizeDifferencePercentage.Click
         My.Settings.ShowCompressionSizeDifferencePercentage = ChkShowCompressionSizeDifferencePercentage.Checked
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
     End Sub
 
     Private Sub btnLimitByDate_Click(sender As Object, e As EventArgs) Handles btnLimitByDate.Click

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -796,14 +796,6 @@ Public Class ViewLogBackups
 
         If strLimiter.Equals(strBlank, StringComparison.OrdinalIgnoreCase) Then strLimiter = ""
 
-        If strLimitBy.Equals("Source Hostname", StringComparison.OrdinalIgnoreCase) And String.IsNullOrWhiteSpace(strLimiter) Then
-            MsgBox("You must select a hostname to limit by.", MsgBoxStyle.Exclamation, Text)
-            Exit Sub
-        ElseIf strLimitBy.Equals("Source IP Address", StringComparison.OrdinalIgnoreCase) And String.IsNullOrWhiteSpace(strLimiter) Then
-            MsgBox("You must select an IP address to limit by.", MsgBoxStyle.Exclamation, Text)
-            Exit Sub
-        End If
-
         BtnSearch.Enabled = False
 
         Dim worker As New BackgroundWorker()
@@ -1026,5 +1018,9 @@ Public Class ViewLogBackups
         endDate = Date.MaxValue
         btnClearDateLimit.Enabled = False
         ToolTip.SetToolTip(btnLimitByDate, "")
+    End Sub
+
+    Private Sub boxLimiter_SelectedValueChanged(sender As Object, e As EventArgs) Handles boxLimiter.SelectedValueChanged
+        btnViewLogsWithLimits.Enabled = Not String.IsNullOrWhiteSpace(boxLimiter.Text)
     End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -15,7 +15,6 @@ Public Class ViewLogBackups
     Private startDate As Date = Date.MinValue
     Private endDate As Date = Date.MaxValue
     Private dateMinimumFromLoadingFiles As Date = Date.MinValue
-    Private Const strBlank As String = "(Blank)"
 
     Private Sub Logs_ColumnHeaderMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles FileList.ColumnHeaderMouseClick
         If e.Button = MouseButtons.Left Then

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -234,6 +234,8 @@ Public Class ViewLogBackups
                        FileList.ClearSelection()
                        FileList.Rows(intReselectItem).Selected = True
                        FileList.FirstDisplayedScrollingRowIndex = intReselectItem
+                   Else
+                       FileList.ClearSelection()
                    End If
                End Sub)
     End Sub
@@ -361,7 +363,9 @@ Public Class ViewLogBackups
     End Sub
 
     Private Sub BtnRefresh_Click(sender As Object, e As EventArgs) Handles BtnRefresh.Click
-        ThreadPool.QueueUserWorkItem(AddressOf LoadFileList)
+        Dim intOldIndex As Integer = -1
+        If FileList.SelectedRows.Count > 0 Then intOldIndex = FileList.SelectedRows(0).Index
+        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(intOldIndex))
     End Sub
 
     Private Sub ViewLogBackups_ResizeEnd(sender As Object, e As EventArgs) Handles Me.ResizeEnd

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -1022,4 +1022,8 @@ Public Class ViewLogBackups
     Private Sub boxLimiter_SelectedValueChanged(sender As Object, e As EventArgs) Handles boxLimiter.SelectedValueChanged
         btnViewLogsWithLimits.Enabled = Not String.IsNullOrWhiteSpace(boxLimiter.Text)
     End Sub
+
+    Private Sub FileList_MouseClick(sender As Object, e As MouseEventArgs) Handles FileList.MouseClick
+        If FileList.HitTest(e.X, e.Y).Type = DataGridViewHitTestType.None Then FileList.ClearSelection()
+    End Sub
 End Class

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -520,10 +520,14 @@ Public Class ViewLogBackups
 
     Private Sub ContextMenuStrip1_Opening(sender As Object, e As CancelEventArgs) Handles ContextMenuStrip1.Opening
         If FileList.SelectedRows.Count > 0 Then
-            DeleteToolStripMenuItem.Enabled = True
+            DeleteToolStripMenuItem.Visible = True
             ShowInWindowsExplorerToolStripMenuItem.Visible = True
             RenameToolStripMenuItem.Visible = True
-            ViewToolStripMenuItem.Enabled = FileList.SelectedRows.Count <= 1
+            ViewToolStripMenuItem.Visible = FileList.SelectedRows.Count <= 1
+            UnhideToolStripMenuItem.Visible = True
+            HideToolStripMenuItem.Visible = True
+            GZIPCompressFileToolStripMenuItem.Visible = True
+            UncompressFileToolStripMenuItem.Visible = True
 
             Dim fileName As String = Path.Combine(strPathToDataBackupFolder, FileList.SelectedRows(0).Cells(0).Value)
             Dim fileInfo As New FileInfo(fileName)
@@ -544,10 +548,14 @@ Public Class ViewLogBackups
                 UncompressFileToolStripMenuItem.Visible = False
             End If
         Else
-            DeleteToolStripMenuItem.Enabled = False
-            ViewToolStripMenuItem.Enabled = False
+            DeleteToolStripMenuItem.Visible = False
+            ViewToolStripMenuItem.Visible = False
             ShowInWindowsExplorerToolStripMenuItem.Visible = False
             RenameToolStripMenuItem.Visible = False
+            UnhideToolStripMenuItem.Visible = False
+            HideToolStripMenuItem.Visible = False
+            GZIPCompressFileToolStripMenuItem.Visible = False
+            UncompressFileToolStripMenuItem.Visible = False
         End If
     End Sub
 
@@ -1025,5 +1033,9 @@ Public Class ViewLogBackups
 
     Private Sub FileList_MouseClick(sender As Object, e As MouseEventArgs) Handles FileList.MouseClick
         If FileList.HitTest(e.X, e.Y).Type = DataGridViewHitTestType.None Then FileList.ClearSelection()
+    End Sub
+
+    Private Sub RefreshToolStripMenuItem_CheckedChanged(sender As Object, e As EventArgs) Handles RefreshToolStripMenuItem.CheckedChanged
+        BtnRefresh.PerformClick()
     End Sub
 End Class


### PR DESCRIPTION
- Brought the same code recent changes that I made to the "View Log Backups" window to the main window. 7a78a6417a0b78f8bd39cb6a7a4befa55a832a5a
- Now the "Limit By" button is only enabled when appropriate on the "View Log Backups" window. 2051bcd32f65ad5912892d41a6534bbd92bed2c8
- Made it so that if click in a blank area of the file list on the "View Log Backups" window the selection is cleared. 96285af1376214c125e1b19a425aa4aa7d2cfe12
- Made it so that the file list context menu has only appropriate menu items when right-clicking and you have no item selected on the "View Log Backups" window. 7b5f64517568b21a04e04dc13a1624015cc0efb4
- Fixed the file refresh routine on the "View Log Backups" window where it would select the first file even if you had no file selected prior to refreshing the file list. 42cd9e9d0b683a44a255e8cc0175e06aac9e279a
- Added the ability to de-select a log entry on the main window by clicking outside the area where logs are shown. 1a6f6b6cec27b9a9e1a9f67b1b1f6b73164d35ea
- Put in code to remove source code file path data from the exception stacktrace data. f9fd25dda228d3b29e3ef1032be1e503770acacf
- Wrapped the ProcessIncomingLog() function code inside a Try-Catch block. b04b52d1c16cbba45eae551fd1b13a064c6e6355

And a whole lot of other under-the-hood changes to the code.