### PR TITLE
Version 5.7 Build 2

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.7.1.129")>
+<Assembly: AssemblyFileVersion("5.7.2.130")>

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -46,6 +46,8 @@ Public Class Alerts_History
 
         SupportCode.LoadColumnOrders(AlertHistoryList.Columns, My.Settings.alertsHistoryColumnOrder)
 
+        AlertHistoryList.Columns(3).SortMode = DataGridViewColumnSortMode.NotSortable
+
         RefreshData()
 
         chkAlertTextColumnAutoFill.Checked = My.Settings.AlertsHistoryAlertColumnFill
@@ -204,6 +206,8 @@ Public Class Alerts_History
     End Sub
 
     Private Sub AlertHistoryList_ColumnHeaderMouseClick(sender As Object, e As DataGridViewCellMouseEventArgs) Handles AlertHistoryList.ColumnHeaderMouseClick
+        If e.ColumnIndex = 3 Then Exit Sub
+
         If e.Button = MouseButtons.Left Then
             Dim column As DataGridViewColumn = AlertHistoryList.Columns(e.ColumnIndex)
 

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -184,7 +184,7 @@ Public Class Alerts_History
     Private Sub chkShowAlertsFromAllFiles_CheckedChanged(sender As Object, e As EventArgs) Handles chkShowAlertsFromAllFiles.CheckedChanged
         colFileName.Visible = chkShowAlertsFromAllFiles.Checked
         chkIncludeHiddenFiles.Enabled = chkShowAlertsFromAllFiles.Checked
-        RefreshData()
+        If boolDoneLoading Then RefreshData()
     End Sub
 
     Private Sub chkAlertTextColumnAutoFill_Click(sender As Object, e As EventArgs) Handles chkAlertTextColumnAutoFill.Click

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -34,6 +34,8 @@ Public Class Alerts_History
 
         SupportCode.SetDoubleBufferingFlag(AlertHistoryList)
 
+        AlertHistoryList.RowsDefaultCellStyle.Padding = New Padding(0, 2, 0, 2)
+
         AlertHistoryList.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = SupportCode.GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
         Location = SupportCode.VerifyWindowLocation(My.Settings.AlertHistoryLocation, Me)
 
@@ -166,6 +168,7 @@ Public Class Alerts_History
                     AlertHistoryList.Rows.Clear()
                     AlertHistoryList.Rows.AddRange(listOfDataRows.ToArray)
                     AlertHistoryList.ResumeLayout()
+                    AlertHistoryList.AutoResizeRows()
                 End If
 
                 lblTimeTakenToLoadData.Text = $"Time Taken to Load Data: {stopwatch.ElapsedMilliseconds}ms"

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -44,7 +44,7 @@ Public Class Alerts_History
 
         SupportCode.LoadColumnOrders(AlertHistoryList.Columns, My.Settings.alertsHistoryColumnOrder)
 
-        BtnRefresh.PerformClick()
+        RefreshData()
 
         chkAlertTextColumnAutoFill.Checked = My.Settings.AlertsHistoryAlertColumnFill
         colAlert.AutoSizeMode = If(My.Settings.AlertsHistoryAlertColumnFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
@@ -82,10 +82,10 @@ Public Class Alerts_History
     End Sub
 
     Private Sub Alerts_History_KeyUp(sender As Object, e As KeyEventArgs) Handles Me.KeyUp
-        If e.KeyCode = Keys.F5 Then BtnRefresh.PerformClick()
+        If e.KeyCode = Keys.F5 Then RefreshData()
     End Sub
 
-    Private Sub BtnRefresh_Click(sender As Object, e As EventArgs) Handles BtnRefresh.Click
+    Private Sub RefreshData()
         If ParentForm IsNot Nothing Then
             With ParentForm
                 Dim stopwatch As Stopwatch = Stopwatch.StartNew()
@@ -171,6 +171,10 @@ Public Class Alerts_History
                 lblTimeTakenToLoadData.Text = $"Time Taken to Load Data: {stopwatch.ElapsedMilliseconds}ms"
             End With
         End If
+    End Sub
+
+    Private Sub BtnRefresh_Click(sender As Object, e As EventArgs) Handles BtnRefresh.Click
+        RefreshData()
     End Sub
 
     Private Sub Alerts_History_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -1,9 +1,6 @@
-﻿Imports System.ComponentModel
-Imports System.IO
+﻿Imports System.IO
 Imports System.Threading.Tasks
 Imports Free_SysLog.ThreadSafetyLists
-Imports Microsoft.VisualBasic.Logging
-Imports Windows.UI.Xaml.Controls
 
 Public Class Alerts_History
     Private Shadows ParentForm As Form1

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -91,7 +91,7 @@ Public Class Alerts_History
         If ParentForm IsNot Nothing Then
             With ParentForm
                 Dim stopwatch As Stopwatch = Stopwatch.StartNew()
-                Dim data As New ThreadSafeList(Of AlertsHistory)
+                Dim data As New ThreadSafeList(Of AlertsHistoryDataGridViewRow)
 
                 SyncLock ParentForm.dataGridLockObject
                     For Each item As MyDataGridViewRow In ParentForm.Logs.Rows
@@ -107,7 +107,7 @@ Public Class Alerts_History
                                      .alertDate = item.DateObject,
                                      .boolCompressed = False,
                                      .boolHidden = False
-                                    })
+                                    }.MakeDataGridRow(AlertHistoryList))
                         End If
                     Next
                 End SyncLock
@@ -148,25 +148,20 @@ Public Class Alerts_History
                                                                                                      .alertDate = SavedData.DateObject,
                                                                                                      .boolHidden = boolHidden,
                                                                                                      .boolCompressed = boolCompressed
-                                                                                                  })
+                                                                                                  }.MakeDataGridRow(AlertHistoryList))
                                                                                               End If
                                                                                           End Sub)
                                                        End Sub)
                 End If
 
-                data.Sort(Function(x As AlertsHistory, y As AlertsHistory) y.alertDate.CompareTo(x.alertDate))
+                data.Sort(Function(x As AlertsHistoryDataGridViewRow, y As AlertsHistoryDataGridViewRow) y.alertDate.CompareTo(x.alertDate))
 
                 If data.Any() Then
                     lblNumberOfAlerts.Text = $"Number of Alerts: {data.Count:N0}"
-                    Dim listOfDataRows As New List(Of AlertsHistoryDataGridViewRow)
-
-                    For Each item As AlertsHistory In data.GetSnapshot()
-                        listOfDataRows.Add(item.MakeDataGridRow(AlertHistoryList))
-                    Next
 
                     AlertHistoryList.SuspendLayout()
                     AlertHistoryList.Rows.Clear()
-                    AlertHistoryList.Rows.AddRange(listOfDataRows.ToArray)
+                    AlertHistoryList.Rows.AddRange(data.GetSnapshot.ToArray)
                     AlertHistoryList.ResumeLayout()
                     AlertHistoryList.AutoResizeRows()
                 End If

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -184,7 +184,7 @@ Public Class Alerts_History
     Private Sub chkShowAlertsFromAllFiles_CheckedChanged(sender As Object, e As EventArgs) Handles chkShowAlertsFromAllFiles.CheckedChanged
         colFileName.Visible = chkShowAlertsFromAllFiles.Checked
         chkIncludeHiddenFiles.Enabled = chkShowAlertsFromAllFiles.Checked
-        BtnRefresh.PerformClick()
+        RefreshData()
     End Sub
 
     Private Sub chkAlertTextColumnAutoFill_Click(sender As Object, e As EventArgs) Handles chkAlertTextColumnAutoFill.Click

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -36,6 +36,7 @@ Public Class Form1
     Private ReplacementsInstance As Replacements
     Private AlertsInstance As Alerts
     Private ConfigureSysLogMirrorClientsInstance As ConfigureSysLogMirrorClients
+    Private AlertsHistoryInstance As Alerts_History
 #End Region
 
     Private Sub ChkStartAtUserStartup_Click(sender As Object, e As EventArgs) Handles ChkEnableStartAtUserStartup.Click
@@ -1368,9 +1369,19 @@ Public Class Form1
             Dim boolAnyAlerts As Boolean = Logs.Rows.Cast(Of MyDataGridViewRow).Any(Function(row As MyDataGridViewRow) row.BoolAlerted)
 
             If boolAnyAlerts Then
-                Using Alerts_History As New Alerts_History() With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent, .SetParentForm = Me, .Size = My.Settings.AlertHistorySize}
-                    Alerts_History.ShowDialog(Me)
-                End Using
+                If AlertsHistoryInstance IsNot Nothing AndAlso Not AlertsHistoryInstance.IsDisposed Then
+                    AlertsHistoryInstance.WindowState = FormWindowState.Normal
+                    AlertsHistoryInstance.BringToFront()
+                    AlertsHistoryInstance.Activate()
+                Else
+                    AlertsHistoryInstance = New Alerts_History With {
+                        .Icon = Icon,
+                        .StartPosition = FormStartPosition.CenterParent,
+                        .Size = My.Settings.AlertHistorySize,
+                        .SetParentForm = Me
+                    }
+                    AlertsHistoryInstance.Show()
+                End If
             Else
                 MsgBox("There are no alerts to show in the Alerts History.", MsgBoxStyle.Information, Text)
             End If

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -283,7 +283,12 @@ Public Class IgnoredWordsAndPhrases
 
     Private Sub UpdateStats()
         If _boolCurrentlyEditing Or boolF1KeyDown OrElse (Not NativeMethod.NativeMethods.GetForegroundWindow() = Me.Handle And ChkRefreshOnlyIfActive.Checked) Then Exit Sub
-        btnUpdateHits.PerformClick()
+
+        If InvokeRequired Then
+            Invoke(Sub() UpdateHits())
+        Else
+            UpdateHits()
+        End If
     End Sub
 
     Private Sub IgnoredWordsAndPhrases_Load(sender As Object, e As EventArgs) Handles Me.Load
@@ -632,7 +637,7 @@ Public Class IgnoredWordsAndPhrases
         If e.KeyCode = Keys.Escape Then
             Close()
         ElseIf e.KeyCode = Keys.F5 Then
-            btnUpdateHits.PerformClick()
+            UpdateHits()
         ElseIf e.KeyCode = Keys.F1 Then
             boolF1KeyDown = False
             ChkAutoRefresh.Enabled = True
@@ -809,6 +814,10 @@ Public Class IgnoredWordsAndPhrases
     End Sub
 
     Private Sub btnUpdateHits_Click(sender As Object, e As EventArgs) Handles btnUpdateHits.Click
+        UpdateHits()
+    End Sub
+
+    Private Sub UpdateHits()
         Dim longTotalHits As Long = 0
         Dim sinceLastEvent As TimeSpan
         Dim intHits As Integer

--- a/Free SysLog/Windows/Ignored Words and Phrases.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.vb
@@ -819,6 +819,8 @@ Public Class IgnoredWordsAndPhrases
         IgnoredListView.BeginUpdate()
 
         For Each item As MyIgnoredListViewItem In IgnoredListView.Items
+            If StatUpdateCancellation IsNot Nothing AndAlso StatUpdateCancellation.Token.IsCancellationRequested Then Exit For
+
             If item.BoolEnabled Then
                 IgnoredStatsEntry = Nothing
                 intHits = 0


### PR DESCRIPTION
This is a bit of a minor update to the program.

- Updated loop over IgnoredListView.Items to exit early if StatUpdateCancellation is requested, improving responsiveness to cancellation and hopefully fix a small crash bug that only appears if the timing is just right. 6ae0c85b49797def7c045d78a7c482aaadbe8d74
- Moved the code that used to be in the btnUpdateHits Click event into a separate function called UpdateHits(). That function is now called instead of using btnUpdateHits.PerformClick(). In addition, the UpdateStats() function includes a check to see if an Invoke is require and if so, it uses an Invoke to call UpdateHits() safely from other threads. Otherwise, it just calls it. 4ec8725f9d80b4d32a943a8a111110ab5e3a16b9
- Refactor data refresh logic into RefreshData() method. Extracted refresh logic to a new RefreshData() method. Both the F5 key event and the refresh button now call this method directly, improving code clarity and reusability. 9c862994fdb67dd791c3d863c1384ba9360d3bcc
- Added padding to the Alerts History to make rows easier to read. 9b93003ac5e13bf29f1d03cc1c0f24bc259dca09
- Changed how the data is loaded on the "Alerts History" window to reduce the number of loops required to load the data. 6176acfe317be33eb2f1d67ace2f45d416448cc1
- Disabled sorting by file name on the "Alerts History" window. 40a6de1e1ff119791b87c8f21da2dfd8f0fc2dcf
- Replaced a call to BtnRefresh.PerformClick() with a direct call to the RefreshData() function in the chkShowAlertsFromAllFiles's CheckedChanged event handler. ee17698dcf201b25da45c1fa150af411ae4af4e1
- We now check to see if the window is fully loaded by checking the state of the boolDoneLoading variable in the chkShowAlertsFromAllFiles's CheckedChanged. 97b71265a72f7259ed52df204ca3433bf1b0f65c
- Made it so that the "Alerts History" window can be pushed aside. 6860646f52773fbc2133361b978dac1d7d6f9173