### PR TITLE
Version 5.7 Build 3

### DIFF
--- a/Free SysLog/Free SysLog.vbproj
+++ b/Free SysLog/Free SysLog.vbproj
@@ -154,6 +154,12 @@
     <Compile Include="Windows\Close Free SysLog Dialog.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Windows\Color Picker.Designer.vb">
+      <DependentUpon>Color Picker.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\Color Picker.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Windows\Configure SysLog Mirror Clients.Designer.vb">
       <DependentUpon>Configure SysLog Mirror Clients.vb</DependentUpon>
     </Compile>
@@ -269,6 +275,9 @@
     <EmbeddedResource Include="Windows\Close Free SysLog Dialog.resx">
       <DependentUpon>Close Free SysLog Dialog.vb</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Windows\Color Picker.resx">
+      <DependentUpon>Color Picker.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Windows\Configure SysLog Mirror Clients.resx">
       <DependentUpon>Configure SysLog Mirror Clients.vb</DependentUpon>
       <SubType>Designer</SubType>
@@ -347,6 +356,9 @@
   <ItemGroup>
     <PackageReference Include="CrashReporter.NET.Official">
       <Version>1.6.0</Version>
+    </PackageReference>
+    <PackageReference Include="Cyotek.Windows.Forms.ColorPicker">
+      <Version>1.7.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
       <Version>7.1.3</Version>

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.7.2.130")>
+<Assembly: AssemblyFileVersion("5.7.3.131")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1484,6 +1484,29 @@ Namespace My
                 Me("ShowAlertsFromAllFilesWithHiddenFiles") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+        Public Property CustomColors() As Global.System.Collections.Specialized.StringCollection
+            Get
+                Return CType(Me("CustomColors"),Global.System.Collections.Specialized.StringCollection)
+            End Get
+            Set
+                Me("CustomColors") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("733, 326")>  _
+        Public Property ColorPickerDialogSize() As Global.System.Drawing.Size
+            Get
+                Return CType(Me("ColorPickerDialogSize"),Global.System.Drawing.Size)
+            End Get
+            Set
+                Me("ColorPickerDialogSize") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -362,5 +362,11 @@
     <Setting Name="ShowAlertsFromAllFilesWithHiddenFiles" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CustomColors" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="ColorPickerDialogSize" Type="System.Drawing.Size" Scope="User">
+      <Value Profile="(Default)">733, 326</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/Namespace Code/Support Code.vb
+++ b/Free SysLog/Support Code/Namespace Code/Support Code.vb
@@ -603,9 +603,9 @@ Namespace SupportCode
             Return ipv6Address
         End Function
 
-        Public Function GetGoodTextColorBasedUponBackgroundColor(input As Color) As Color
-            Dim intCombinedTotal As Short = Integer.Parse(input.R.ToString) + Integer.Parse(input.G.ToString) + Integer.Parse(input.B.ToString)
-            Return If((intCombinedTotal / 3) < 128, Color.White, Color.Black)
+        Public Function GetGoodTextColorBasedUponBackgroundColor(background As Color) As Color
+            Dim luminance As Double = (0.299 * background.R) + (0.587 * background.G) + (0.114 * background.B)
+            Return If(luminance < 128, Color.White, Color.Black)
         End Function
 
         Public Function FileSizeToHumanSize(size As Long, Optional roundToNearestWholeNumber As Boolean = False) As String

--- a/Free SysLog/Windows/Color Picker.Designer.vb
+++ b/Free SysLog/Windows/Color Picker.Designer.vb
@@ -1,0 +1,122 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class Color_Picker
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.ColorWheel1 = New Cyotek.Windows.Forms.ColorWheel()
+        Me.ColorGrid1 = New Cyotek.Windows.Forms.ColorGrid()
+        Me.ColorEditor1 = New Cyotek.Windows.Forms.ColorEditor()
+        Me.lblColorShower = New System.Windows.Forms.Label()
+        Me.btnChooseColor = New System.Windows.Forms.Button()
+        Me.btnSaveColorToCustomColors = New System.Windows.Forms.Button()
+        Me.btnClearCustomColors = New System.Windows.Forms.Button()
+        Me.SuspendLayout()
+        '
+        'ColorWheel1
+        '
+        Me.ColorWheel1.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.ColorWheel1.Color = System.Drawing.Color.FromArgb(CType(CType(0, Byte), Integer), CType(CType(0, Byte), Integer), CType(CType(0, Byte), Integer))
+        Me.ColorWheel1.Location = New System.Drawing.Point(471, 12)
+        Me.ColorWheel1.Name = "ColorWheel1"
+        Me.ColorWheel1.Size = New System.Drawing.Size(239, 260)
+        Me.ColorWheel1.TabIndex = 0
+        '
+        'ColorGrid1
+        '
+        Me.ColorGrid1.Location = New System.Drawing.Point(12, 12)
+        Me.ColorGrid1.Name = "ColorGrid1"
+        Me.ColorGrid1.Size = New System.Drawing.Size(247, 165)
+        Me.ColorGrid1.TabIndex = 1
+        '
+        'ColorEditor1
+        '
+        Me.ColorEditor1.Location = New System.Drawing.Point(265, 12)
+        Me.ColorEditor1.Name = "ColorEditor1"
+        Me.ColorEditor1.Size = New System.Drawing.Size(200, 260)
+        Me.ColorEditor1.TabIndex = 2
+        '
+        'lblColorShower
+        '
+        Me.lblColorShower.Location = New System.Drawing.Point(12, 191)
+        Me.lblColorShower.Name = "lblColorShower"
+        Me.lblColorShower.Size = New System.Drawing.Size(247, 60)
+        Me.lblColorShower.TabIndex = 3
+        '
+        'btnChooseColor
+        '
+        Me.btnChooseColor.Location = New System.Drawing.Point(12, 254)
+        Me.btnChooseColor.Name = "btnChooseColor"
+        Me.btnChooseColor.Size = New System.Drawing.Size(117, 23)
+        Me.btnChooseColor.TabIndex = 4
+        Me.btnChooseColor.Text = "Choose Color"
+        Me.btnChooseColor.UseVisualStyleBackColor = True
+        '
+        'btnSaveColorToCustomColors
+        '
+        Me.btnSaveColorToCustomColors.Location = New System.Drawing.Point(135, 254)
+        Me.btnSaveColorToCustomColors.Name = "btnSaveColorToCustomColors"
+        Me.btnSaveColorToCustomColors.Size = New System.Drawing.Size(176, 23)
+        Me.btnSaveColorToCustomColors.TabIndex = 5
+        Me.btnSaveColorToCustomColors.Text = "Save Color to Custom Colors"
+        Me.btnSaveColorToCustomColors.UseVisualStyleBackColor = True
+        '
+        'btnClearCustomColors
+        '
+        Me.btnClearCustomColors.Location = New System.Drawing.Point(317, 254)
+        Me.btnClearCustomColors.Name = "btnClearCustomColors"
+        Me.btnClearCustomColors.Size = New System.Drawing.Size(148, 23)
+        Me.btnClearCustomColors.TabIndex = 6
+        Me.btnClearCustomColors.Text = "Clear Custom Colors"
+        Me.btnClearCustomColors.UseVisualStyleBackColor = True
+        '
+        'Color_Picker
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(717, 287)
+        Me.Controls.Add(Me.btnClearCustomColors)
+        Me.Controls.Add(Me.btnSaveColorToCustomColors)
+        Me.Controls.Add(Me.btnChooseColor)
+        Me.Controls.Add(Me.lblColorShower)
+        Me.Controls.Add(Me.ColorEditor1)
+        Me.Controls.Add(Me.ColorGrid1)
+        Me.Controls.Add(Me.ColorWheel1)
+        Me.MaximizeBox = False
+        Me.MinimizeBox = False
+        Me.MinimumSize = New System.Drawing.Size(733, 326)
+        Me.Name = "Color_Picker"
+        Me.Text = "Color Picker"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents ColorWheel1 As Cyotek.Windows.Forms.ColorWheel
+    Friend WithEvents ColorGrid1 As Cyotek.Windows.Forms.ColorGrid
+    Friend WithEvents ColorEditor1 As Cyotek.Windows.Forms.ColorEditor
+    Friend WithEvents lblColorShower As Label
+    Friend WithEvents btnChooseColor As Button
+    Friend WithEvents btnSaveColorToCustomColors As Button
+    Friend WithEvents btnClearCustomColors As Button
+End Class

--- a/Free SysLog/Windows/Color Picker.resx
+++ b/Free SysLog/Windows/Color Picker.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Free SysLog/Windows/Color Picker.vb
+++ b/Free SysLog/Windows/Color Picker.vb
@@ -1,0 +1,114 @@
+﻿Public Class Color_Picker
+    Public Property ChosenColor As Color
+
+    Private Sub ColorGrid1_Click(sender As Object, e As EventArgs) Handles ColorGrid1.Click
+        ColorEditor1.Color = ColorGrid1.Color
+        ColorWheel1.Color = ColorGrid1.Color
+        lblColorShower.BackColor = ColorGrid1.Color
+    End Sub
+
+    Private Sub ColorEditor1_ColorChanged(sender As Object, e As EventArgs) Handles ColorEditor1.ColorChanged
+        lblColorShower.BackColor = ColorEditor1.Color
+        ColorWheel1.Color = ColorEditor1.Color
+    End Sub
+
+    Private Sub ColorWheel1_ColorChanged(sender As Object, e As EventArgs) Handles ColorWheel1.ColorChanged
+        lblColorShower.BackColor = ColorWheel1.Color
+    End Sub
+
+    Private Sub Color_Picker_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        LoadCustomColors()
+
+        ColorEditor1.Color = ChosenColor
+        ColorWheel1.Color = ChosenColor
+        ColorGrid1.Color = ChosenColor
+        lblColorShower.BackColor = ChosenColor
+    End Sub
+
+    Private Sub Color_Picker_FormClosing(sender As Object, e As FormClosingEventArgs) Handles Me.FormClosing
+        My.Settings.ColorPickerDialogSize = Size
+        SaveCustomColors()
+    End Sub
+
+    Private Sub btnChooseColor_Click(sender As Object, e As EventArgs) Handles btnChooseColor.Click
+        ChosenColor = lblColorShower.BackColor
+        Close()
+    End Sub
+
+    Private Sub btnSaveColorToCustomColors_Click(sender As Object, e As EventArgs) Handles btnSaveColorToCustomColors.Click
+        AddCustomColor(lblColorShower.BackColor)
+    End Sub
+
+    Private Sub AddCustomColor(c As Color)
+        Dim colors As Cyotek.Windows.Forms.ColorCollection = ColorGrid1.CustomColors
+
+        'Avoid duplicates
+        For i = 0 To colors.Count - 1
+            If colors(i).ToArgb() = c.ToArgb() Then
+                ColorGrid1.Color = c
+                Return
+            End If
+        Next
+
+        'Find an empty/default slot
+        For i = 0 To colors.Count - 1
+            If colors(i).IsEmpty OrElse colors(i).ToArgb() = Color.White.ToArgb() Then
+                colors(i) = c
+                ColorGrid1.Color = c
+                ColorGrid1.Invalidate()
+                Return
+            End If
+        Next
+
+        'No empty slots; shift older colors down and insert at front
+        For i = colors.Count - 1 To 1 Step -1
+            colors(i) = colors(i - 1)
+        Next
+
+        If colors.Count = 0 Then
+            colors.Add(c)
+        Else
+            colors(0) = c
+        End If
+
+        ColorGrid1.Color = c
+        ColorGrid1.Invalidate()
+    End Sub
+
+    Private Sub SaveCustomColors()
+        If My.Settings.CustomColors Is Nothing Then My.Settings.CustomColors = New Specialized.StringCollection()
+        My.Settings.CustomColors.Clear()
+
+        For Each c As Color In ColorGrid1.CustomColors
+            My.Settings.CustomColors.Add(c.ToArgb().ToString())
+        Next
+
+        My.Settings.Save()
+    End Sub
+
+    Private Function IsEmptyCustomColor(c As Color) As Boolean
+        Return c.IsEmpty OrElse c.ToArgb() = Color.White.ToArgb()
+    End Function
+
+    Private Sub LoadCustomColors()
+        If My.Settings.CustomColors Is Nothing OrElse My.Settings.CustomColors.Count = 0 Then Exit Sub
+
+        Dim argb As Integer
+        Dim color As Color
+
+        For i As Integer = 0 To Math.Min(ColorGrid1.CustomColors.Count - 1, My.Settings.CustomColors.Count - 1)
+            If Integer.TryParse(My.Settings.CustomColors(i), argb) Then
+                color = Color.FromArgb(argb)
+                If Not IsEmptyCustomColor(color) Then ColorGrid1.CustomColors(i) = color
+            End If
+        Next
+
+        ColorGrid1.Invalidate()
+    End Sub
+
+    Private Sub btnClearCustomColors_Click(sender As Object, e As EventArgs) Handles btnClearCustomColors.Click
+        My.Settings.CustomColors.Clear()
+        ColorGrid1.CustomColors.Clear()
+        ColorGrid1.Invalidate()
+    End Sub
+End Class

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -720,14 +720,15 @@ Public Class Form1
     End Sub
 
     Private Sub ConfigureAlternatingColorToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ChangeAlternatingColorToolStripMenuItem.Click
-        Using ColorDialog As New ColorDialog()
-            If ColorDialog.ShowDialog() = DialogResult.OK Then
-                My.Settings.searchColor = ColorDialog.Color
+        Dim Color_Picker As New Color_Picker With {.StartPosition = FormStartPosition.CenterParent, .Icon = Icon, .ChosenColor = My.Settings.searchColor, .Size = My.Settings.ColorPickerDialogSize}
+        Color_Picker.ShowDialog()
 
-                Dim rowStyle As New DataGridViewCellStyle() With {.BackColor = ColorDialog.Color, .ForeColor = GetGoodTextColorBasedUponBackgroundColor(ColorDialog.Color)}
-                Logs.AlternatingRowsDefaultCellStyle = rowStyle
-            End If
-        End Using
+        My.Settings.searchColor = Color_Picker.ChosenColor
+
+        Dim rowStyle As New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
+        Logs.AlternatingRowsDefaultCellStyle = rowStyle
+
+        Color_Picker.Dispose()
     End Sub
 
     Private Sub AboutToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles AboutToolStripMenuItem.Click

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -189,7 +189,7 @@ Public Class IgnoredLogsAndSearchResults
 
         SetDoubleBufferingFlag(Logs)
 
-        Logs.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor}
+        Logs.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
         Logs.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
         ColLog.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
 

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -46,7 +46,6 @@ Partial Class ViewLogBackups
         Me.lblTotalNumberOfLogs = New System.Windows.Forms.ToolStripStatusLabel()
         Me.ChkShowHidden = New System.Windows.Forms.CheckBox()
         Me.colHidden = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.ChkShowHiddenAsGray = New System.Windows.Forms.CheckBox()
         Me.colEntryCount = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.HideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.UnhideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -320,17 +319,6 @@ Partial Class ViewLogBackups
         Me.colHidden.ReadOnly = True
         Me.colHidden.Width = 60
         '
-        'ChkShowHiddenAsGray
-        '
-        Me.ChkShowHiddenAsGray.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.ChkShowHiddenAsGray.AutoSize = True
-        Me.ChkShowHiddenAsGray.Location = New System.Drawing.Point(814, 319)
-        Me.ChkShowHiddenAsGray.Name = "ChkShowHiddenAsGray"
-        Me.ChkShowHiddenAsGray.Size = New System.Drawing.Size(153, 17)
-        Me.ChkShowHiddenAsGray.TabIndex = 35
-        Me.ChkShowHiddenAsGray.Text = "Show Hidden Files as Gray"
-        Me.ChkShowHiddenAsGray.UseVisualStyleBackColor = True
-        '
         'lblNumberOfHiddenFiles
         '
         Me.lblNumberOfHiddenFiles.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
@@ -457,7 +445,6 @@ Partial Class ViewLogBackups
         Me.Controls.Add(Me.boxLimitBy)
         Me.Controls.Add(Me.lblLimitBy)
         Me.Controls.Add(Me.ChkIgnoreSearchResultsLimits)
-        Me.Controls.Add(Me.ChkShowHiddenAsGray)
         Me.Controls.Add(Me.ChkShowHidden)
         Me.Controls.Add(Me.ChkCaseInsensitiveSearch)
         Me.Controls.Add(Me.ChkRegExSearch)
@@ -511,7 +498,6 @@ Partial Class ViewLogBackups
     Friend WithEvents HideToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents UnhideToolStripMenuItem As ToolStripMenuItem
     Friend WithEvents colHidden As DataGridViewTextBoxColumn
-    Friend WithEvents ChkShowHiddenAsGray As CheckBox
     Friend WithEvents lblNumberOfHiddenFiles As ToolStripStatusLabel
     Friend WithEvents LblTotalDiskSpace As ToolStripStatusLabel
     Friend WithEvents colEntryCount As DataGridViewTextBoxColumn

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -138,7 +138,6 @@ Public Class ViewLogBackups
 
                                                    For Each cell As DataGridViewCell In row.Cells
                                                        cell.Style.Font = My.Settings.font
-                                                       If boolIsHidden AndAlso ChkShowHiddenAsGray.Checked Then cell.Style.ForeColor = Color.Gray
                                                        If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then cell.Style.ForeColor = Color.Blue
                                                    Next
 
@@ -258,8 +257,6 @@ Public Class ViewLogBackups
 
         colHidden.Visible = My.Settings.boolShowHiddenFilesOnViewLogBackyupsWindow
         ChkShowHidden.Checked = My.Settings.boolShowHiddenFilesOnViewLogBackyupsWindow
-        ChkShowHiddenAsGray.Checked = My.Settings.boolShowHiddenAsGray
-        ChkShowHiddenAsGray.Enabled = ChkShowHidden.Checked
         ChkLogFileDeletions.Checked = My.Settings.LogFileDeletions
         Size = My.Settings.ViewLogBackupsSize
         CenterFormOverParent(MyParentForm, Me)
@@ -555,7 +552,6 @@ Public Class ViewLogBackups
 
     Private Sub ChkShowHidden_Click(sender As Object, e As EventArgs) Handles ChkShowHidden.Click
         My.Settings.boolShowHiddenFilesOnViewLogBackyupsWindow = ChkShowHidden.Checked
-        ChkShowHiddenAsGray.Enabled = ChkShowHidden.Checked
         colHidden.Visible = ChkShowHidden.Checked
         ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
     End Sub
@@ -689,11 +685,6 @@ Public Class ViewLogBackups
             attributes = attributes And Not FileAttributes.Hidden
             File.SetAttributes(fileName, attributes)
         End If
-    End Sub
-
-    Private Sub ChkShowHiddenAsGray_Click(sender As Object, e As EventArgs) Handles ChkShowHiddenAsGray.Click
-        My.Settings.boolShowHiddenAsGray = ChkShowHiddenAsGray.Checked
-        ThreadPool.QueueUserWorkItem(Sub() LoadFileList(-1))
     End Sub
 
     Private Sub FileList_ColumnWidthChanged(sender As Object, e As DataGridViewColumnEventArgs) Handles FileList.ColumnWidthChanged

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -238,7 +238,7 @@ Public Class ViewLogBackups
         Dim propInfo As Reflection.PropertyInfo = GetType(DataGridView).GetProperty("DoubleBuffered", flags)
         propInfo?.SetValue(FileList, True, Nothing)
 
-        FileList.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor}
+        FileList.AlternatingRowsDefaultCellStyle = New DataGridViewCellStyle() With {.BackColor = My.Settings.searchColor, .ForeColor = GetGoodTextColorBasedUponBackgroundColor(My.Settings.searchColor)}
         FileList.DefaultCellStyle = New DataGridViewCellStyle() With {.WrapMode = DataGridViewTriState.True}
         FileList.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders
 

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -138,7 +138,6 @@ Public Class ViewLogBackups
 
                                                    For Each cell As DataGridViewCell In row.Cells
                                                        cell.Style.Font = My.Settings.font
-                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) Then cell.Style.ForeColor = Color.Blue
                                                    Next
 
                                                    row.Cells(2).Style.Alignment = DataGridViewContentAlignment.MiddleCenter

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -362,6 +362,9 @@
             <setting name="ShowAlertsFromAllFilesWithHiddenFiles" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="ColorPickerDialogSize" serializeAs="String">
+                <value>733, 326</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
Another minor update to the program.

- The Alternating Row Font Colors on both the "Ignored Logs and Search Results" and "View Log Backups" window use the GetGoodTextColorBasedUponBackgroundColor() function to get a good color. 66b1d3e5b5d93a98a799054edf5a4d14962452ca
- Removed the option to show hidden log files on the "View Log Backups" window as gray since if you choose a darker color scheme for alternating row colors, the gray font color won't be able to be read. 32f9b4d1f39615287a9c39828f5c7c2d68dd8e16
- Removed the option to show GZ compressed log files on the "View Log Backups" window as blue since if you choose a darker color scheme for alternating row colors, the blue font color won't be able to be read. ee1aca38b0cb6740a1b6105235f95c79932fb713
- Added a replacement for the dumb built-in Color Picker. c04230d891d58be6e241d97cd08e4bf0a09c06b6
- Improved upon the GetGoodTextColorBasedUponBackgroundColor() function. 5b5390e3cadf5b1b95ddef610063b6e6a6ef926f