### PR TITLE
Version 5.7 Build 7

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -82,7 +82,7 @@ Namespace My
                 Threading.Tasks.Parallel.ForEach(filesInDirectory, Sub(file As IO.FileInfo)
                                                                        Dim collectionOfSavedData As List(Of SavedData)
 
-                                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
+                                                                       If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) AndAlso IsGZipFile(file.FullName) Then
                                                                            collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                        Else
                                                                            Using fileStream As New IO.StreamReader(file.FullName)

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.7.6.134")>
+<Assembly: AssemblyFileVersion("5.7.7.135")>

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -12,17 +12,22 @@
             ' Clean up old notification entries
             CleanUpOldEntries(currentTime)
 
-            ' Check if this message has been shown recently
-            If lastNotificationTime.ContainsKey(tipText) Then
-                Dim lastTime As Date = lastNotificationTime(tipText)
-                Dim timeSinceLastNotification As TimeSpan = currentTime - lastTime
+            Dim shouldShow As Boolean = False
 
-                ' If the message was shown within the time limit, do not show it again
-                If timeSinceLastNotification.TotalSeconds < My.Settings.TimeBetweenSameNotifications Then Exit Sub
-            End If
+            lastNotificationTime.AddOrUpdate(tipText, Function(key As String) ' key not present — always show
+                                                          shouldShow = True
+                                                          Return currentTime
+                                                      End Function,
+                                             Function(key As String, existingTime As Date) ' key present — decide atomically
+                                                 If (currentTime - existingTime).TotalSeconds >= My.Settings.TimeBetweenSameNotifications Then
+                                                     shouldShow = True
+                                                     Return currentTime
+                                                 Else
+                                                     Return existingTime ' leave timestamp untouched, don't show
+                                                 End If
+                                             End Function)
 
-            ' Update the last shown time for this message
-            lastNotificationTime(tipText) = currentTime
+            If Not shouldShow Then Exit Sub
 
             SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alertType, rowGUID)
         End Sub

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -686,13 +686,8 @@ Namespace SyslogParser
         End Function
 
         Private Function GetCachedRegex(ByRef regexCache As ConcurrentDictionary(Of String, Regex), pattern As String, Optional boolCaseSensitive As Boolean = True) As Regex
-            If regexCache.ContainsKey(pattern) Then
-                Return regexCache(pattern)
-            Else
-                Dim regExObject As New Regex(pattern, If(boolCaseSensitive, RegexOptions.Compiled, RegexOptions.Compiled Or RegexOptions.IgnoreCase))
-                regexCache(pattern) = regExObject
-                Return regExObject
-            End If
+            Dim options As RegexOptions = If(boolCaseSensitive, RegexOptions.Compiled, RegexOptions.Compiled Or RegexOptions.IgnoreCase)
+            Return regexCache.GetOrAdd(pattern, Function(p As String) New Regex(p, options))
         End Function
 
         Private Function IpToHostname(ipAddress As String) As String

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -158,7 +158,6 @@ Public Class Alerts_History
                     AlertHistoryList.Rows.Clear()
                     AlertHistoryList.Rows.AddRange(data.GetSnapshot.ToArray)
                     AlertHistoryList.ResumeLayout()
-                    AlertHistoryList.AutoResizeRows()
                 End If
 
                 lblTimeTakenToLoadData.Text = $"Time Taken to Load Data: {stopwatch.ElapsedMilliseconds}ms"

--- a/Free SysLog/Windows/Alerts History.vb
+++ b/Free SysLog/Windows/Alerts History.vb
@@ -124,7 +124,7 @@ Public Class Alerts_History
                     Parallel.ForEach(filesInDirectory, Sub(file As FileInfo)
                                                            Dim dataFromFile As List(Of SavedData)
 
-                                                           If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And SupportCode.IsGZipFile(file.FullName) Then
+                                                           If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) AndAlso SupportCode.IsGZipFile(file.FullName) Then
                                                                dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(SupportCode.GetTextContentsFromGZIPedLogFile(file.FullName), SupportCode.JSONDecoderSettingsForLogFiles)
                                                            Else
                                                                Using fileStream As New StreamReader(file.FullName)

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -705,13 +705,17 @@ Public Class Form1
     End Sub
 
     Private Sub ZerooutIgnoredLogsCounterToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles ZerooutIgnoredLogsCounterToolStripMenuItem.Click
-        IgnoredStats.Clear()
-        longNumberOfIgnoredLogs = 0
-        LblNumberOfIgnoredIncomingLogs.Text = $"Number of Ignored Incoming Logs: {longNumberOfIgnoredLogs:N0}"
+        If MsgBox("Are you sure you want to zero out the ignored logs counters?", MsgBoxStyle.Question + MsgBoxStyle.YesNo + vbDefaultButton2, Text) = MsgBoxResult.Yes Then
+            IgnoredStats.Clear()
+            longNumberOfIgnoredLogs = 0
+            LblNumberOfIgnoredIncomingLogs.Text = $"Number of Ignored Incoming Logs: {longNumberOfIgnoredLogs:N0}"
 
-        If My.Settings.saveIgnoredLogCount Then
-            NumberOfIgnoredLogs = longNumberOfIgnoredLogs
-            WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+            If My.Settings.saveIgnoredLogCount Then
+                NumberOfIgnoredLogs = longNumberOfIgnoredLogs
+                WriteFileAtomically(strPathToIgnoredStatsFile, Newtonsoft.Json.JsonConvert.SerializeObject(IgnoredStats, Newtonsoft.Json.Formatting.Indented))
+            End If
+        Else
+            MsgBox("The ignored logs counters have not been zeroed out.", MsgBoxStyle.Information, Text)
         End If
     End Sub
 
@@ -765,7 +769,7 @@ Public Class Form1
                         MsgBox("Data exported successfully.", MsgBoxStyle.Information, Text)
                     End If
                 Catch ex As Exception
-                    MsgBox("There was an issue saving your exported settings to disk, export failed.", MsgBoxStyle.Critical, Text)
+                    MsgBox("There was an issue saving your exported settings To disk, export failed.", MsgBoxStyle.Critical, Text)
                 End Try
             End If
         End Using
@@ -781,7 +785,7 @@ Public Class Form1
 
                 Threading.Thread.Sleep(500)
 
-                MsgBox("Free SysLog will now close and restart itself for the imported settings to take effect.", MsgBoxStyle.Information, Text)
+                MsgBox("Free SysLog will now close And restart itself For the imported settings To take effect.", MsgBoxStyle.Information, Text)
                 Process.Start(strEXEPath)
 
                 Try
@@ -893,7 +897,7 @@ Public Class Form1
                 If allSelectedLogs.Length > 0 Then boolCopyToClipboardResults = CopyTextToWindowsClipboard(allSelectedLogs.ToString().Trim, Text)
             End If
 
-            If boolCopyToClipboardResults Then MsgBox("Data copied to clipboard.", MsgBoxStyle.Information, Text)
+            If boolCopyToClipboardResults Then MsgBox("Data copied To clipboard.", MsgBoxStyle.Information, Text)
         End If
     End Sub
 
@@ -947,13 +951,13 @@ Public Class Form1
             Dim choice As Confirm_Delete.UserChoice
 
             Using Confirm_Delete As New Confirm_Delete(intNumberOfLogsDeleted) With {.Icon = Icon, .StartPosition = FormStartPosition.CenterParent}
-                Confirm_Delete.lblMainLabel.Text = $"Are you sure you want to delete the {intNumberOfLogsDeleted} selected {If(intNumberOfLogsDeleted = 1, "log", "logs")}?"
+                Confirm_Delete.lblMainLabel.Text = $"Are you sure you want To delete the {intNumberOfLogsDeleted} selected {If(intNumberOfLogsDeleted = 1, "log", "logs")}?"
                 Confirm_Delete.ShowDialog(Me)
                 choice = Confirm_Delete.choice
             End Using
 
             If choice = Confirm_Delete.UserChoice.NoDelete Then
-                MsgBox($"{If(intNumberOfLogsDeleted = 1, "Log", "Logs")} not deleted.", MsgBoxStyle.Information, Text)
+                MsgBox($"{If(intNumberOfLogsDeleted = 1, "Log", "Logs")} Not deleted.", MsgBoxStyle.Information, Text)
                 Exit Sub
             ElseIf choice = Confirm_Delete.UserChoice.YesDeleteYesBackup Then
                 MakeLogBackup()

--- a/Free SysLog/Windows/Ignored Logs and Search Results.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.vb
@@ -476,7 +476,7 @@ Public Class IgnoredLogsAndSearchResults
         Try
             Dim fileInfo As New FileInfo(strFileName)
 
-            If fileInfo.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(fileInfo.FullName) Then
+            If fileInfo.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) AndAlso IsGZipFile(fileInfo.FullName) Then
                 collectionOfSavedData = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(fileInfo.FullName), JSONDecoderSettingsForSettingsFiles)
             Else
                 Using fileStream As New StreamReader(strFileName)

--- a/Free SysLog/Windows/ViewLogBackups.vb
+++ b/Free SysLog/Windows/ViewLogBackups.vb
@@ -61,7 +61,7 @@ Public Class ViewLogBackups
 
     Private Function GetEntryCount(strFileName As String) As Integer
         Try
-            If New FileInfo(strFileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(strFileName) Then
+            If New FileInfo(strFileName).Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) AndAlso IsGZipFile(strFileName) Then
                 Return Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(strFileName), JSONDecoderSettingsForLogFiles).Count
             Else
                 Using fileStream As New StreamReader(strFileName)
@@ -400,7 +400,7 @@ Public Class ViewLogBackups
                                                                                      Exit Sub
                                                                                  End If
 
-                                                                                 If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
+                                                                                 If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) AndAlso IsGZipFile(file.FullName) Then
                                                                                      dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                                  Else
                                                                                      Using fileStream As New StreamReader(file.FullName)
@@ -802,7 +802,7 @@ Public Class ViewLogBackups
                                                                                  Exit Sub
                                                                              End If
 
-                                                                             If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) And IsGZipFile(file.FullName) Then
+                                                                             If file.Extension.Equals(".gz", StringComparison.OrdinalIgnoreCase) AndAlso IsGZipFile(file.FullName) Then
                                                                                  dataFromFile = Newtonsoft.Json.JsonConvert.DeserializeObject(Of List(Of SavedData))(GetTextContentsFromGZIPedLogFile(file.FullName), JSONDecoderSettingsForLogFiles)
                                                                              Else
                                                                                  Using fileStream As New StreamReader(file.FullName)


### PR DESCRIPTION
- Rewrote the GetCachedRegex() function to eliminate a TOCTOU bug. 481d7986103489d39efa8b17c64327c917a3db70
- Rewrote the ShowNotification() function in the notification limiter code to eliminate a TOCTOU bug. 97898e92bb76b70d2063838e9f5c661f20fbcfb1
- Made the And statement an AndAlso logic check when checking ".gz" file types in the program. Because... why? Why check if the file is a GZIP file if the file doesn't end with ".gz". ad12e32ebce718ecd9ca444a19dc83c2e297f478
- Added a message box to ask if you really want to zero-out the ignored log counters. 2573535d350496268027eca8cd6737c724c7fe14
- Removed a call to AutoResizeRows(), it slows things down when loading data. e337226b373deb68825bceff6ecfa86c8222c2dd