### PR TITLE
Version 5.7 Build 9

### DIFF
--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.7.8.136")>
+<Assembly: AssemblyFileVersion("5.7.9.137")>

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -13,35 +13,35 @@ Option Explicit On
 
 
 Namespace My
-    
-    <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.6.0.0"),  _
-     Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
+
+    <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.9.0.0"),
+     Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
-        
-        Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings()),MySettings)
-        
+
+        Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings()), MySettings)
+
 #Region "My.Settings Auto-Save Functionality"
 #If _MyType = "WindowsForms" Then
-    Private Shared addedHandler As Boolean
+        Private Shared addedHandler As Boolean
 
-    Private Shared addedHandlerLockObject As New Object
+        Private Shared addedHandlerLockObject As New Object
 
-    <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
-    Private Shared Sub AutoSaveSettings(sender As Global.System.Object, e As Global.System.EventArgs)
-        If My.Application.SaveMySettingsOnExit Then
-            My.Settings.Save()
-        End If
-    End Sub
+        <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>
+        Private Shared Sub AutoSaveSettings(sender As Global.System.Object, e As Global.System.EventArgs)
+            If My.Application.SaveMySettingsOnExit Then
+                My.Settings.Save()
+            End If
+        End Sub
 #End If
 #End Region
-        
+
         Public Shared ReadOnly Property [Default]() As MySettings
             Get
-                
+
 #If _MyType = "WindowsForms" Then
-               If Not addedHandler Then
+                If Not addedHandler Then
                     SyncLock addedHandlerLockObject
                         If Not addedHandler Then
                             AddHandler My.Application.Shutdown, AddressOf AutoSaveSettings
@@ -53,1458 +53,1458 @@ Namespace My
                 Return defaultInstance
             End Get
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("")>
         Public Property logFileLocation() As String
             Get
-                Return CType(Me("logFileLocation"),String)
+                Return CType(Me("logFileLocation"), String)
             End Get
             Set
-                Me("logFileLocation") = value
+                Me("logFileLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("816, 173")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("816, 173")>
         Public Property logViewerWindowSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("logViewerWindowSize"),Global.System.Drawing.Size)
+                Return CType(Me("logViewerWindowSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("logViewerWindowSize") = value
+                Me("logViewerWindowSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property autoScroll() As Boolean
             Get
-                Return CType(Me("autoScroll"),Boolean)
+                Return CType(Me("autoScroll"), Boolean)
             End Get
             Set
-                Me("autoScroll") = value
+                Me("autoScroll") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1191, 485")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1191, 485")>
         Public Property mainWindowSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("mainWindowSize"),Global.System.Drawing.Size)
+                Return CType(Me("mainWindowSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("mainWindowSize") = value
+                Me("mainWindowSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("196")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("196")>
         Public Property columnTimeSize() As Integer
             Get
-                Return CType(Me("columnTimeSize"),Integer)
+                Return CType(Me("columnTimeSize"), Integer)
             End Get
             Set
-                Me("columnTimeSize") = value
+                Me("columnTimeSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("102")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("102")>
         Public Property columnIPSize() As Integer
             Get
-                Return CType(Me("columnIPSize"),Integer)
+                Return CType(Me("columnIPSize"), Integer)
             End Get
             Set
-                Me("columnIPSize") = value
+                Me("columnIPSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("670")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("670")>
         Public Property columnLogSize() As Integer
             Get
-                Return CType(Me("columnLogSize"),Integer)
+                Return CType(Me("columnLogSize"), Integer)
             End Get
             Set
-                Me("columnLogSize") = value
+                Me("columnLogSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property autoSave() As Boolean
             Get
-                Return CType(Me("autoSave"),Boolean)
+                Return CType(Me("autoSave"), Boolean)
             End Get
             Set
-                Me("autoSave") = value
+                Me("autoSave") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("5")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("5")>
         Public Property autoSaveMinutes() As Short
             Get
-                Return CType(Me("autoSaveMinutes"),Short)
+                Return CType(Me("autoSaveMinutes"), Short)
             End Get
             Set
-                Me("autoSaveMinutes") = value
+                Me("autoSaveMinutes") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("514")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("514")>
         Public Property sysLogPort() As Integer
             Get
-                Return CType(Me("sysLogPort"),Integer)
+                Return CType(Me("sysLogPort"), Integer)
             End Get
             Set
-                Me("sysLogPort") = value
+                Me("sysLogPort") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property ignored() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("ignored"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("ignored"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("ignored") = value
+                Me("ignored") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("LightBlue")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("LightBlue")>
         Public Property searchColor() As Global.System.Drawing.Color
             Get
-                Return CType(Me("searchColor"),Global.System.Drawing.Color)
+                Return CType(Me("searchColor"), Global.System.Drawing.Color)
             End Get
             Set
-                Me("searchColor") = value
+                Me("searchColor") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1168, 464")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1168, 464")>
         Public Property ignoredWindowSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("ignoredWindowSize"),Global.System.Drawing.Size)
+                Return CType(Me("ignoredWindowSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("ignoredWindowSize") = value
+                Me("ignoredWindowSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property windowLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("windowLocation"),Global.System.Drawing.Point)
+                Return CType(Me("windowLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("windowLocation") = value
+                Me("windowLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property ignoredWindowLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("ignoredWindowLocation"),Global.System.Drawing.Point)
+                Return CType(Me("ignoredWindowLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("ignoredWindowLocation") = value
+                Me("ignoredWindowLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property ignoredWordsLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("ignoredWordsLocation"),Global.System.Drawing.Point)
+                Return CType(Me("ignoredWordsLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("ignoredWordsLocation") = value
+                Me("ignoredWordsLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property recordIgnoredLogs() As Boolean
             Get
-                Return CType(Me("recordIgnoredLogs"),Boolean)
+                Return CType(Me("recordIgnoredLogs"), Boolean)
             End Get
             Set
-                Me("recordIgnoredLogs") = value
+                Me("recordIgnoredLogs") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property replacements() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("replacements"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("replacements"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("replacements") = value
+                Me("replacements") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property boolMaximized() As Boolean
             Get
-                Return CType(Me("boolMaximized"),Boolean)
+                Return CType(Me("boolMaximized"), Boolean)
             End Get
             Set
-                Me("boolMaximized") = value
+                Me("boolMaximized") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolConfirmClose() As Boolean
             Get
-                Return CType(Me("boolConfirmClose"),Boolean)
+                Return CType(Me("boolConfirmClose"), Boolean)
             End Get
             Set
-                Me("boolConfirmClose") = value
+                Me("boolConfirmClose") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property ignored2() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("ignored2"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("ignored2"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("ignored2") = value
+                Me("ignored2") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property replacementsLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("replacementsLocation"),Global.System.Drawing.Point)
+                Return CType(Me("replacementsLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("replacementsLocation") = value
+                Me("replacementsLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property searchWindowLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("searchWindowLocation"),Global.System.Drawing.Point)
+                Return CType(Me("searchWindowLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("searchWindowLocation") = value
+                Me("searchWindowLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1168, 464")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1168, 464")>
         Public Property searchWindowSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("searchWindowSize"),Global.System.Drawing.Size)
+                Return CType(Me("searchWindowSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("searchWindowSize") = value
+                Me("searchWindowSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property alerts() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("alerts"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("alerts"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("alerts") = value
+                Me("alerts") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property alertsLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("alertsLocation"),Global.System.Drawing.Point)
+                Return CType(Me("alertsLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("alertsLocation") = value
+                Me("alertsLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolDeselectItemsWhenMinimizing() As Boolean
             Get
-                Return CType(Me("boolDeselectItemsWhenMinimizing"),Boolean)
+                Return CType(Me("boolDeselectItemsWhenMinimizing"), Boolean)
             End Get
             Set
-                Me("boolDeselectItemsWhenMinimizing") = value
+                Me("boolDeselectItemsWhenMinimizing") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolShowAlertedColumn() As Boolean
             Get
-                Return CType(Me("boolShowAlertedColumn"),Boolean)
+                Return CType(Me("boolShowAlertedColumn"), Boolean)
             End Get
             Set
-                Me("boolShowAlertedColumn") = value
+                Me("boolShowAlertedColumn") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("345")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("345")>
         Public Property colIgnoredReplace() As Integer
             Get
-                Return CType(Me("colIgnoredReplace"),Integer)
+                Return CType(Me("colIgnoredReplace"), Integer)
             End Get
             Set
-                Me("colIgnoredReplace") = value
+                Me("colIgnoredReplace") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property colIgnoredRegex() As Integer
             Get
-                Return CType(Me("colIgnoredRegex"),Integer)
+                Return CType(Me("colIgnoredRegex"), Integer)
             End Get
             Set
-                Me("colIgnoredRegex") = value
+                Me("colIgnoredRegex") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("91")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("91")>
         Public Property colIgnoredCaseSensitive() As Integer
             Get
-                Return CType(Me("colIgnoredCaseSensitive"),Integer)
+                Return CType(Me("colIgnoredCaseSensitive"), Integer)
             End Get
             Set
-                Me("colIgnoredCaseSensitive") = value
+                Me("colIgnoredCaseSensitive") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property colIgnoredEnabled() As Integer
             Get
-                Return CType(Me("colIgnoredEnabled"),Integer)
+                Return CType(Me("colIgnoredEnabled"), Integer)
             End Get
             Set
-                Me("colIgnoredEnabled") = value
+                Me("colIgnoredEnabled") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("345")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("345")>
         Public Property colReplacementsReplace() As Integer
             Get
-                Return CType(Me("colReplacementsReplace"),Integer)
+                Return CType(Me("colReplacementsReplace"), Integer)
             End Get
             Set
-                Me("colReplacementsReplace") = value
+                Me("colReplacementsReplace") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("345")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("345")>
         Public Property colReplacementsReplaceWith() As Integer
             Get
-                Return CType(Me("colReplacementsReplaceWith"),Integer)
+                Return CType(Me("colReplacementsReplaceWith"), Integer)
             End Get
             Set
-                Me("colReplacementsReplaceWith") = value
+                Me("colReplacementsReplaceWith") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property colReplacementsRegex() As Integer
             Get
-                Return CType(Me("colReplacementsRegex"),Integer)
+                Return CType(Me("colReplacementsRegex"), Integer)
             End Get
             Set
-                Me("colReplacementsRegex") = value
+                Me("colReplacementsRegex") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("91")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("91")>
         Public Property colReplacementsCaseSensitive() As Integer
             Get
-                Return CType(Me("colReplacementsCaseSensitive"),Integer)
+                Return CType(Me("colReplacementsCaseSensitive"), Integer)
             End Get
             Set
-                Me("colReplacementsCaseSensitive") = value
+                Me("colReplacementsCaseSensitive") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property colReplacementsEnabled() As Integer
             Get
-                Return CType(Me("colReplacementsEnabled"),Integer)
+                Return CType(Me("colReplacementsEnabled"), Integer)
             End Get
             Set
-                Me("colReplacementsEnabled") = value
+                Me("colReplacementsEnabled") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("308")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("308")>
         Public Property colAlertsAlertLogText() As Integer
             Get
-                Return CType(Me("colAlertsAlertLogText"),Integer)
+                Return CType(Me("colAlertsAlertLogText"), Integer)
             End Get
             Set
-                Me("colAlertsAlertLogText") = value
+                Me("colAlertsAlertLogText") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("257")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("257")>
         Public Property colAlertsAlertText() As Integer
             Get
-                Return CType(Me("colAlertsAlertText"),Integer)
+                Return CType(Me("colAlertsAlertText"), Integer)
             End Get
             Set
-                Me("colAlertsAlertText") = value
+                Me("colAlertsAlertText") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property colAlertsRegex() As Integer
             Get
-                Return CType(Me("colAlertsRegex"),Integer)
+                Return CType(Me("colAlertsRegex"), Integer)
             End Get
             Set
-                Me("colAlertsRegex") = value
+                Me("colAlertsRegex") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("91")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("91")>
         Public Property colAlertsCaseSensitive() As Integer
             Get
-                Return CType(Me("colAlertsCaseSensitive"),Integer)
+                Return CType(Me("colAlertsCaseSensitive"), Integer)
             End Get
             Set
-                Me("colAlertsCaseSensitive") = value
+                Me("colAlertsCaseSensitive") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("90")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("90")>
         Public Property colAlertsType() As Integer
             Get
-                Return CType(Me("colAlertsType"),Integer)
+                Return CType(Me("colAlertsType"), Integer)
             End Get
             Set
-                Me("colAlertsType") = value
+                Me("colAlertsType") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property colAlertsEnabled() As Integer
             Get
-                Return CType(Me("colAlertsEnabled"),Integer)
+                Return CType(Me("colAlertsEnabled"), Integer)
             End Get
             Set
-                Me("colAlertsEnabled") = value
+                Me("colAlertsEnabled") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("670, 304")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("670, 304")>
         Public Property ConfigureIgnoredSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("ConfigureIgnoredSize"),Global.System.Drawing.Size)
+                Return CType(Me("ConfigureIgnoredSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("ConfigureIgnoredSize") = value
+                Me("ConfigureIgnoredSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1051, 489")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1051, 489")>
         Public Property ConfigureReplacementsSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("ConfigureReplacementsSize"),Global.System.Drawing.Size)
+                Return CType(Me("ConfigureReplacementsSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("ConfigureReplacementsSize") = value
+                Me("ConfigureReplacementsSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1003, 322")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1003, 322")>
         Public Property ConfigureAlertsSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("ConfigureAlertsSize"),Global.System.Drawing.Size)
+                Return CType(Me("ConfigureAlertsSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("ConfigureAlertsSize") = value
+                Me("ConfigureAlertsSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property ServersToSendTo() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("ServersToSendTo"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("ServersToSendTo"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("ServersToSendTo") = value
+                Me("ServersToSendTo") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property MinimizeToClockTray() As Boolean
             Get
-                Return CType(Me("MinimizeToClockTray"),Boolean)
+                Return CType(Me("MinimizeToClockTray"), Boolean)
             End Get
             Set
-                Me("MinimizeToClockTray") = value
+                Me("MinimizeToClockTray") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property DeleteOldLogsAtMidnight() As Boolean
             Get
-                Return CType(Me("DeleteOldLogsAtMidnight"),Boolean)
+                Return CType(Me("DeleteOldLogsAtMidnight"), Boolean)
             End Get
             Set
-                Me("DeleteOldLogsAtMidnight") = value
+                Me("DeleteOldLogsAtMidnight") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1168, 464")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1168, 464")>
         Public Property logFileViewerSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("logFileViewerSize"),Global.System.Drawing.Size)
+                Return CType(Me("logFileViewerSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("logFileViewerSize") = value
+                Me("logFileViewerSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property logFileViewerLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("logFileViewerLocation"),Global.System.Drawing.Point)
+                Return CType(Me("logFileViewerLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("logFileViewerLocation") = value
+                Me("logFileViewerLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property BackupOldLogsAfterClearingAtMidnight() As Boolean
             Get
-                Return CType(Me("BackupOldLogsAfterClearingAtMidnight"),Boolean)
+                Return CType(Me("BackupOldLogsAfterClearingAtMidnight"), Boolean)
             End Get
             Set
-                Me("BackupOldLogsAfterClearingAtMidnight") = value
+                Me("BackupOldLogsAfterClearingAtMidnight") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolCheckForUpdates() As Boolean
             Get
-                Return CType(Me("boolCheckForUpdates"),Boolean)
+                Return CType(Me("boolCheckForUpdates"), Boolean)
             End Get
             Set
-                Me("boolCheckForUpdates") = value
+                Me("boolCheckForUpdates") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property DateChooserWindowLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("DateChooserWindowLocation"),Global.System.Drawing.Point)
+                Return CType(Me("DateChooserWindowLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("DateChooserWindowLocation") = value
+                Me("DateChooserWindowLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0")>
         Public Property DateFormat() As Byte
             Get
-                Return CType(Me("DateFormat"),Byte)
+                Return CType(Me("DateFormat"), Byte)
             End Get
             Set
-                Me("DateFormat") = value
+                Me("DateFormat") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("")>
         Public Property CustomDateFormat() As String
             Get
-                Return CType(Me("CustomDateFormat"),String)
+                Return CType(Me("CustomDateFormat"), String)
             End Get
             Set
-                Me("CustomDateFormat") = value
+                Me("CustomDateFormat") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("816, 403")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("816, 403")>
         Public Property ViewLogBackupsSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("ViewLogBackupsSize"),Global.System.Drawing.Size)
+                Return CType(Me("ViewLogBackupsSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("ViewLogBackupsSize") = value
+                Me("ViewLogBackupsSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property EnableTCPServer() As Boolean
             Get
-                Return CType(Me("EnableTCPServer"),Boolean)
+                Return CType(Me("EnableTCPServer"), Boolean)
             End Get
             Set
-                Me("EnableTCPServer") = value
+                Me("EnableTCPServer") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("150")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("150")>
         Public Property RemoteProcessHeaderSize() As Integer
             Get
-                Return CType(Me("RemoteProcessHeaderSize"),Integer)
+                Return CType(Me("RemoteProcessHeaderSize"), Integer)
             End Get
             Set
-                Me("RemoteProcessHeaderSize") = value
+                Me("RemoteProcessHeaderSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("200")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("200")>
         Public Property LogTypeWidth() As Integer
             Get
-                Return CType(Me("LogTypeWidth"),Integer)
+                Return CType(Me("LogTypeWidth"), Integer)
             End Get
             Set
-                Me("LogTypeWidth") = value
+                Me("LogTypeWidth") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("150")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("150")>
         Public Property HostnameWidth() As Integer
             Get
-                Return CType(Me("HostnameWidth"),Integer)
+                Return CType(Me("HostnameWidth"), Integer)
             End Get
             Set
-                Me("HostnameWidth") = value
+                Me("HostnameWidth") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("150")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("150")>
         Public Property ServerTimeWidth() As Integer
             Get
-                Return CType(Me("ServerTimeWidth"),Integer)
+                Return CType(Me("ServerTimeWidth"), Integer)
             End Get
             Set
-                Me("ServerTimeWidth") = value
+                Me("ServerTimeWidth") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolShowHostnameColumn() As Boolean
             Get
-                Return CType(Me("boolShowHostnameColumn"),Boolean)
+                Return CType(Me("boolShowHostnameColumn"), Boolean)
             End Get
             Set
-                Me("boolShowHostnameColumn") = value
+                Me("boolShowHostnameColumn") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolShowServerTimeColumn() As Boolean
             Get
-                Return CType(Me("boolShowServerTimeColumn"),Boolean)
+                Return CType(Me("boolShowServerTimeColumn"), Boolean)
             End Get
             Set
-                Me("boolShowServerTimeColumn") = value
+                Me("boolShowServerTimeColumn") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolShowLogTypeColumn() As Boolean
             Get
-                Return CType(Me("boolShowLogTypeColumn"),Boolean)
+                Return CType(Me("boolShowLogTypeColumn"), Boolean)
             End Get
             Set
-                Me("boolShowLogTypeColumn") = value
+                Me("boolShowLogTypeColumn") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property RemoveNumbersFromRemoteApp() As Boolean
             Get
-                Return CType(Me("RemoveNumbersFromRemoteApp"),Boolean)
+                Return CType(Me("RemoveNumbersFromRemoteApp"), Boolean)
             End Get
             Set
-                Me("RemoveNumbersFromRemoteApp") = value
+                Me("RemoveNumbersFromRemoteApp") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property IPv6Support() As Boolean
             Get
-                Return CType(Me("IPv6Support"),Boolean)
+                Return CType(Me("IPv6Support"), Boolean)
             End Get
             Set
-                Me("IPv6Support") = value
+                Me("IPv6Support") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property boolShowRawLogOnLogViewer() As Boolean
             Get
-                Return CType(Me("boolShowRawLogOnLogViewer"),Boolean)
+                Return CType(Me("boolShowRawLogOnLogViewer"), Boolean)
             End Get
             Set
-                Me("boolShowRawLogOnLogViewer") = value
+                Me("boolShowRawLogOnLogViewer") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property hostnames() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("hostnames"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("hostnames"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("hostnames") = value
+                Me("hostnames") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property boolShowHiddenFilesOnViewLogBackyupsWindow() As Boolean
             Get
-                Return CType(Me("boolShowHiddenFilesOnViewLogBackyupsWindow"),Boolean)
+                Return CType(Me("boolShowHiddenFilesOnViewLogBackyupsWindow"), Boolean)
             End Get
             Set
-                Me("boolShowHiddenFilesOnViewLogBackyupsWindow") = value
+                Me("boolShowHiddenFilesOnViewLogBackyupsWindow") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property boolShowHiddenAsGray() As Boolean
             Get
-                Return CType(Me("boolShowHiddenAsGray"),Boolean)
+                Return CType(Me("boolShowHiddenAsGray"), Boolean)
             End Get
             Set
-                Me("boolShowHiddenAsGray") = value
+                Me("boolShowHiddenAsGray") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("Microsoft Sans Serif, 8.25pt")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("Microsoft Sans Serif, 8.25pt")>
         Public Property font() As Global.System.Drawing.Font
             Get
-                Return CType(Me("font"),Global.System.Drawing.Font)
+                Return CType(Me("font"), Global.System.Drawing.Font)
             End Get
             Set
-                Me("font") = value
+                Me("font") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("240")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("240")>
         Public Property ColViewLogBackupsFileSize() As Integer
             Get
-                Return CType(Me("ColViewLogBackupsFileSize"),Integer)
+                Return CType(Me("ColViewLogBackupsFileSize"), Integer)
             End Get
             Set
-                Me("ColViewLogBackupsFileSize") = value
+                Me("ColViewLogBackupsFileSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("240")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("240")>
         Public Property ColViewLogBackupsFileDate() As Integer
             Get
-                Return CType(Me("ColViewLogBackupsFileDate"),Integer)
+                Return CType(Me("ColViewLogBackupsFileDate"), Integer)
             End Get
             Set
-                Me("ColViewLogBackupsFileDate") = value
+                Me("ColViewLogBackupsFileDate") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("240")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("240")>
         Public Property ColViewLogBackupsFileName() As Integer
             Get
-                Return CType(Me("ColViewLogBackupsFileName"),Integer)
+                Return CType(Me("ColViewLogBackupsFileName"), Integer)
             End Get
             Set
-                Me("ColViewLogBackupsFileName") = value
+                Me("ColViewLogBackupsFileName") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property TimeBetweenSameNotifications() As Integer
             Get
-                Return CType(Me("TimeBetweenSameNotifications"),Integer)
+                Return CType(Me("TimeBetweenSameNotifications"), Integer)
             End Get
             Set
-                Me("TimeBetweenSameNotifications") = value
+                Me("TimeBetweenSameNotifications") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property IncludeButtonsOnNotifications() As Boolean
             Get
-                Return CType(Me("IncludeButtonsOnNotifications"),Boolean)
+                Return CType(Me("IncludeButtonsOnNotifications"), Boolean)
             End Get
             Set
-                Me("IncludeButtonsOnNotifications") = value
+                Me("IncludeButtonsOnNotifications") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0")>
         Public Property NotificationLength() As Byte
             Get
-                Return CType(Me("NotificationLength"),Byte)
+                Return CType(Me("NotificationLength"), Byte)
             End Get
             Set
-                Me("NotificationLength") = value
+                Me("NotificationLength") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("776, 426")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("776, 426")>
         Public Property AlertHistorySize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("AlertHistorySize"),Global.System.Drawing.Size)
+                Return CType(Me("AlertHistorySize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("AlertHistorySize") = value
+                Me("AlertHistorySize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property AlertHistoryLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("AlertHistoryLocation"),Global.System.Drawing.Point)
+                Return CType(Me("AlertHistoryLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("AlertHistoryLocation") = value
+                Me("AlertHistoryLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property logsColumnOrder() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("logsColumnOrder"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("logsColumnOrder"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("logsColumnOrder") = value
+                Me("logsColumnOrder") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property fileListColumnOrder() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("fileListColumnOrder"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("fileListColumnOrder"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("fileListColumnOrder") = value
+                Me("fileListColumnOrder") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property alertsHistoryColumnOrder() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("alertsHistoryColumnOrder"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("alertsHistoryColumnOrder"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("alertsHistoryColumnOrder") = value
+                Me("alertsHistoryColumnOrder") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property hostnamesLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("hostnamesLocation"),Global.System.Drawing.Point)
+                Return CType(Me("hostnamesLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("hostnamesLocation") = value
+                Me("hostnamesLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0, 0")>
         Public Property syslogProxyLocation() As Global.System.Drawing.Point
             Get
-                Return CType(Me("syslogProxyLocation"),Global.System.Drawing.Point)
+                Return CType(Me("syslogProxyLocation"), Global.System.Drawing.Point)
             End Get
             Set
-                Me("syslogProxyLocation") = value
+                Me("syslogProxyLocation") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("125")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("125")>
         Public Property viewLogBackupsEntryCountColumnSize() As Integer
             Get
-                Return CType(Me("viewLogBackupsEntryCountColumnSize"),Integer)
+                Return CType(Me("viewLogBackupsEntryCountColumnSize"), Integer)
             End Get
             Set
-                Me("viewLogBackupsEntryCountColumnSize") = value
+                Me("viewLogBackupsEntryCountColumnSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property colLogAutoFill() As Boolean
             Get
-                Return CType(Me("colLogAutoFill"),Boolean)
+                Return CType(Me("colLogAutoFill"), Boolean)
             End Get
             Set
-                Me("colLogAutoFill") = value
+                Me("colLogAutoFill") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property disableAutoScrollUponScrolling() As Boolean
             Get
-                Return CType(Me("disableAutoScrollUponScrolling"),Boolean)
+                Return CType(Me("disableAutoScrollUponScrolling"), Boolean)
             End Get
             Set
-                Me("disableAutoScrollUponScrolling") = value
+                Me("disableAutoScrollUponScrolling") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("60")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("60")>
         Public Property viewLogBackupsHiddenColumnSize() As Integer
             Get
-                Return CType(Me("viewLogBackupsHiddenColumnSize"),Integer)
+                Return CType(Me("viewLogBackupsHiddenColumnSize"), Integer)
             End Get
             Set
-                Me("viewLogBackupsHiddenColumnSize") = value
+                Me("viewLogBackupsHiddenColumnSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("50")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("50")>
         Public Property columnAlertedSize() As Integer
             Get
-                Return CType(Me("columnAlertedSize"),Integer)
+                Return CType(Me("columnAlertedSize"), Integer)
             End Get
             Set
-                Me("columnAlertedSize") = value
+                Me("columnAlertedSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("150")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("150")>
         Public Property columnFileNameSize() As Integer
             Get
-                Return CType(Me("columnFileNameSize"),Integer)
+                Return CType(Me("columnFileNameSize"), Integer)
             End Get
             Set
-                Me("columnFileNameSize") = value
+                Me("columnFileNameSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property boolDebug() As Boolean
             Get
-                Return CType(Me("boolDebug"),Boolean)
+                Return CType(Me("boolDebug"), Boolean)
             End Get
             Set
-                Me("boolDebug") = value
+                Me("boolDebug") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property ConfirmDelete() As Boolean
             Get
-                Return CType(Me("ConfirmDelete"),Boolean)
+                Return CType(Me("ConfirmDelete"), Boolean)
             End Get
             Set
-                Me("ConfirmDelete") = value
+                Me("ConfirmDelete") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property IgnoreSearchResultLimits() As Boolean
             Get
-                Return CType(Me("IgnoreSearchResultLimits"),Boolean)
+                Return CType(Me("IgnoreSearchResultLimits"), Boolean)
             End Get
             Set
-                Me("IgnoreSearchResultLimits") = value
+                Me("IgnoreSearchResultLimits") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property LogFileDeletions() As Boolean
             Get
-                Return CType(Me("LogFileDeletions"),Boolean)
+                Return CType(Me("LogFileDeletions"), Boolean)
             End Get
             Set
-                Me("LogFileDeletions") = value
+                Me("LogFileDeletions") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property ProcessReplacementsInSyslogDataFirst() As Boolean
             Get
-                Return CType(Me("ProcessReplacementsInSyslogDataFirst"),Boolean)
+                Return CType(Me("ProcessReplacementsInSyslogDataFirst"), Boolean)
             End Get
             Set
-                Me("ProcessReplacementsInSyslogDataFirst") = value
+                Me("ProcessReplacementsInSyslogDataFirst") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("1000")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("1000")>
         Public Property LimitNumberOfIgnoredLogs() As Integer
             Get
-                Return CType(Me("LimitNumberOfIgnoredLogs"),Integer)
+                Return CType(Me("LimitNumberOfIgnoredLogs"), Integer)
             End Get
             Set
-                Me("LimitNumberOfIgnoredLogs") = value
+                Me("LimitNumberOfIgnoredLogs") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property AskOpenExplorer() As Boolean
             Get
-                Return CType(Me("AskOpenExplorer"),Boolean)
+                Return CType(Me("AskOpenExplorer"), Boolean)
             End Get
             Set
-                Me("AskOpenExplorer") = value
+                Me("AskOpenExplorer") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("0")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("0")>
         Public Property ignoredLogCount() As Long
             Get
-                Return CType(Me("ignoredLogCount"),Long)
+                Return CType(Me("ignoredLogCount"), Long)
             End Get
             Set
-                Me("ignoredLogCount") = value
+                Me("ignoredLogCount") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property saveIgnoredLogCount() As Boolean
             Get
-                Return CType(Me("saveIgnoredLogCount"),Boolean)
+                Return CType(Me("saveIgnoredLogCount"), Boolean)
             End Get
             Set
-                Me("saveIgnoredLogCount") = value
+                Me("saveIgnoredLogCount") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("180")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("180")>
         Public Property colIgnoredDateCreated() As Integer
             Get
-                Return CType(Me("colIgnoredDateCreated"),Integer)
+                Return CType(Me("colIgnoredDateCreated"), Integer)
             End Get
             Set
-                Me("colIgnoredDateCreated") = value
+                Me("colIgnoredDateCreated") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property ShowCloseButtonOnNotifications() As Boolean
             Get
-                Return CType(Me("ShowCloseButtonOnNotifications"),Boolean)
+                Return CType(Me("ShowCloseButtonOnNotifications"), Boolean)
             End Get
             Set
-                Me("ShowCloseButtonOnNotifications") = value
+                Me("ShowCloseButtonOnNotifications") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property FirstRun() As Boolean
             Get
-                Return CType(Me("FirstRun"),Boolean)
+                Return CType(Me("FirstRun"), Boolean)
             End Get
             Set
-                Me("FirstRun") = value
+                Me("FirstRun") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property OnlySaveAlertedLogs() As Boolean
             Get
-                Return CType(Me("OnlySaveAlertedLogs"),Boolean)
+                Return CType(Me("OnlySaveAlertedLogs"), Boolean)
             End Get
             Set
-                Me("OnlySaveAlertedLogs") = value
+                Me("OnlySaveAlertedLogs") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("240")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("240")>
         Public Property DateOfLastEventColumnWidth() As Integer
             Get
-                Return CType(Me("DateOfLastEventColumnWidth"),Integer)
+                Return CType(Me("DateOfLastEventColumnWidth"), Integer)
             End Get
             Set
-                Me("DateOfLastEventColumnWidth") = value
+                Me("DateOfLastEventColumnWidth") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("")>
         Public Property IgnoredWordsAndPhrasesColumnOrder() As String
             Get
-                Return CType(Me("IgnoredWordsAndPhrasesColumnOrder"),String)
+                Return CType(Me("IgnoredWordsAndPhrasesColumnOrder"), String)
             End Get
             Set
-                Me("IgnoredWordsAndPhrasesColumnOrder") = value
+                Me("IgnoredWordsAndPhrasesColumnOrder") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("")>
         Public Property alertsColumnOrder() As String
             Get
-                Return CType(Me("alertsColumnOrder"),String)
+                Return CType(Me("alertsColumnOrder"), String)
             End Get
             Set
-                Me("alertsColumnOrder") = value
+                Me("alertsColumnOrder") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("")>
         Public Property replacementsColumnOrder() As String
             Get
-                Return CType(Me("replacementsColumnOrder"),String)
+                Return CType(Me("replacementsColumnOrder"), String)
             End Get
             Set
-                Me("replacementsColumnOrder") = value
+                Me("replacementsColumnOrder") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("100")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("100")>
         Public Property ColSinceLastEventWidth() As Integer
             Get
-                Return CType(Me("ColSinceLastEventWidth"),Integer)
+                Return CType(Me("ColSinceLastEventWidth"), Integer)
             End Get
             Set
-                Me("ColSinceLastEventWidth") = value
+                Me("ColSinceLastEventWidth") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property AutomaticStatRefreshOnIgnoredWordsAndPhrases() As Boolean
             Get
-                Return CType(Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases"),Boolean)
+                Return CType(Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases"), Boolean)
             End Get
             Set
-                Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases") = value
+                Me("AutomaticStatRefreshOnIgnoredWordsAndPhrases") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases() As Boolean
             Get
-                Return CType(Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases"),Boolean)
+                Return CType(Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases"), Boolean)
             End Get
             Set
-                Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases") = value
+                Me("AutomaticStatRefreshOnIfActiveOnIgnoredWordsAndPhrases") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property IncludeCommasInDHMS() As Boolean
             Get
-                Return CType(Me("IncludeCommasInDHMS"),Boolean)
+                Return CType(Me("IncludeCommasInDHMS"), Boolean)
             End Get
             Set
-                Me("IncludeCommasInDHMS") = value
+                Me("IncludeCommasInDHMS") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property ShowCompressionSizeDifference() As Boolean
             Get
-                Return CType(Me("ShowCompressionSizeDifference"),Boolean)
+                Return CType(Me("ShowCompressionSizeDifference"), Boolean)
             End Get
             Set
-                Me("ShowCompressionSizeDifference") = value
+                Me("ShowCompressionSizeDifference") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property ShowCompressionSizeDifferencePercentage() As Boolean
             Get
-                Return CType(Me("ShowCompressionSizeDifferencePercentage"),Boolean)
+                Return CType(Me("ShowCompressionSizeDifferencePercentage"), Boolean)
             End Get
             Set
-                Me("ShowCompressionSizeDifferencePercentage") = value
+                Me("ShowCompressionSizeDifferencePercentage") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property CompressBackupLogFiles() As Boolean
             Get
-                Return CType(Me("CompressBackupLogFiles"),Boolean)
+                Return CType(Me("CompressBackupLogFiles"), Boolean)
             End Get
             Set
-                Me("CompressBackupLogFiles") = value
+                Me("CompressBackupLogFiles") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property ClearIgnoredStatsAtMidnight() As Boolean
             Get
-                Return CType(Me("ClearIgnoredStatsAtMidnight"),Boolean)
+                Return CType(Me("ClearIgnoredStatsAtMidnight"), Boolean)
             End Get
             Set
-                Me("ClearIgnoredStatsAtMidnight") = value
+                Me("ClearIgnoredStatsAtMidnight") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>
         Public Property AlertsHistoryAlertColumnFill() As Boolean
             Get
-                Return CType(Me("AlertsHistoryAlertColumnFill"),Boolean)
+                Return CType(Me("AlertsHistoryAlertColumnFill"), Boolean)
             End Get
             Set
-                Me("AlertsHistoryAlertColumnFill") = value
+                Me("AlertsHistoryAlertColumnFill") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("100")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("100")>
         Public Property AlertsHistoryFileNameColumnSize() As Integer
             Get
-                Return CType(Me("AlertsHistoryFileNameColumnSize"),Integer)
+                Return CType(Me("AlertsHistoryFileNameColumnSize"), Integer)
             End Get
             Set
-                Me("AlertsHistoryFileNameColumnSize") = value
+                Me("AlertsHistoryFileNameColumnSize") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property ShowAlertsFromAllFiles() As Boolean
             Get
-                Return CType(Me("ShowAlertsFromAllFiles"),Boolean)
+                Return CType(Me("ShowAlertsFromAllFiles"), Boolean)
             End Get
             Set
-                Me("ShowAlertsFromAllFiles") = value
+                Me("ShowAlertsFromAllFiles") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
         Public Property ShowAlertsFromAllFilesWithHiddenFiles() As Boolean
             Get
-                Return CType(Me("ShowAlertsFromAllFilesWithHiddenFiles"),Boolean)
+                Return CType(Me("ShowAlertsFromAllFilesWithHiddenFiles"), Boolean)
             End Get
             Set
-                Me("ShowAlertsFromAllFilesWithHiddenFiles") = value
+                Me("ShowAlertsFromAllFilesWithHiddenFiles") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute()>
         Public Property CustomColors() As Global.System.Collections.Specialized.StringCollection
             Get
-                Return CType(Me("CustomColors"),Global.System.Collections.Specialized.StringCollection)
+                Return CType(Me("CustomColors"), Global.System.Collections.Specialized.StringCollection)
             End Get
             Set
-                Me("CustomColors") = value
+                Me("CustomColors") = Value
             End Set
         End Property
-        
-        <Global.System.Configuration.UserScopedSettingAttribute(),  _
-         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("733, 326")>  _
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("733, 326")>
         Public Property ColorPickerDialogSize() As Global.System.Drawing.Size
             Get
-                Return CType(Me("ColorPickerDialogSize"),Global.System.Drawing.Size)
+                Return CType(Me("ColorPickerDialogSize"), Global.System.Drawing.Size)
             End Get
             Set
-                Me("ColorPickerDialogSize") = value
+                Me("ColorPickerDialogSize") = Value
             End Set
         End Property
     End Class

--- a/Free SysLog/My Project/Settings.Designer.vb
+++ b/Free SysLog/My Project/Settings.Designer.vb
@@ -1507,6 +1507,18 @@ Namespace My
                 Me("ColorPickerDialogSize") = Value
             End Set
         End Property
+
+        <Global.System.Configuration.UserScopedSettingAttribute(),
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>
+        Public Property ShowAsAlertedEvenIfLimitedByTime() As Boolean
+            Get
+                Return CType(Me("ShowAsAlertedEvenIfLimitedByTime"), Boolean)
+            End Get
+            Set
+                Me("ShowAsAlertedEvenIfLimitedByTime") = Value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/Free SysLog/My Project/Settings.settings
+++ b/Free SysLog/My Project/Settings.settings
@@ -368,5 +368,8 @@
     <Setting Name="ColorPickerDialogSize" Type="System.Drawing.Size" Scope="User">
       <Value Profile="(Default)">733, 326</Value>
     </Setting>
+    <Setting Name="ShowAsAlertedEvenIfLimitedByTime" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -5,7 +5,7 @@
         ' Time after which an unused entry is considered stale (in minutes)
         Private Const CleanupThresholdInMinutes As Integer = 10
 
-        Public Sub ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType, rowGUID As Guid)
+        Public Function ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType, rowGUID As Guid) As Boolean
             ' Get the current time
             Dim currentTime As Date = Date.Now
 
@@ -27,10 +27,11 @@
                                                  End If
                                              End Function)
 
-            If Not shouldShow Then Exit Sub
+            If Not shouldShow Then Return False
 
             SupportCode.ShowToastNotification(tipText, tipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alertType, rowGUID)
-        End Sub
+            Return True
+        End Function
 
         ' Function to clean up old notification entries
         Private Sub CleanUpOldEntries(currentTime As Date)

--- a/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
+++ b/Free SysLog/Support Code/Namespace Code/Notification Limiter.vb
@@ -8,10 +8,6 @@
         Public Function ShowNotification(tipText As String, tipIcon As ToolTipIcon, strLogText As String, strLogDate As String, strSourceIP As String, strRawLogText As String, alertType As AlertType, rowGUID As Guid) As Boolean
             ' Get the current time
             Dim currentTime As Date = Date.Now
-
-            ' Clean up old notification entries
-            CleanUpOldEntries(currentTime)
-
             Dim shouldShow As Boolean = False
 
             lastNotificationTime.AddOrUpdate(tipText, Function(key As String) ' key not present — always show
@@ -34,7 +30,7 @@
         End Function
 
         ' Function to clean up old notification entries
-        Private Sub CleanUpOldEntries(currentTime As Date)
+        Public Sub CleanUpOldEntries(currentTime As Date)
             Dim keysToRemove As List(Of String) = lastNotificationTime.Where(Function(kvp As KeyValuePair(Of String, Date)) (currentTime - kvp.Value).TotalMinutes > CleanupThresholdInMinutes).Select(Function(kvp As KeyValuePair(Of String, Date)) kvp.Key).ToList()
 
             For Each key As String In keysToRemove

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -744,14 +744,18 @@ Namespace SyslogParser
                     strAlertText = strAlertText.Replace("{NL}", vbCrLf, StringComparison.OrdinalIgnoreCase).Trim()
                     strAlertText = ProcessEmbeddedCommands(strAlertText)
 
+                    Dim boolAlerted As Boolean = False
+
                     If alert.BoolLimited Then
-                        NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)
+                        boolAlerted = NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)
                     Else
+                        boolAlerted = True
                         ShowToastNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)
                     End If
 
-                    strOutgoingAlertText = strAlertText
-                    Return True
+                    If boolAlerted Then strOutgoingAlertText = strAlertText
+
+                    Return boolAlerted
                 End If
             Next
 

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -750,6 +750,7 @@ Namespace SyslogParser
 
                     If alert.BoolLimited Then
                         boolAlerted = NotificationLimiter.ShowNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)
+                        If My.Settings.ShowAsAlertedEvenIfLimitedByTime Then boolAlerted = True
                     Else
                         boolAlerted = True
                         ShowToastNotification(strAlertText, ToolTipIcon, strLogText, strLogDate, strSourceIP, strRawLogText, alert.alertType, rowGUID)

--- a/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
+++ b/Free SysLog/Support Code/Namespace Code/Syslog Parser.vb
@@ -503,6 +503,8 @@ Namespace SyslogParser
             If Not boolIgnored Then
                 SyncLock ParentForm.dataGridLockObject
                     ParentForm.Logs.Invoke(Sub()
+                                               If Not boolAlerted Then strAlertText = Nothing
+
                                                Dim newItem As MyDataGridViewRow = MakeDataGridRow(serverTimeStamp:=serverDate,
                                                              dateObject:=currentDate,
                                                              strTime:=currentDate.ToString,

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -29,18 +29,23 @@ Partial Class Form1
         Me.LimitNumberOfIgnoredLogs = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnOpenLogForViewing = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnClearLog = New System.Windows.Forms.ToolStripMenuItem()
-        Me.AlertsHistory = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnClearAllLogs = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsOlderThanToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OlderThan1DayToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OlderThan2DaysToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OlderThan3DaysToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OlderThanAWeekToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.AlertsHistory = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnSaveLogsToDisk = New System.Windows.Forms.ToolStripMenuItem()
         Me.ExportAllLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.StatusStrip = New System.Windows.Forms.StatusStrip()
         Me.NumberOfLogs = New System.Windows.Forms.ToolStripStatusLabel()
-        Me.LblAutoSaved = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblItemsSelected = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.LblAutoSaved = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblLogFileSize = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblNumberOfIgnoredIncomingLogs = New System.Windows.Forms.ToolStripStatusLabel()
         Me.LblAutoScrollStatus = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.lblProcessUptime = New System.Windows.Forms.ToolStripStatusLabel()
         Me.ChkEnableAutoScroll = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkDisableAutoScrollUponScrolling = New System.Windows.Forms.ToolStripMenuItem()
         Me.AutomaticallyCheckForUpdates = New System.Windows.Forms.ToolStripMenuItem()
@@ -56,16 +61,56 @@ Partial Class Form1
         Me.ChkRegExSearch = New System.Windows.Forms.CheckBox()
         Me.MenuStrip = New System.Windows.Forms.MenuStrip()
         Me.MainMenuToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.AboutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ImportExportSettingsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ExportToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ImportToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OpenWindowsExplorerToAppConfigFile = New System.Windows.Forms.ToolStripMenuItem()
+        Me.StopServerStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripMenuSeparator = New System.Windows.Forms.ToolStripSeparator()
+        Me.CloseMe = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogFunctionsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ClearNotificationLimits = New System.Windows.Forms.ToolStripMenuItem()
         Me.IgnoredLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ClearIgnoredLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ViewIgnoredLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ZerooutIgnoredLogsCounterToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ViewLogBackups = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ZerooutIgnoredLogsCounterToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.SettingsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfigureReplacementsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.BackupFileNameDateFormatChooser = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChangeAlternatingColorToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChangeFont = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChangeSyslogServerPortToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ClearIgnoredStatsAtMidnight = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CompressBackupLogFilesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ConfigureAlertsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ConfigureHostnames = New System.Windows.Forms.ToolStripMenuItem()
         Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ConfigureReplacementsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ConfigureSysLogMirrorServers = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ConfigureTimeBetweenSameNotifications = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ConfirmDelete = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkDebug = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkDeselectItemAfterMinimizingWindow = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChangeLogAutosaveIntervalToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ChkEnableConfirmCloseToolStripItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.IPv6Support = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkEnableRecordingOfIgnoredLogs = New System.Windows.Forms.ToolStripMenuItem()
+        Me.IncludeButtonsOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
+        Me.IncludeCommasInDHMS = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
+        Me.MinimizeToClockTray = New System.Windows.Forms.ToolStripMenuItem()
+        Me.NotificationLength = New System.Windows.Forms.ToolStripMenuItem()
+        Me.NotificationLengthLong = New System.Windows.Forms.ToolStripMenuItem()
+        Me.NotificationLengthShort = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OnlySaveAlertedLogs = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ProcessReplacementsInSyslogDataFirst = New System.Windows.Forms.ToolStripMenuItem()
+        Me.RemoveNumbersFromRemoteApp = New System.Windows.Forms.ToolStripMenuItem()
+        Me.SaveIgnoredLogCount = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ShowCloseButtonOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ShowLogAsAlertedEvenIfLimitedByTime = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ShowRawLogOnLogViewer = New System.Windows.Forms.ToolStripMenuItem()
+        Me.DonationStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.LblSearchLabel = New System.Windows.Forms.Label()
         Me.TxtSearchTerms = New System.Windows.Forms.TextBox()
         Me.BtnSearch = New System.Windows.Forms.Button()
@@ -73,81 +118,36 @@ Partial Class Form1
         Me.Logs = New System.Windows.Forms.DataGridView()
         Me.ColTime = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.colServerTime = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.ColIPAddress = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.colLogType = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ColIPAddress = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ColHostname = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ColRemoteProcess = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColLog = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColAlerts = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.ColRemoteProcess = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.ColHostname = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.NotifyIcon = New System.Windows.Forms.NotifyIcon(Me.components)
-        Me.ChkEnableConfirmCloseToolStripItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChangeAlternatingColorToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChangeFont = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfigureAlertsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfigureHostnames = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CompressBackupLogFilesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ClearNotificationLimits = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ColLogsAutoFill = New System.Windows.Forms.ToolStripMenuItem()
+        Me.colDelete = New System.Windows.Forms.DataGridViewCheckBoxColumn()
         Me.LogsMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.LogsHeaderMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.CopyRawLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.AboutToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CloseMe = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ToolStripMenuSeparator = New System.Windows.Forms.ToolStripSeparator()
+        Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CreateIgnoredLogToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CreateReplacementToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.DeleteLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.DeleteSimilarLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ExportsLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.OpenLogViewerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.NotifyIcon = New System.Windows.Forms.NotifyIcon(Me.components)
+        Me.IconMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.ReOpenToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.LogsHeaderMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.LogsMenuHideAlertsColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenuHideHostnameColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenuHideLogTypeColumn = New System.Windows.Forms.ToolStripMenuItem()
         Me.LogsMenuHideServerTimeColumn = New System.Windows.Forms.ToolStripMenuItem()
-        Me.DeleteLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.DeleteSimilarLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ExportsLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ImportExportSettingsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.IncludeButtonsOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
-        Me.IncludeCommasInDHMS = New System.Windows.Forms.ToolStripMenuItem()
-        Me.IPv6Support = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ExportToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ImportToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OlderThan1DayToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OlderThan2DaysToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OlderThan3DaysToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OlderThanAWeekToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OpenWindowsExplorerToAppConfigFile = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ProcessReplacementsInSyslogDataFirst = New System.Windows.Forms.ToolStripMenuItem()
-        Me.RemoveNumbersFromRemoteApp = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ShowRawLogOnLogViewer = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ShowLogAsAlertedEvenIfLimitedByTime = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ShowCloseButtonOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
-        Me.SaveIgnoredLogCount = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.DonationStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.StopServerStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChangeSyslogServerPortToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ClearIgnoredStatsAtMidnight = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChangeLogAutosaveIntervalToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CreateIgnoredLogToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CreateReplacementToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfigureSysLogMirrorServers = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfigureTimeBetweenSameNotifications = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ConfirmDelete = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChkDeselectItemAfterMinimizingWindow = New System.Windows.Forms.ToolStripMenuItem()
-        Me.ChkDebug = New System.Windows.Forms.ToolStripMenuItem()
-        Me.BackupFileNameDateFormatChooser = New System.Windows.Forms.ToolStripMenuItem()
         Me.btnShowLimit = New System.Windows.Forms.Button()
-        Me.MinimizeToClockTray = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OnlySaveAlertedLogs = New System.Windows.Forms.ToolStripMenuItem()
-        Me.NotificationLength = New System.Windows.Forms.ToolStripMenuItem()
-        Me.NotificationLengthLong = New System.Windows.Forms.ToolStripMenuItem()
-        Me.NotificationLengthShort = New System.Windows.Forms.ToolStripMenuItem()
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
-        Me.IconMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.ReOpenToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
-        Me.lblProcessUptime = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblLimitBy = New System.Windows.Forms.Label()
-        Me.colDelete = New System.Windows.Forms.DataGridViewCheckBoxColumn()
         Me.StatusStrip.SuspendLayout()
         Me.MenuStrip.SuspendLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -156,39 +156,11 @@ Partial Class Form1
         Me.LogsHeaderMenu.SuspendLayout()
         Me.SuspendLayout()
         '
-        'NotificationLength
+        'BtnOpenLogLocation
         '
-        Me.NotificationLength.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.NotificationLengthLong, Me.NotificationLengthShort})
-        Me.NotificationLength.Name = "NotificationLength"
-        Me.NotificationLength.Size = New System.Drawing.Size(319, 22)
-        Me.NotificationLength.Text = "Notification Length"
-        '
-        'NotificationLengthLong
-        '
-        Me.NotificationLengthLong.CheckOnClick = True
-        Me.NotificationLengthLong.Name = "NotificationLengthLong"
-        Me.NotificationLengthLong.Size = New System.Drawing.Size(102, 22)
-        Me.NotificationLengthLong.Text = "Long"
-        '
-        'NotificationLengthShort
-        '
-        Me.NotificationLengthShort.CheckOnClick = True
-        Me.NotificationLengthShort.Name = "NotificationLengthShort"
-        Me.NotificationLengthShort.Size = New System.Drawing.Size(102, 22)
-        Me.NotificationLengthShort.Text = "Short"
-        '
-        'OnlySaveAlertedLogs
-        '
-        Me.OnlySaveAlertedLogs.CheckOnClick = True
-        Me.OnlySaveAlertedLogs.Name = "OnlySaveAlertedLogs"
-        Me.OnlySaveAlertedLogs.Size = New System.Drawing.Size(102, 22)
-        Me.OnlySaveAlertedLogs.Text = "Only Save Alerted Logs"
-        '
-        'CreateAlertToolStripMenuItem
-        '
-        Me.CreateAlertToolStripMenuItem.Name = "CreateAlertToolStripMenuItem"
-        Me.CreateAlertToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
-        Me.CreateAlertToolStripMenuItem.Text = "Create Alert"
+        Me.BtnOpenLogLocation.Name = "BtnOpenLogLocation"
+        Me.BtnOpenLogLocation.Size = New System.Drawing.Size(239, 22)
+        Me.BtnOpenLogLocation.Text = "Open Log File Location"
         '
         'LimitNumberOfIgnoredLogs
         '
@@ -197,24 +169,11 @@ Partial Class Form1
         Me.LimitNumberOfIgnoredLogs.Text = "Limit Number of Ignored Logs"
         Me.LimitNumberOfIgnoredLogs.ToolTipText = "Limits the number of ignored logs that stored in system RAM by the program."
         '
-        'BtnOpenLogLocation
-        '
-        Me.BtnOpenLogLocation.Name = "BtnOpenLogLocation"
-        Me.BtnOpenLogLocation.Size = New System.Drawing.Size(239, 22)
-        Me.BtnOpenLogLocation.Text = "Open Log File Location"
-        '
         'BtnOpenLogForViewing
         '
         Me.BtnOpenLogForViewing.Name = "BtnOpenLogForViewing"
         Me.BtnOpenLogForViewing.Size = New System.Drawing.Size(239, 22)
         Me.BtnOpenLogForViewing.Text = "Open Log File for Viewing"
-        '
-        'AlertsHistory
-        '
-        Me.AlertsHistory.Enabled = True
-        Me.AlertsHistory.Name = "AlertsHistory"
-        Me.AlertsHistory.Size = New System.Drawing.Size(239, 22)
-        Me.AlertsHistory.Text = "Alerts History"
         '
         'BtnClearLog
         '
@@ -237,12 +196,48 @@ Partial Class Form1
         Me.LogsOlderThanToolStripMenuItem.Size = New System.Drawing.Size(165, 22)
         Me.LogsOlderThanToolStripMenuItem.Text = "Logs older than..."
         '
+        'OlderThan1DayToolStripMenuItem
+        '
+        Me.OlderThan1DayToolStripMenuItem.Name = "OlderThan1DayToolStripMenuItem"
+        Me.OlderThan1DayToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
+        Me.OlderThan1DayToolStripMenuItem.Text = "Older than 1 day"
+        '
+        'OlderThan2DaysToolStripMenuItem
+        '
+        Me.OlderThan2DaysToolStripMenuItem.Name = "OlderThan2DaysToolStripMenuItem"
+        Me.OlderThan2DaysToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
+        Me.OlderThan2DaysToolStripMenuItem.Text = "Older than 2 days"
+        '
+        'OlderThan3DaysToolStripMenuItem
+        '
+        Me.OlderThan3DaysToolStripMenuItem.Name = "OlderThan3DaysToolStripMenuItem"
+        Me.OlderThan3DaysToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
+        Me.OlderThan3DaysToolStripMenuItem.Text = "Older than 3 days"
+        '
+        'OlderThanAWeekToolStripMenuItem
+        '
+        Me.OlderThanAWeekToolStripMenuItem.Name = "OlderThanAWeekToolStripMenuItem"
+        Me.OlderThanAWeekToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
+        Me.OlderThanAWeekToolStripMenuItem.Text = "Older than a week"
+        '
+        'AlertsHistory
+        '
+        Me.AlertsHistory.Name = "AlertsHistory"
+        Me.AlertsHistory.Size = New System.Drawing.Size(239, 22)
+        Me.AlertsHistory.Text = "Alerts History"
+        '
         'BtnSaveLogsToDisk
         '
         Me.BtnSaveLogsToDisk.Enabled = False
         Me.BtnSaveLogsToDisk.Name = "BtnSaveLogsToDisk"
         Me.BtnSaveLogsToDisk.Size = New System.Drawing.Size(239, 22)
         Me.BtnSaveLogsToDisk.Text = "Save Logs to Disk"
+        '
+        'ExportAllLogsToolStripMenuItem
+        '
+        Me.ExportAllLogsToolStripMenuItem.Name = "ExportAllLogsToolStripMenuItem"
+        Me.ExportAllLogsToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.ExportAllLogsToolStripMenuItem.Text = "Export All Logs"
         '
         'StatusStrip
         '
@@ -286,29 +281,21 @@ Partial Class Form1
         '
         Me.LblNumberOfIgnoredIncomingLogs.Margin = New System.Windows.Forms.Padding(0, 3, 25, 2)
         Me.LblNumberOfIgnoredIncomingLogs.Name = "LblNumberOfIgnoredIncomingLogs"
-        Me.LblNumberOfIgnoredIncomingLogs.Size = New System.Drawing.Size(200, 17)
+        Me.LblNumberOfIgnoredIncomingLogs.Size = New System.Drawing.Size(203, 17)
         Me.LblNumberOfIgnoredIncomingLogs.Text = "Number of Ignored Incoming Logs: 0"
         '
         'LblAutoScrollStatus
         '
         Me.LblAutoScrollStatus.Margin = New System.Windows.Forms.Padding(0, 3, 25, 2)
         Me.LblAutoScrollStatus.Name = "LblAutoScrollStatus"
-        Me.LblAutoScrollStatus.Size = New System.Drawing.Size(200, 17)
+        Me.LblAutoScrollStatus.Size = New System.Drawing.Size(151, 17)
         Me.LblAutoScrollStatus.Text = "Auto Scroll Status: Disabled"
         '
-        'AskToOpenExplorerWhenSavingData
+        'lblProcessUptime
         '
-        Me.AskToOpenExplorerWhenSavingData.CheckOnClick = True
-        Me.AskToOpenExplorerWhenSavingData.Name = "AskToOpenExplorerWhenSavingData"
-        Me.AskToOpenExplorerWhenSavingData.Size = New System.Drawing.Size(319, 22)
-        Me.AskToOpenExplorerWhenSavingData.Text = "Ask to open Explorer after saving a file to disk"
-        '
-        'AutomaticallyCheckForUpdates
-        '
-        Me.AutomaticallyCheckForUpdates.CheckOnClick = True
-        Me.AutomaticallyCheckForUpdates.Name = "AutomaticallyCheckForUpdates"
-        Me.AutomaticallyCheckForUpdates.Size = New System.Drawing.Size(319, 22)
-        Me.AutomaticallyCheckForUpdates.Text = "Automatically Check for Updates"
+        Me.lblProcessUptime.Name = "lblProcessUptime"
+        Me.lblProcessUptime.Size = New System.Drawing.Size(98, 15)
+        Me.lblProcessUptime.Text = "Program Uptime:"
         '
         'ChkEnableAutoScroll
         '
@@ -323,6 +310,20 @@ Partial Class Form1
         Me.ChkDisableAutoScrollUponScrolling.Name = "ChkDisableAutoScrollUponScrolling"
         Me.ChkDisableAutoScrollUponScrolling.Size = New System.Drawing.Size(319, 22)
         Me.ChkDisableAutoScrollUponScrolling.Text = "        Disable Auto Scroll upon scrolling"
+        '
+        'AutomaticallyCheckForUpdates
+        '
+        Me.AutomaticallyCheckForUpdates.CheckOnClick = True
+        Me.AutomaticallyCheckForUpdates.Name = "AutomaticallyCheckForUpdates"
+        Me.AutomaticallyCheckForUpdates.Size = New System.Drawing.Size(319, 22)
+        Me.AutomaticallyCheckForUpdates.Text = "Automatically Check for Updates"
+        '
+        'AskToOpenExplorerWhenSavingData
+        '
+        Me.AskToOpenExplorerWhenSavingData.CheckOnClick = True
+        Me.AskToOpenExplorerWhenSavingData.Name = "AskToOpenExplorerWhenSavingData"
+        Me.AskToOpenExplorerWhenSavingData.Size = New System.Drawing.Size(319, 22)
+        Me.AskToOpenExplorerWhenSavingData.Text = "Ask to open Explorer after saving a file to disk"
         '
         'BtnCheckForUpdates
         '
@@ -352,34 +353,6 @@ Partial Class Form1
         Me.BackupOldLogsAfterClearingAtMidnight.Size = New System.Drawing.Size(319, 22)
         Me.BackupOldLogsAfterClearingAtMidnight.Text = "        Backup old logs after clearing at midnight"
         '
-        'MinimizeToClockTray
-        '
-        Me.MinimizeToClockTray.CheckOnClick = True
-        Me.MinimizeToClockTray.Name = "MinimizeToClockTray"
-        Me.MinimizeToClockTray.Size = New System.Drawing.Size(319, 22)
-        Me.MinimizeToClockTray.Text = "Minimize to Clock Tray"
-        '
-        'ChkDebug
-        '
-        Me.ChkDebug.CheckOnClick = True
-        Me.ChkDebug.Name = "ChkDebug"
-        Me.ChkDebug.Size = New System.Drawing.Size(319, 22)
-        Me.ChkDebug.Text = "Debug Mode"
-        Me.ChkDebug.ToolTipText = "Enables debug data from the program to be written to the Syslog Data."
-        '
-        'ChkDeselectItemAfterMinimizingWindow
-        '
-        Me.ChkDeselectItemAfterMinimizingWindow.CheckOnClick = True
-        Me.ChkDeselectItemAfterMinimizingWindow.Name = "ChkDeselectItemAfterMinimizingWindow"
-        Me.ChkDeselectItemAfterMinimizingWindow.Size = New System.Drawing.Size(319, 22)
-        Me.ChkDeselectItemAfterMinimizingWindow.Text = "De-Select Items When Minimizing Window"
-        '
-        'BackupFileNameDateFormatChooser
-        '
-        Me.BackupFileNameDateFormatChooser.Name = "BackupFileNameDateFormatChooser"
-        Me.BackupFileNameDateFormatChooser.Size = New System.Drawing.Size(319, 22)
-        Me.BackupFileNameDateFormatChooser.Text = "Backup File Name Date Format Chooser"
-        '
         'ChkEnableStartAtUserStartup
         '
         Me.ChkEnableStartAtUserStartup.CheckOnClick = True
@@ -396,14 +369,13 @@ Partial Class Form1
         '
         'StartUpDelay
         '
-        Me.StartUpDelay.Name = "StartUpDelay"
         Me.StartUpDelay.Enabled = False
+        Me.StartUpDelay.Name = "StartUpDelay"
         Me.StartUpDelay.Size = New System.Drawing.Size(319, 22)
         Me.StartUpDelay.Text = "        Startup Delay"
         '
         'ChkRegExSearch
         '
-        Me.ChkRegExSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkRegExSearch.AutoSize = True
         Me.ChkRegExSearch.Location = New System.Drawing.Point(239, 31)
         Me.ChkRegExSearch.Name = "ChkRegExSearch"
@@ -430,6 +402,43 @@ Partial Class Form1
         Me.MainMenuToolStripMenuItem.Size = New System.Drawing.Size(80, 20)
         Me.MainMenuToolStripMenuItem.Text = "Main Menu"
         '
+        'AboutToolStripMenuItem
+        '
+        Me.AboutToolStripMenuItem.Name = "AboutToolStripMenuItem"
+        Me.AboutToolStripMenuItem.Size = New System.Drawing.Size(338, 22)
+        Me.AboutToolStripMenuItem.Text = "About"
+        '
+        'ImportExportSettingsToolStripMenuItem
+        '
+        Me.ImportExportSettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ExportToolStripMenuItem, Me.ImportToolStripMenuItem})
+        Me.ImportExportSettingsToolStripMenuItem.Name = "ImportExportSettingsToolStripMenuItem"
+        Me.ImportExportSettingsToolStripMenuItem.Size = New System.Drawing.Size(338, 22)
+        Me.ImportExportSettingsToolStripMenuItem.Text = "Import/Export Program Settings"
+        '
+        'ExportToolStripMenuItem
+        '
+        Me.ExportToolStripMenuItem.Name = "ExportToolStripMenuItem"
+        Me.ExportToolStripMenuItem.Size = New System.Drawing.Size(110, 22)
+        Me.ExportToolStripMenuItem.Text = "Export"
+        '
+        'ImportToolStripMenuItem
+        '
+        Me.ImportToolStripMenuItem.Name = "ImportToolStripMenuItem"
+        Me.ImportToolStripMenuItem.Size = New System.Drawing.Size(110, 22)
+        Me.ImportToolStripMenuItem.Text = "Import"
+        '
+        'OpenWindowsExplorerToAppConfigFile
+        '
+        Me.OpenWindowsExplorerToAppConfigFile.Name = "OpenWindowsExplorerToAppConfigFile"
+        Me.OpenWindowsExplorerToAppConfigFile.Size = New System.Drawing.Size(338, 22)
+        Me.OpenWindowsExplorerToAppConfigFile.Text = "Open Windows Explorer to Application Config File"
+        '
+        'StopServerStripMenuItem
+        '
+        Me.StopServerStripMenuItem.Name = "StopServerStripMenuItem"
+        Me.StopServerStripMenuItem.Size = New System.Drawing.Size(338, 22)
+        Me.StopServerStripMenuItem.Text = "Stop Server"
+        '
         'ToolStripMenuSeparator
         '
         Me.ToolStripMenuSeparator.Name = "ToolStripMenuSeparator"
@@ -448,6 +457,12 @@ Partial Class Form1
         Me.LogFunctionsToolStripMenuItem.Size = New System.Drawing.Size(94, 20)
         Me.LogFunctionsToolStripMenuItem.Text = "Log Functions"
         '
+        'ClearNotificationLimits
+        '
+        Me.ClearNotificationLimits.Name = "ClearNotificationLimits"
+        Me.ClearNotificationLimits.Size = New System.Drawing.Size(239, 22)
+        Me.ClearNotificationLimits.Text = "Clear Notification Limits"
+        '
         'IgnoredLogsToolStripMenuItem
         '
         Me.IgnoredLogsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ClearIgnoredLogsToolStripMenuItem, Me.ViewIgnoredLogsToolStripMenuItem})
@@ -457,8 +472,8 @@ Partial Class Form1
         '
         'ClearIgnoredLogsToolStripMenuItem
         '
-        Me.ClearIgnoredLogsToolStripMenuItem.Name = "ClearIgnoredLogsToolStripMenuItem"
         Me.ClearIgnoredLogsToolStripMenuItem.Enabled = False
+        Me.ClearIgnoredLogsToolStripMenuItem.Name = "ClearIgnoredLogsToolStripMenuItem"
         Me.ClearIgnoredLogsToolStripMenuItem.Size = New System.Drawing.Size(101, 22)
         Me.ClearIgnoredLogsToolStripMenuItem.Text = "Clear"
         '
@@ -468,18 +483,18 @@ Partial Class Form1
         Me.ViewIgnoredLogsToolStripMenuItem.Size = New System.Drawing.Size(101, 22)
         Me.ViewIgnoredLogsToolStripMenuItem.Text = "View"
         '
-        'ZerooutIgnoredLogsCounterToolStripMenuItem
-        '
-        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Name = "ZerooutIgnoredLogsCounterToolStripMenuItem"
-        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Text = "Zero-out Ignored Logs Counter"
-        '
         'ViewLogBackups
         '
         Me.ViewLogBackups.Name = "ViewLogBackups"
         Me.ViewLogBackups.Size = New System.Drawing.Size(239, 22)
         Me.ViewLogBackups.Text = "View Log Backups"
         Me.ViewLogBackups.Visible = False
+        '
+        'ZerooutIgnoredLogsCounterToolStripMenuItem
+        '
+        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Name = "ZerooutIgnoredLogsCounterToolStripMenuItem"
+        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
+        Me.ZerooutIgnoredLogsCounterToolStripMenuItem.Text = "Zero-out Ignored Logs Counter"
         '
         'SettingsToolStripMenuItem
         '
@@ -488,11 +503,36 @@ Partial Class Form1
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
         '
-        'ClearNotificationLimits
+        'BackupFileNameDateFormatChooser
         '
-        Me.ClearNotificationLimits.Name = "ClearNotificationLimits"
-        Me.ClearNotificationLimits.Size = New System.Drawing.Size(239, 22)
-        Me.ClearNotificationLimits.Text = "Clear Notification Limits"
+        Me.BackupFileNameDateFormatChooser.Name = "BackupFileNameDateFormatChooser"
+        Me.BackupFileNameDateFormatChooser.Size = New System.Drawing.Size(319, 22)
+        Me.BackupFileNameDateFormatChooser.Text = "Backup File Name Date Format Chooser"
+        '
+        'ChangeAlternatingColorToolStripMenuItem
+        '
+        Me.ChangeAlternatingColorToolStripMenuItem.Name = "ChangeAlternatingColorToolStripMenuItem"
+        Me.ChangeAlternatingColorToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
+        Me.ChangeAlternatingColorToolStripMenuItem.Text = "Change Alternating Row Color"
+        '
+        'ChangeFont
+        '
+        Me.ChangeFont.Name = "ChangeFont"
+        Me.ChangeFont.Size = New System.Drawing.Size(319, 22)
+        Me.ChangeFont.Text = "Change Font"
+        '
+        'ChangeSyslogServerPortToolStripMenuItem
+        '
+        Me.ChangeSyslogServerPortToolStripMenuItem.Name = "ChangeSyslogServerPortToolStripMenuItem"
+        Me.ChangeSyslogServerPortToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
+        Me.ChangeSyslogServerPortToolStripMenuItem.Text = "Change Syslog Server Port"
+        '
+        'ClearIgnoredStatsAtMidnight
+        '
+        Me.ClearIgnoredStatsAtMidnight.CheckOnClick = True
+        Me.ClearIgnoredStatsAtMidnight.Name = "ClearIgnoredStatsAtMidnight"
+        Me.ClearIgnoredStatsAtMidnight.Size = New System.Drawing.Size(319, 22)
+        Me.ClearIgnoredStatsAtMidnight.Text = "Clear Ignored Log Stats at Midnight"
         '
         'CompressBackupLogFilesToolStripMenuItem
         '
@@ -501,24 +541,29 @@ Partial Class Form1
         Me.CompressBackupLogFilesToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
         Me.CompressBackupLogFilesToolStripMenuItem.Text = "Compress Backup Log Files"
         '
-        'ColLogsAutoFill
+        'ConfigureAlertsToolStripMenuItem
         '
-        Me.ColLogsAutoFill.CheckOnClick = True
-        Me.ColLogsAutoFill.Name = "ColLogsAutoFill"
-        Me.ColLogsAutoFill.Size = New System.Drawing.Size(319, 22)
-        Me.ColLogsAutoFill.Text = "Log Column AutoFill"
+        Me.ConfigureAlertsToolStripMenuItem.Name = "ConfigureAlertsToolStripMenuItem"
+        Me.ConfigureAlertsToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
+        Me.ConfigureAlertsToolStripMenuItem.Text = "Configure Alerts"
         '
-        'ConfigureReplacementsToolStripMenuItem
+        'ConfigureHostnames
         '
-        Me.ConfigureReplacementsToolStripMenuItem.Name = "ConfigureReplacementsToolStripMenuItem"
-        Me.ConfigureReplacementsToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
-        Me.ConfigureReplacementsToolStripMenuItem.Text = "Configure Replacements"
+        Me.ConfigureHostnames.Name = "ConfigureHostnames"
+        Me.ConfigureHostnames.Size = New System.Drawing.Size(319, 22)
+        Me.ConfigureHostnames.Text = "Configure Custom Hostnames/Device Names"
         '
         'ConfigureIgnoredWordsAndPhrasesToolStripMenuItem
         '
         Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Name = "ConfigureIgnoredWordsAndPhrasesToolStripMenuItem"
         Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
         Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem.Text = "Configure Ignored Words and Phrases"
+        '
+        'ConfigureReplacementsToolStripMenuItem
+        '
+        Me.ConfigureReplacementsToolStripMenuItem.Name = "ConfigureReplacementsToolStripMenuItem"
+        Me.ConfigureReplacementsToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
+        Me.ConfigureReplacementsToolStripMenuItem.Text = "Configure Replacements"
         '
         'ConfigureSysLogMirrorServers
         '
@@ -539,6 +584,41 @@ Partial Class Form1
         Me.ConfirmDelete.Size = New System.Drawing.Size(319, 22)
         Me.ConfirmDelete.Text = "Confirm Deletion of Logs"
         '
+        'ChkDebug
+        '
+        Me.ChkDebug.CheckOnClick = True
+        Me.ChkDebug.Name = "ChkDebug"
+        Me.ChkDebug.Size = New System.Drawing.Size(319, 22)
+        Me.ChkDebug.Text = "Debug Mode"
+        Me.ChkDebug.ToolTipText = "Enables debug data from the program to be written to the Syslog Data."
+        '
+        'ChkDeselectItemAfterMinimizingWindow
+        '
+        Me.ChkDeselectItemAfterMinimizingWindow.CheckOnClick = True
+        Me.ChkDeselectItemAfterMinimizingWindow.Name = "ChkDeselectItemAfterMinimizingWindow"
+        Me.ChkDeselectItemAfterMinimizingWindow.Size = New System.Drawing.Size(319, 22)
+        Me.ChkDeselectItemAfterMinimizingWindow.Text = "De-Select Items When Minimizing Window"
+        '
+        'ChangeLogAutosaveIntervalToolStripMenuItem
+        '
+        Me.ChangeLogAutosaveIntervalToolStripMenuItem.Name = "ChangeLogAutosaveIntervalToolStripMenuItem"
+        Me.ChangeLogAutosaveIntervalToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
+        Me.ChangeLogAutosaveIntervalToolStripMenuItem.Text = "        Change Log Autosave Interval"
+        '
+        'ChkEnableConfirmCloseToolStripItem
+        '
+        Me.ChkEnableConfirmCloseToolStripItem.CheckOnClick = True
+        Me.ChkEnableConfirmCloseToolStripItem.Name = "ChkEnableConfirmCloseToolStripItem"
+        Me.ChkEnableConfirmCloseToolStripItem.Size = New System.Drawing.Size(319, 22)
+        Me.ChkEnableConfirmCloseToolStripItem.Text = "Enable Confirm Close"
+        '
+        'IPv6Support
+        '
+        Me.IPv6Support.CheckOnClick = True
+        Me.IPv6Support.Name = "IPv6Support"
+        Me.IPv6Support.Size = New System.Drawing.Size(319, 22)
+        Me.IPv6Support.Text = "Enable IPv6 Support"
+        '
         'ChkEnableRecordingOfIgnoredLogs
         '
         Me.ChkEnableRecordingOfIgnoredLogs.CheckOnClick = True
@@ -548,9 +628,116 @@ Partial Class Form1
         Me.ChkEnableRecordingOfIgnoredLogs.ToolTipText = "When enabled, ignored logs are only stored in the program's memory and are not wr" &
     "itten to disk."
         '
+        'IncludeButtonsOnNotifications
+        '
+        Me.IncludeButtonsOnNotifications.CheckOnClick = True
+        Me.IncludeButtonsOnNotifications.Name = "IncludeButtonsOnNotifications"
+        Me.IncludeButtonsOnNotifications.Size = New System.Drawing.Size(319, 22)
+        Me.IncludeButtonsOnNotifications.Text = "Include Buttons on Notifications"
+        '
+        'IncludeCommasInDHMS
+        '
+        Me.IncludeCommasInDHMS.CheckOnClick = True
+        Me.IncludeCommasInDHMS.Name = "IncludeCommasInDHMS"
+        Me.IncludeCommasInDHMS.Size = New System.Drawing.Size(319, 22)
+        Me.IncludeCommasInDHMS.Text = "Include Commas in DHMS Strings"
+        Me.IncludeCommasInDHMS.ToolTipText = "Changes how DHMS strings are shown." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & """d, h, m, s"" or ""d h m s"""
+        '
+        'ColLogsAutoFill
+        '
+        Me.ColLogsAutoFill.CheckOnClick = True
+        Me.ColLogsAutoFill.Name = "ColLogsAutoFill"
+        Me.ColLogsAutoFill.Size = New System.Drawing.Size(319, 22)
+        Me.ColLogsAutoFill.Text = "Log Column AutoFill"
+        '
+        'MinimizeToClockTray
+        '
+        Me.MinimizeToClockTray.CheckOnClick = True
+        Me.MinimizeToClockTray.Name = "MinimizeToClockTray"
+        Me.MinimizeToClockTray.Size = New System.Drawing.Size(319, 22)
+        Me.MinimizeToClockTray.Text = "Minimize to Clock Tray"
+        '
+        'NotificationLength
+        '
+        Me.NotificationLength.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.NotificationLengthLong, Me.NotificationLengthShort})
+        Me.NotificationLength.Name = "NotificationLength"
+        Me.NotificationLength.Size = New System.Drawing.Size(319, 22)
+        Me.NotificationLength.Text = "Notification Length"
+        '
+        'NotificationLengthLong
+        '
+        Me.NotificationLengthLong.CheckOnClick = True
+        Me.NotificationLengthLong.Name = "NotificationLengthLong"
+        Me.NotificationLengthLong.Size = New System.Drawing.Size(102, 22)
+        Me.NotificationLengthLong.Text = "Long"
+        '
+        'NotificationLengthShort
+        '
+        Me.NotificationLengthShort.CheckOnClick = True
+        Me.NotificationLengthShort.Name = "NotificationLengthShort"
+        Me.NotificationLengthShort.Size = New System.Drawing.Size(102, 22)
+        Me.NotificationLengthShort.Text = "Short"
+        '
+        'OnlySaveAlertedLogs
+        '
+        Me.OnlySaveAlertedLogs.CheckOnClick = True
+        Me.OnlySaveAlertedLogs.Name = "OnlySaveAlertedLogs"
+        Me.OnlySaveAlertedLogs.Size = New System.Drawing.Size(319, 22)
+        Me.OnlySaveAlertedLogs.Text = "Only Save Alerted Logs"
+        '
+        'ProcessReplacementsInSyslogDataFirst
+        '
+        Me.ProcessReplacementsInSyslogDataFirst.CheckOnClick = True
+        Me.ProcessReplacementsInSyslogDataFirst.Name = "ProcessReplacementsInSyslogDataFirst"
+        Me.ProcessReplacementsInSyslogDataFirst.Size = New System.Drawing.Size(319, 22)
+        Me.ProcessReplacementsInSyslogDataFirst.Text = "Process Replacements in Syslog Data First"
+        '
+        'RemoveNumbersFromRemoteApp
+        '
+        Me.RemoveNumbersFromRemoteApp.CheckOnClick = True
+        Me.RemoveNumbersFromRemoteApp.Name = "RemoveNumbersFromRemoteApp"
+        Me.RemoveNumbersFromRemoteApp.Size = New System.Drawing.Size(319, 22)
+        Me.RemoveNumbersFromRemoteApp.Text = "Remove Numbers From Remote App"
+        '
+        'SaveIgnoredLogCount
+        '
+        Me.SaveIgnoredLogCount.CheckOnClick = True
+        Me.SaveIgnoredLogCount.Name = "SaveIgnoredLogCount"
+        Me.SaveIgnoredLogCount.Size = New System.Drawing.Size(319, 22)
+        Me.SaveIgnoredLogCount.Text = "Save Ignored Log Count"
+        Me.SaveIgnoredLogCount.ToolTipText = "Saves the ignored log count and ignored rule stat data to disk for historical ana" &
+    "lysis." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Before it was for the funzies, now this can be an incredible tool to hel" &
+    "p you fine tune rules."
+        '
+        'ShowCloseButtonOnNotifications
+        '
+        Me.ShowCloseButtonOnNotifications.CheckOnClick = True
+        Me.ShowCloseButtonOnNotifications.Name = "ShowCloseButtonOnNotifications"
+        Me.ShowCloseButtonOnNotifications.Size = New System.Drawing.Size(319, 22)
+        Me.ShowCloseButtonOnNotifications.Text = "Show Close Button on Notifications"
+        '
+        'ShowLogAsAlertedEvenIfLimitedByTime
+        '
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.CheckOnClick = True
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.Name = "ShowLogAsAlertedEvenIfLimitedByTime"
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.Size = New System.Drawing.Size(319, 22)
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.Text = "Show Log as Alerted Even if Limited by Time"
+        '
+        'ShowRawLogOnLogViewer
+        '
+        Me.ShowRawLogOnLogViewer.CheckOnClick = True
+        Me.ShowRawLogOnLogViewer.Name = "ShowRawLogOnLogViewer"
+        Me.ShowRawLogOnLogViewer.Size = New System.Drawing.Size(319, 22)
+        Me.ShowRawLogOnLogViewer.Text = "Show Raw Log on Log Viewer Window"
+        '
+        'DonationStripMenuItem
+        '
+        Me.DonationStripMenuItem.Name = "DonationStripMenuItem"
+        Me.DonationStripMenuItem.Size = New System.Drawing.Size(211, 20)
+        Me.DonationStripMenuItem.Text = "Donate to me via ""Buy Me A Coffee"""
+        '
         'LblSearchLabel
         '
-        Me.LblSearchLabel.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.LblSearchLabel.AutoSize = True
         Me.LblSearchLabel.Location = New System.Drawing.Point(12, 31)
         Me.LblSearchLabel.Name = "LblSearchLabel"
@@ -560,7 +747,6 @@ Partial Class Form1
         '
         'TxtSearchTerms
         '
-        Me.TxtSearchTerms.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.TxtSearchTerms.Location = New System.Drawing.Point(85, 28)
         Me.TxtSearchTerms.Name = "TxtSearchTerms"
         Me.TxtSearchTerms.Size = New System.Drawing.Size(148, 20)
@@ -568,7 +754,6 @@ Partial Class Form1
         '
         'BtnSearch
         '
-        Me.BtnSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.BtnSearch.Location = New System.Drawing.Point(851, 27)
         Me.BtnSearch.Name = "BtnSearch"
         Me.BtnSearch.Size = New System.Drawing.Size(52, 23)
@@ -578,7 +763,6 @@ Partial Class Form1
         '
         'ChkCaseInsensitiveSearch
         '
-        Me.ChkCaseInsensitiveSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.ChkCaseInsensitiveSearch.AutoSize = True
         Me.ChkCaseInsensitiveSearch.Checked = True
         Me.ChkCaseInsensitiveSearch.CheckState = System.Windows.Forms.CheckState.Checked
@@ -608,14 +792,6 @@ Partial Class Form1
         Me.Logs.Size = New System.Drawing.Size(1151, 369)
         Me.Logs.TabIndex = 18
         '
-        'colServerTime
-        '
-        Me.colServerTime.HeaderText = "Server Time"
-        Me.colServerTime.Name = "colServerTime"
-        Me.colServerTime.ReadOnly = True
-        Me.colServerTime.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.colServerTime.ToolTipText = "The time on the server at which the log entry came in."
-        '
         'ColTime
         '
         Me.ColTime.HeaderText = "Time"
@@ -624,13 +800,13 @@ Partial Class Form1
         Me.ColTime.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
         Me.ColTime.ToolTipText = "The time at which the log entry came in."
         '
-        'ColIPAddress
+        'colServerTime
         '
-        Me.ColIPAddress.HeaderText = "IP Address"
-        Me.ColIPAddress.Name = "ColIPAddress"
-        Me.ColIPAddress.ReadOnly = True
-        Me.ColIPAddress.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.ColIPAddress.ToolTipText = "The IP address of the system from which the log came from."
+        Me.colServerTime.HeaderText = "Server Time"
+        Me.colServerTime.Name = "colServerTime"
+        Me.colServerTime.ReadOnly = True
+        Me.colServerTime.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.colServerTime.ToolTipText = "The time on the server at which the log entry came in."
         '
         'colLogType
         '
@@ -639,14 +815,13 @@ Partial Class Form1
         Me.colLogType.ReadOnly = True
         Me.colLogType.Width = 200
         '
-        'ColAlerts
+        'ColIPAddress
         '
-        Me.ColAlerts.HeaderText = "Alerted"
-        Me.ColAlerts.Name = "ColAlerts"
-        Me.ColAlerts.ReadOnly = True
-        Me.ColAlerts.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.ColAlerts.Width = 50
-        Me.ColAlerts.ToolTipText = "Yes or No. Indicates if the log entry triggered an alert from this program."
+        Me.ColIPAddress.HeaderText = "IP Address"
+        Me.ColIPAddress.Name = "ColIPAddress"
+        Me.ColIPAddress.ReadOnly = True
+        Me.ColIPAddress.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.ColIPAddress.ToolTipText = "The IP address of the system from which the log came from."
         '
         'ColHostname
         '
@@ -673,125 +848,27 @@ Partial Class Form1
         Me.ColLog.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
         Me.ColLog.ToolTipText = "The text contents of the log."
         '
-        'ConfigureAlertsToolStripMenuItem
+        'ColAlerts
         '
-        Me.ConfigureAlertsToolStripMenuItem.Name = "ConfigureAlertsToolStripMenuItem"
-        Me.ConfigureAlertsToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
-        Me.ConfigureAlertsToolStripMenuItem.Text = "Configure Alerts"
+        Me.ColAlerts.HeaderText = "Alerted"
+        Me.ColAlerts.Name = "ColAlerts"
+        Me.ColAlerts.ReadOnly = True
+        Me.ColAlerts.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.ColAlerts.ToolTipText = "Yes or No. Indicates if the log entry triggered an alert from this program."
+        Me.ColAlerts.Width = 50
         '
-        'ConfigureHostnames
+        'colDelete
         '
-        Me.ConfigureHostnames.Name = "ConfigureHostnames"
-        Me.ConfigureHostnames.Size = New System.Drawing.Size(319, 22)
-        Me.ConfigureHostnames.Text = "Configure Custom Hostnames/Device Names"
-        '
-        'ChangeAlternatingColorToolStripMenuItem
-        '
-        Me.ChangeAlternatingColorToolStripMenuItem.Name = "ChangeAlternatingColorToolStripMenuItem"
-        Me.ChangeAlternatingColorToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
-        Me.ChangeAlternatingColorToolStripMenuItem.Text = "Change Alternating Row Color"
-        '
-        'ChangeFont
-        '
-        Me.ChangeFont.Name = "ChangeFont"
-        Me.ChangeFont.Size = New System.Drawing.Size(319, 22)
-        Me.ChangeFont.Text = "Change Font"
-        '
-        'AboutToolStripMenuItem
-        '
-        Me.AboutToolStripMenuItem.Name = "AboutToolStripMenuItem"
-        Me.AboutToolStripMenuItem.Size = New System.Drawing.Size(338, 22)
-        Me.AboutToolStripMenuItem.Text = "About"
-        '
-        'ImportExportSettingsToolStripMenuItem
-        '
-        Me.ImportExportSettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ExportToolStripMenuItem, Me.ImportToolStripMenuItem})
-        Me.ImportExportSettingsToolStripMenuItem.Name = "ImportExportSettingsToolStripMenuItem"
-        Me.ImportExportSettingsToolStripMenuItem.Size = New System.Drawing.Size(338, 22)
-        Me.ImportExportSettingsToolStripMenuItem.Text = "Import/Export Program Settings"
-        '
-        'IncludeButtonsOnNotifications
-        '
-        Me.IncludeButtonsOnNotifications.CheckOnClick = True
-        Me.IncludeButtonsOnNotifications.Name = "IncludeButtonsOnNotifications"
-        Me.IncludeButtonsOnNotifications.Size = New System.Drawing.Size(319, 22)
-        Me.IncludeButtonsOnNotifications.Text = "Include Buttons on Notifications"
-        '
-        'IncludeCommasInDHMS
-        '
-        Me.IncludeCommasInDHMS.CheckOnClick = True
-        Me.IncludeCommasInDHMS.Name = "IncludeCommasInDHMS"
-        Me.IncludeCommasInDHMS.Size = New System.Drawing.Size(319, 22)
-        Me.IncludeCommasInDHMS.Text = "Include Commas in DHMS Strings"
-        Me.IncludeCommasInDHMS.ToolTipText = "Changes how DHMS strings are shown." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & """d, h, m, s"" or ""d h m s"""
-        '
-        'IPv6Support
-        '
-        Me.IPv6Support.CheckOnClick = True
-        Me.IPv6Support.Name = "IPv6Support"
-        Me.IPv6Support.Size = New System.Drawing.Size(319, 22)
-        Me.IPv6Support.Text = "Enable IPv6 Support"
-        '
-        'ExportToolStripMenuItem
-        '
-        Me.ExportToolStripMenuItem.Name = "ExportToolStripMenuItem"
-        Me.ExportToolStripMenuItem.Size = New System.Drawing.Size(110, 22)
-        Me.ExportToolStripMenuItem.Text = "Export"
-        '
-        'ImportToolStripMenuItem
-        '
-        Me.ImportToolStripMenuItem.Name = "ImportToolStripMenuItem"
-        Me.ImportToolStripMenuItem.Size = New System.Drawing.Size(110, 22)
-        Me.ImportToolStripMenuItem.Text = "Import"
-        '
-        'NotifyIcon
-        '
-        Me.NotifyIcon.ContextMenuStrip = Me.IconMenu
-        Me.NotifyIcon.Text = "NotifyIcon"
-        Me.NotifyIcon.Visible = True
-        '
-        'OlderThan1DayToolStripMenuItem
-        '
-        Me.OlderThan1DayToolStripMenuItem.Name = "OlderThan1DayToolStripMenuItem"
-        Me.OlderThan1DayToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
-        Me.OlderThan1DayToolStripMenuItem.Text = "Older than 1 day"
-        '
-        'OlderThan2DaysToolStripMenuItem
-        '
-        Me.OlderThan2DaysToolStripMenuItem.Name = "OlderThan2DaysToolStripMenuItem"
-        Me.OlderThan2DaysToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
-        Me.OlderThan2DaysToolStripMenuItem.Text = "Older than 2 days"
-        '
-        'OlderThan3DaysToolStripMenuItem
-        '
-        Me.OlderThan3DaysToolStripMenuItem.Name = "OlderThan3DaysToolStripMenuItem"
-        Me.OlderThan3DaysToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
-        Me.OlderThan3DaysToolStripMenuItem.Text = "Older than 3 days"
-        '
-        'OlderThanAWeekToolStripMenuItem
-        '
-        Me.OlderThanAWeekToolStripMenuItem.Name = "OlderThanAWeekToolStripMenuItem"
-        Me.OlderThanAWeekToolStripMenuItem.Size = New System.Drawing.Size(169, 22)
-        Me.OlderThanAWeekToolStripMenuItem.Text = "Older than a week"
-        '
-        'ChkEnableConfirmCloseToolStripItem
-        '
-        Me.ChkEnableConfirmCloseToolStripItem.CheckOnClick = True
-        Me.ChkEnableConfirmCloseToolStripItem.Name = "ChkEnableConfirmCloseToolStripItem"
-        Me.ChkEnableConfirmCloseToolStripItem.Size = New System.Drawing.Size(319, 22)
-        Me.ChkEnableConfirmCloseToolStripItem.Text = "Enable Confirm Close"
-        '
-        'LogsHeaderMenu
-        '
-        Me.LogsHeaderMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LogsMenuHideAlertsColumn, Me.LogsMenuHideHostnameColumn, Me.LogsMenuHideLogTypeColumn, Me.LogsMenuHideServerTimeColumn})
-        Me.LogsHeaderMenu.Name = "LogsHeaderMenu"
-        Me.LogsHeaderMenu.Size = New System.Drawing.Size(183, 180)
+        Me.colDelete.HeaderText = "Delete?"
+        Me.colDelete.Name = "colDelete"
+        Me.colDelete.ReadOnly = True
+        Me.colDelete.Width = 60
         '
         'LogsMenu
         '
         Me.LogsMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.CreateIgnoredLogToolStripMenuItem, Me.CreateReplacementToolStripMenuItem, Me.DeleteLogsToolStripMenuItem, Me.DeleteSimilarLogsToolStripMenuItem, Me.ExportsLogsToolStripMenuItem, Me.OpenLogViewerToolStripMenuItem})
         Me.LogsMenu.Name = "LogsMenu"
-        Me.LogsMenu.Size = New System.Drawing.Size(183, 180)
+        Me.LogsMenu.Size = New System.Drawing.Size(183, 202)
         '
         'CopyLogTextToolStripMenuItem
         '
@@ -805,141 +882,11 @@ Partial Class Form1
         Me.CopyRawLogTextToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
         Me.CopyRawLogTextToolStripMenuItem.Text = "Copy Raw Log Text"
         '
-        'OpenLogViewerToolStripMenuItem
+        'CreateAlertToolStripMenuItem
         '
-        Me.OpenLogViewerToolStripMenuItem.Name = "OpenLogViewerToolStripMenuItem"
-        Me.OpenLogViewerToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
-        Me.OpenLogViewerToolStripMenuItem.Text = "Open Log Viewer"
-        '
-        'LogsMenuHideAlertsColumn
-        '
-        Me.LogsMenuHideAlertsColumn.Name = "LogsMenuHideAlertsColumn"
-        Me.LogsMenuHideAlertsColumn.Size = New System.Drawing.Size(182, 22)
-        Me.LogsMenuHideAlertsColumn.Text = "Hide 'Alerts' Column"
-        '
-        'LogsMenuHideHostnameColumn
-        '
-        Me.LogsMenuHideHostnameColumn.Name = "LogsMenuHideHostnameColumn"
-        Me.LogsMenuHideHostnameColumn.Size = New System.Drawing.Size(182, 22)
-        Me.LogsMenuHideHostnameColumn.Text = "Hide 'Hostname' Column"
-        '
-        'LogsMenuHideLogTypeColumn
-        '
-        Me.LogsMenuHideLogTypeColumn.Name = "LogsMenuHideLogTypeColumn"
-        Me.LogsMenuHideLogTypeColumn.Size = New System.Drawing.Size(182, 22)
-        Me.LogsMenuHideLogTypeColumn.Text = "Hide 'Log Type' Column"
-        '
-        'LogsMenuHideServerTimeColumn
-        '
-        Me.LogsMenuHideServerTimeColumn.Name = "LogsMenuHideServerTimeColumn"
-        Me.LogsMenuHideServerTimeColumn.Size = New System.Drawing.Size(182, 22)
-        Me.LogsMenuHideServerTimeColumn.Text = "Hide 'Server Time' Column"
-        '
-        'DeleteSimilarLogsToolStripMenuItem
-        '
-        Me.DeleteSimilarLogsToolStripMenuItem.Name = "DeleteSimilarLogsToolStripMenuItem"
-        Me.DeleteSimilarLogsToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
-        Me.DeleteSimilarLogsToolStripMenuItem.Text = "Delete Similar Logs"
-        '
-        'DeleteLogsToolStripMenuItem
-        '
-        Me.DeleteLogsToolStripMenuItem.Name = "DeleteLogsToolStripMenuItem"
-        Me.DeleteLogsToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
-        Me.DeleteLogsToolStripMenuItem.Text = "Delete Selected Logs"
-        '
-        'ExportAllLogsToolStripMenuItem
-        '
-        Me.ExportAllLogsToolStripMenuItem.Name = "ExportAllLogsToolStripMenuItem"
-        Me.ExportAllLogsToolStripMenuItem.Size = New System.Drawing.Size(239, 22)
-        Me.ExportAllLogsToolStripMenuItem.Text = "Export All Logs"
-        '
-        'ExportsLogsToolStripMenuItem
-        '
-        Me.ExportsLogsToolStripMenuItem.Name = "ExportsLogsToolStripMenuItem"
-        Me.ExportsLogsToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
-        Me.ExportsLogsToolStripMenuItem.Text = "Export Selected Logs"
-        '
-        'DonationStripMenuItem
-        '
-        Me.DonationStripMenuItem.Name = "DonationStripMenuItem"
-        Me.DonationStripMenuItem.Size = New System.Drawing.Size(177, 20)
-        Me.DonationStripMenuItem.Text = "Donate to me via ""Buy Me A Coffee"""
-        '
-        'StopServerStripMenuItem
-        '
-        Me.StopServerStripMenuItem.Name = "StopServerStripMenuItem"
-        Me.StopServerStripMenuItem.Size = New System.Drawing.Size(338, 22)
-        Me.StopServerStripMenuItem.Text = "Stop Server"
-        '
-        'ChangeSyslogServerPortToolStripMenuItem
-        '
-        Me.ChangeSyslogServerPortToolStripMenuItem.Name = "ChangeSyslogServerPortToolStripMenuItem"
-        Me.ChangeSyslogServerPortToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
-        Me.ChangeSyslogServerPortToolStripMenuItem.Text = "Change Syslog Server Port"
-        '
-        'ClearIgnoredStatsAtMidnight
-        '
-        Me.ClearIgnoredStatsAtMidnight.CheckOnClick = True
-        Me.ClearIgnoredStatsAtMidnight.Name = "ClearIgnoredStatsAtMidnight"
-        Me.ClearIgnoredStatsAtMidnight.Size = New System.Drawing.Size(319, 22)
-        Me.ClearIgnoredStatsAtMidnight.Text = "Clear Ignored Log Stats at Midnight"
-        '
-        'ChangeLogAutosaveIntervalToolStripMenuItem
-        '
-        Me.ChangeLogAutosaveIntervalToolStripMenuItem.Name = "ChangeLogAutosaveIntervalToolStripMenuItem"
-        Me.ChangeLogAutosaveIntervalToolStripMenuItem.Size = New System.Drawing.Size(319, 22)
-        Me.ChangeLogAutosaveIntervalToolStripMenuItem.Text = "        Change Log Autosave Interval"
-        '
-        'OpenWindowsExplorerToAppConfigFile
-        '
-        Me.OpenWindowsExplorerToAppConfigFile.Name = "OpenWindowsExplorerToAppConfigFile"
-        Me.OpenWindowsExplorerToAppConfigFile.Size = New System.Drawing.Size(338, 22)
-        Me.OpenWindowsExplorerToAppConfigFile.Text = "Open Windows Explorer to Application Config File"
-        '
-        'RemoveNumbersFromRemoteApp
-        '
-        Me.RemoveNumbersFromRemoteApp.CheckOnClick = True
-        Me.RemoveNumbersFromRemoteApp.Name = "RemoveNumbersFromRemoteApp"
-        Me.RemoveNumbersFromRemoteApp.Size = New System.Drawing.Size(319, 22)
-        Me.RemoveNumbersFromRemoteApp.Text = "Remove Numbers From Remote App"
-        '
-        'ProcessReplacementsInSyslogDataFirst
-        '
-        Me.ProcessReplacementsInSyslogDataFirst.CheckOnClick = True
-        Me.ProcessReplacementsInSyslogDataFirst.Name = "ProcessReplacementsInSyslogDataFirst"
-        Me.ProcessReplacementsInSyslogDataFirst.Size = New System.Drawing.Size(319, 22)
-        Me.ProcessReplacementsInSyslogDataFirst.Text = "Process Replacements in Syslog Data First"
-        '
-        'ShowLogAsAlertedEvenIfLimitedByTime
-        '
-        Me.ShowLogAsAlertedEvenIfLimitedByTime.CheckOnClick = True
-        Me.ShowLogAsAlertedEvenIfLimitedByTime.Name = "ShowLogAsAlertedEvenIfLimitedByTime"
-        Me.ShowLogAsAlertedEvenIfLimitedByTime.Size = New System.Drawing.Size(319, 22)
-        Me.ShowLogAsAlertedEvenIfLimitedByTime.Text = "Show Log as Alerted Even if Limited by Time"
-        '
-        'ShowCloseButtonOnNotifications
-        '
-        Me.ShowCloseButtonOnNotifications.CheckOnClick = True
-        Me.ShowCloseButtonOnNotifications.Name = "ShowCloseButtonOnNotifications"
-        Me.ShowCloseButtonOnNotifications.Size = New System.Drawing.Size(319, 22)
-        Me.ShowCloseButtonOnNotifications.Text = "Show Close Button on Notifications"
-        '
-        'ShowRawLogOnLogViewer
-        '
-        Me.ShowRawLogOnLogViewer.CheckOnClick = True
-        Me.ShowRawLogOnLogViewer.Name = "ShowRawLogOnLogViewer"
-        Me.ShowRawLogOnLogViewer.Size = New System.Drawing.Size(319, 22)
-        Me.ShowRawLogOnLogViewer.Text = "Show Raw Log on Log Viewer Window"
-        '
-        'SaveIgnoredLogCount
-        '
-        Me.SaveIgnoredLogCount.CheckOnClick = True
-        Me.SaveIgnoredLogCount.Name = "SaveIgnoredLogCount"
-        Me.SaveIgnoredLogCount.Size = New System.Drawing.Size(319, 22)
-        Me.SaveIgnoredLogCount.Text = "Save Ignored Log Count"
-        Me.SaveIgnoredLogCount.ToolTipText = "Saves the ignored log count and ignored rule stat data to disk for historical ana" &
-    "lysis." & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "Before it was for the funzies, now this can be an incredible tool to hel" &
-    "p you fine tune rules."
+        Me.CreateAlertToolStripMenuItem.Name = "CreateAlertToolStripMenuItem"
+        Me.CreateAlertToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.CreateAlertToolStripMenuItem.Text = "Create Alert"
         '
         'CreateIgnoredLogToolStripMenuItem
         '
@@ -953,15 +900,35 @@ Partial Class Form1
         Me.CreateReplacementToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
         Me.CreateReplacementToolStripMenuItem.Text = "Create Replacement"
         '
-        'LoadingProgressBar
+        'DeleteLogsToolStripMenuItem
         '
-        Me.LoadingProgressBar.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.LoadingProgressBar.Location = New System.Drawing.Point(954, 28)
-        Me.LoadingProgressBar.Name = "LoadingProgressBar"
-        Me.LoadingProgressBar.Size = New System.Drawing.Size(209, 23)
-        Me.LoadingProgressBar.TabIndex = 19
-        Me.LoadingProgressBar.Visible = False
+        Me.DeleteLogsToolStripMenuItem.Name = "DeleteLogsToolStripMenuItem"
+        Me.DeleteLogsToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.DeleteLogsToolStripMenuItem.Text = "Delete Selected Logs"
+        '
+        'DeleteSimilarLogsToolStripMenuItem
+        '
+        Me.DeleteSimilarLogsToolStripMenuItem.Name = "DeleteSimilarLogsToolStripMenuItem"
+        Me.DeleteSimilarLogsToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.DeleteSimilarLogsToolStripMenuItem.Text = "Delete Similar Logs"
+        '
+        'ExportsLogsToolStripMenuItem
+        '
+        Me.ExportsLogsToolStripMenuItem.Name = "ExportsLogsToolStripMenuItem"
+        Me.ExportsLogsToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.ExportsLogsToolStripMenuItem.Text = "Export Selected Logs"
+        '
+        'OpenLogViewerToolStripMenuItem
+        '
+        Me.OpenLogViewerToolStripMenuItem.Name = "OpenLogViewerToolStripMenuItem"
+        Me.OpenLogViewerToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
+        Me.OpenLogViewerToolStripMenuItem.Text = "Open Log Viewer"
+        '
+        'NotifyIcon
+        '
+        Me.NotifyIcon.ContextMenuStrip = Me.IconMenu
+        Me.NotifyIcon.Text = "NotifyIcon"
+        Me.NotifyIcon.Visible = True
         '
         'IconMenu
         '
@@ -975,14 +942,35 @@ Partial Class Form1
         Me.ReOpenToolStripMenuItem.Size = New System.Drawing.Size(121, 22)
         Me.ReOpenToolStripMenuItem.Text = "Re-Open"
         '
-        'lblLimitBy
+        'LogsHeaderMenu
         '
-        Me.lblLimitBy.AutoSize = True
-        Me.lblLimitBy.Location = New System.Drawing.Point(423, 32)
-        Me.lblLimitBy.Name = "lblLimitBy"
-        Me.lblLimitBy.Size = New System.Drawing.Size(46, 13)
-        Me.lblLimitBy.TabIndex = 42
-        Me.lblLimitBy.Text = "Limit By:"
+        Me.LogsHeaderMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LogsMenuHideAlertsColumn, Me.LogsMenuHideHostnameColumn, Me.LogsMenuHideLogTypeColumn, Me.LogsMenuHideServerTimeColumn})
+        Me.LogsHeaderMenu.Name = "LogsHeaderMenu"
+        Me.LogsHeaderMenu.Size = New System.Drawing.Size(217, 92)
+        '
+        'LogsMenuHideAlertsColumn
+        '
+        Me.LogsMenuHideAlertsColumn.Name = "LogsMenuHideAlertsColumn"
+        Me.LogsMenuHideAlertsColumn.Size = New System.Drawing.Size(216, 22)
+        Me.LogsMenuHideAlertsColumn.Text = "Hide 'Alerts' Column"
+        '
+        'LogsMenuHideHostnameColumn
+        '
+        Me.LogsMenuHideHostnameColumn.Name = "LogsMenuHideHostnameColumn"
+        Me.LogsMenuHideHostnameColumn.Size = New System.Drawing.Size(216, 22)
+        Me.LogsMenuHideHostnameColumn.Text = "Hide 'Hostname' Column"
+        '
+        'LogsMenuHideLogTypeColumn
+        '
+        Me.LogsMenuHideLogTypeColumn.Name = "LogsMenuHideLogTypeColumn"
+        Me.LogsMenuHideLogTypeColumn.Size = New System.Drawing.Size(216, 22)
+        Me.LogsMenuHideLogTypeColumn.Text = "Hide 'Log Type' Column"
+        '
+        'LogsMenuHideServerTimeColumn
+        '
+        Me.LogsMenuHideServerTimeColumn.Name = "LogsMenuHideServerTimeColumn"
+        Me.LogsMenuHideServerTimeColumn.Size = New System.Drawing.Size(216, 22)
+        Me.LogsMenuHideServerTimeColumn.Text = "Hide 'Server Time' Column"
         '
         'btnShowLimit
         '
@@ -993,6 +981,16 @@ Partial Class Form1
         Me.btnShowLimit.TabIndex = 45
         Me.btnShowLimit.Text = "Limit"
         Me.btnShowLimit.UseVisualStyleBackColor = True
+        '
+        'LoadingProgressBar
+        '
+        Me.LoadingProgressBar.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.LoadingProgressBar.Location = New System.Drawing.Point(954, 28)
+        Me.LoadingProgressBar.Name = "LoadingProgressBar"
+        Me.LoadingProgressBar.Size = New System.Drawing.Size(209, 23)
+        Me.LoadingProgressBar.TabIndex = 19
+        Me.LoadingProgressBar.Visible = False
         '
         'boxLimiter
         '
@@ -1005,12 +1003,6 @@ Partial Class Form1
         Me.boxLimiter.Sorted = True
         Me.boxLimiter.TabIndex = 44
         '
-        'lblProcessUptime
-        '
-        Me.lblProcessUptime.Name = "lblProcessUptime"
-        Me.lblProcessUptime.Size = New System.Drawing.Size(92, 17)
-        Me.lblProcessUptime.Text = "Program Uptime:"
-        '
         'boxLimitBy
         '
         Me.boxLimitBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
@@ -1019,15 +1011,16 @@ Partial Class Form1
         Me.boxLimitBy.Location = New System.Drawing.Point(468, 29)
         Me.boxLimitBy.Name = "boxLimitBy"
         Me.boxLimitBy.Size = New System.Drawing.Size(121, 21)
-        Me.boxLimitBy.Text = "(Not Specified)"
         Me.boxLimitBy.TabIndex = 43
         '
-        'colDelete
+        'lblLimitBy
         '
-        Me.colDelete.HeaderText = "Delete?"
-        Me.colDelete.Name = "colDelete"
-        Me.colDelete.ReadOnly = True
-        Me.colDelete.Width = 60
+        Me.lblLimitBy.AutoSize = True
+        Me.lblLimitBy.Location = New System.Drawing.Point(423, 32)
+        Me.lblLimitBy.Name = "lblLimitBy"
+        Me.lblLimitBy.Size = New System.Drawing.Size(46, 13)
+        Me.lblLimitBy.TabIndex = 42
+        Me.lblLimitBy.Text = "Limit By:"
         '
         'Form1
         '
@@ -1057,8 +1050,8 @@ Partial Class Form1
         Me.MenuStrip.PerformLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).EndInit()
         Me.LogsMenu.ResumeLayout(False)
-        Me.LogsHeaderMenu.ResumeLayout(False)
         Me.IconMenu.ResumeLayout(False)
+        Me.LogsHeaderMenu.ResumeLayout(False)
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/Free SysLog/Windows/Form1.Designer.vb
+++ b/Free SysLog/Windows/Form1.Designer.vb
@@ -117,6 +117,7 @@ Partial Class Form1
         Me.ProcessReplacementsInSyslogDataFirst = New System.Windows.Forms.ToolStripMenuItem()
         Me.RemoveNumbersFromRemoteApp = New System.Windows.Forms.ToolStripMenuItem()
         Me.ShowRawLogOnLogViewer = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ShowLogAsAlertedEvenIfLimitedByTime = New System.Windows.Forms.ToolStripMenuItem()
         Me.ShowCloseButtonOnNotifications = New System.Windows.Forms.ToolStripMenuItem()
         Me.SaveIgnoredLogCount = New System.Windows.Forms.ToolStripMenuItem()
         Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -152,6 +153,7 @@ Partial Class Form1
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.LogsMenu.SuspendLayout()
         Me.IconMenu.SuspendLayout()
+        Me.LogsHeaderMenu.SuspendLayout()
         Me.SuspendLayout()
         '
         'NotificationLength
@@ -481,7 +483,7 @@ Partial Class Form1
         '
         'SettingsToolStripMenuItem
         '
-        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ClearIgnoredStatsAtMidnight, Me.CompressBackupLogFilesToolStripMenuItem, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowRawLogOnLogViewer})
+        Me.SettingsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AskToOpenExplorerWhenSavingData, Me.AutomaticallyCheckForUpdates, Me.BackupFileNameDateFormatChooser, Me.ChangeAlternatingColorToolStripMenuItem, Me.ChangeFont, Me.ChangeSyslogServerPortToolStripMenuItem, Me.ClearIgnoredStatsAtMidnight, Me.CompressBackupLogFilesToolStripMenuItem, Me.ConfigureAlertsToolStripMenuItem, Me.ConfigureHostnames, Me.ConfigureIgnoredWordsAndPhrasesToolStripMenuItem, Me.ConfigureReplacementsToolStripMenuItem, Me.ConfigureSysLogMirrorServers, Me.ConfigureTimeBetweenSameNotifications, Me.ConfirmDelete, Me.ChkDebug, Me.ChkDeselectItemAfterMinimizingWindow, Me.DeleteOldLogsAtMidnight, Me.BackupOldLogsAfterClearingAtMidnight, Me.ChkEnableAutoSave, Me.ChangeLogAutosaveIntervalToolStripMenuItem, Me.ChkEnableAutoScroll, Me.ChkDisableAutoScrollUponScrolling, Me.ChkEnableConfirmCloseToolStripItem, Me.IPv6Support, Me.ChkEnableRecordingOfIgnoredLogs, Me.ChkEnableTCPSyslogServer, Me.ChkEnableStartAtUserStartup, Me.StartUpDelay, Me.IncludeButtonsOnNotifications, Me.IncludeCommasInDHMS, Me.ColLogsAutoFill, Me.MinimizeToClockTray, Me.NotificationLength, Me.OnlySaveAlertedLogs, Me.ProcessReplacementsInSyslogDataFirst, Me.RemoveNumbersFromRemoteApp, Me.SaveIgnoredLogCount, Me.ShowCloseButtonOnNotifications, Me.ShowLogAsAlertedEvenIfLimitedByTime, Me.ShowRawLogOnLogViewer})
         Me.SettingsToolStripMenuItem.Name = "SettingsToolStripMenuItem"
         Me.SettingsToolStripMenuItem.Size = New System.Drawing.Size(61, 20)
         Me.SettingsToolStripMenuItem.Text = "Settings"
@@ -908,6 +910,13 @@ Partial Class Form1
         Me.ProcessReplacementsInSyslogDataFirst.Size = New System.Drawing.Size(319, 22)
         Me.ProcessReplacementsInSyslogDataFirst.Text = "Process Replacements in Syslog Data First"
         '
+        'ShowLogAsAlertedEvenIfLimitedByTime
+        '
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.CheckOnClick = True
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.Name = "ShowLogAsAlertedEvenIfLimitedByTime"
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.Size = New System.Drawing.Size(319, 22)
+        Me.ShowLogAsAlertedEvenIfLimitedByTime.Text = "Show Log as Alerted Even if Limited by Time"
+        '
         'ShowCloseButtonOnNotifications
         '
         Me.ShowCloseButtonOnNotifications.CheckOnClick = True
@@ -1160,6 +1169,7 @@ Partial Class Form1
     Friend WithEvents RemoveNumbersFromRemoteApp As ToolStripMenuItem
     Friend WithEvents ShowRawLogOnLogViewer As ToolStripMenuItem
     Friend WithEvents ShowCloseButtonOnNotifications As ToolStripMenuItem
+    Friend WithEvents ShowLogAsAlertedEvenIfLimitedByTime As ToolStripMenuItem
     Friend WithEvents SaveIgnoredLogCount As ToolStripMenuItem
     Friend WithEvents ConfigureSysLogMirrorServers As ToolStripMenuItem
     Friend WithEvents ConfigureTimeBetweenSameNotifications As ToolStripMenuItem

--- a/Free SysLog/Windows/Form1.resx
+++ b/Free SysLog/Windows/Form1.resx
@@ -117,31 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="StatusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>133, 17</value>
-  </metadata>
-  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>357, 17</value>
-  </metadata>
-  <metadata name="MenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>449, 17</value>
-  </metadata>
-  <metadata name="colTime.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colIPAddress.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colLog.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="NotifyIcon1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="StatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>493, 17</value>
+  </metadata>
+  <metadata name="MenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>587, 17</value>
+  </metadata>
   <metadata name="LogsMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>552, 17</value>
+    <value>696, 17</value>
+  </metadata>
+  <metadata name="NotifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>127, 17</value>
+  </metadata>
+  <metadata name="IconMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>237, 17</value>
+  </metadata>
+  <metadata name="LogsHeaderMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>345, 17</value>
   </metadata>
 </root>

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -817,6 +817,9 @@ Public Class Form1
     Private Sub ChkConfirmCloseToolStripItem_Click(sender As Object, e As EventArgs) Handles ChkEnableConfirmCloseToolStripItem.Click
         My.Settings.boolConfirmClose = ChkEnableConfirmCloseToolStripItem.Checked
     End Sub
+    Private Sub ShowLogAsAlertedEvenIfLimitedByTime_Click(sender As Object, e As EventArgs) Handles ShowLogAsAlertedEvenIfLimitedByTime.Click
+        My.Settings.ShowAsAlertedEvenIfLimitedByTime = ShowLogAsAlertedEvenIfLimitedByTime.Checked
+    End Sub
 
     Private Sub LogsMenuHideAlertsColumn_Click(sender As Object, e As EventArgs) Handles LogsMenuHideAlertsColumn.Click
         ColAlerts.Visible = Not ColAlerts.Visible
@@ -2091,6 +2094,7 @@ Public Class Form1
 
         ColLog.AutoSizeMode = If(My.Settings.colLogAutoFill, DataGridViewAutoSizeColumnMode.Fill, DataGridViewAutoSizeColumnMode.NotSet)
 
+        ShowLogAsAlertedEvenIfLimitedByTime.Checked = My.Settings.ShowAsAlertedEvenIfLimitedByTime
         OnlySaveAlertedLogs.Checked = My.Settings.OnlySaveAlertedLogs
         SaveIgnoredLogCount.Checked = My.Settings.saveIgnoredLogCount
         AskToOpenExplorerWhenSavingData.Checked = My.Settings.AskOpenExplorer

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -2015,6 +2015,9 @@ Public Class Form1
     End Sub
 
     Public Sub SaveLogsToDiskSub()
+        ' Clean up old notification entries at time of saving logs to disk to prevent memory bloat.
+        NotificationLimiter.CleanUpOldEntries(Date.Now)
+
         WriteLogsToDisk()
         LblAutoSaved.Text = $"Last Saved At: {Date.Now:h:mm:ss tt}"
         StopAutoSaveTask()

--- a/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.Designer.vb
@@ -34,74 +34,44 @@ Partial Class IgnoredLogsAndSearchResults
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
         Me.Logs = New System.Windows.Forms.DataGridView()
-        Me.colServerTime = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColTime = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.colServerTime = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.colLogType = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColIPAddress = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ColHostname = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ColRemoteProcess = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColLog = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColAlerts = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.ColRemoteProcess = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.ColFileName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.LogsContextMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
+        Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CopyRawLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OpenLogFileForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.OpenLogForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ExportSelectedLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ViewIgnoredLogPatternToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.LblCount = New System.Windows.Forms.ToolStripStatusLabel()
-        Me.ColFileName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.LogsLoadedInLabel = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.ToolStripSelectedItems = New System.Windows.Forms.ToolStripStatusLabel()
         Me.BtnExport = New System.Windows.Forms.Button()
         Me.SaveFileDialog = New System.Windows.Forms.SaveFileDialog()
         Me.BtnClearIgnoredLogs = New System.Windows.Forms.Button()
         Me.BtnViewMainWindow = New System.Windows.Forms.Button()
-        Me.CreateAlertToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.LogsContextMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
-        Me.CopyLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CopyRawLogTextToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkCaseInsensitiveSearch = New System.Windows.Forms.CheckBox()
         Me.ChkColLogsAutoFill = New System.Windows.Forms.CheckBox()
         Me.ChkRegExSearch = New System.Windows.Forms.CheckBox()
-        Me.ToolStripSelectedItems = New System.Windows.Forms.ToolStripStatusLabel()
         Me.BtnSearch = New System.Windows.Forms.Button()
         Me.TxtSearchTerms = New System.Windows.Forms.TextBox()
         Me.LblSearchLabel = New System.Windows.Forms.Label()
-        Me.ExportSelectedLogsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.colLogType = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.ColHostname = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.LoadingProgressBar = New System.Windows.Forms.ProgressBar()
-        Me.ViewIgnoredLogPatternToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkAutoScroll = New System.Windows.Forms.CheckBox()
         Me.ChkKeepIgnoredLogsPastUserLimit = New System.Windows.Forms.CheckBox()
-        Me.OpenLogFileForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.OpenLogForViewingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.LogsLoadedInLabel = New System.Windows.Forms.ToolStripStatusLabel()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.LogsContextMenu.SuspendLayout()
         Me.StatusStrip1.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'ColHostname
-        '
-        Me.ColHostname.HeaderText = "Hostname/Device Name"
-        Me.ColHostname.Name = "ColHostname"
-        Me.ColHostname.ReadOnly = True
-        Me.ColHostname.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.ColHostname.Width = 150
-        '
-        'colLogType
-        '
-        Me.colLogType.HeaderText = "Log Type"
-        Me.colLogType.Name = "colLogType"
-        Me.colLogType.ReadOnly = True
-        Me.colLogType.Width = 200
-        '
-        'StatusStrip1
-        '
-        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblCount, Me.LogsLoadedInLabel, Me.ToolStripSelectedItems})
-        Me.StatusStrip1.Location = New System.Drawing.Point(0, 403)
-        Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(1563, 22)
-        Me.StatusStrip1.TabIndex = 5
-        Me.StatusStrip1.Text = "StatusStrip1"
-        '
-        'LblCount
-        '
-        Me.LblCount.Name = "LblCount"
-        Me.LblCount.Size = New System.Drawing.Size(53, 17)
-        Me.LblCount.Text = "lblCount"
         '
         'Logs
         '
@@ -120,6 +90,14 @@ Partial Class IgnoredLogsAndSearchResults
         Me.Logs.Size = New System.Drawing.Size(1539, 359)
         Me.Logs.TabIndex = 19
         '
+        'ColTime
+        '
+        Me.ColTime.HeaderText = "Time"
+        Me.ColTime.Name = "ColTime"
+        Me.ColTime.ReadOnly = True
+        Me.ColTime.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.ColTime.ToolTipText = "The time at which the log entry came in."
+        '
         'colServerTime
         '
         Me.colServerTime.HeaderText = "Server Time"
@@ -128,34 +106,36 @@ Partial Class IgnoredLogsAndSearchResults
         Me.colServerTime.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
         Me.colServerTime.ToolTipText = "The time on the server at which the log entry came in."
         '
-        'ColTime
+        'colLogType
         '
-        Me.ColTime.HeaderCell.Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-        Me.ColTime.HeaderCell.Style.Padding = New Padding(0, 0, 1, 0)
-        Me.ColTime.HeaderText = "Time"
-        Me.ColTime.Name = "ColTime"
-        Me.ColTime.ReadOnly = True
-        Me.ColTime.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.ColTime.ToolTipText = "The time at which the log entry came in."
+        Me.colLogType.HeaderText = "Log Type"
+        Me.colLogType.Name = "colLogType"
+        Me.colLogType.ReadOnly = True
+        Me.colLogType.Width = 200
         '
         'ColIPAddress
         '
-        Me.ColIPAddress.HeaderCell.Style.Alignment = DataGridViewContentAlignment.MiddleCenter
-        Me.ColIPAddress.HeaderCell.Style.Padding = New Padding(0, 0, 2, 0)
         Me.ColIPAddress.HeaderText = "IP Address"
         Me.ColIPAddress.Name = "ColIPAddress"
         Me.ColIPAddress.ReadOnly = True
         Me.ColIPAddress.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
         Me.ColIPAddress.ToolTipText = "The IP address of the system from which the log came from."
         '
-        'ColFileName
+        'ColHostname
         '
-        Me.ColFileName.HeaderText = "File Name"
-        Me.ColFileName.Name = "ColFileName"
-        Me.ColFileName.ReadOnly = True
-        Me.ColFileName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.ColFileName.Visible = False
-        Me.ColFileName.Width = 150
+        Me.ColHostname.HeaderText = "Hostname/Device Name"
+        Me.ColHostname.Name = "ColHostname"
+        Me.ColHostname.ReadOnly = True
+        Me.ColHostname.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.ColHostname.Width = 150
+        '
+        'ColRemoteProcess
+        '
+        Me.ColRemoteProcess.HeaderText = "Remote Process"
+        Me.ColRemoteProcess.Name = "ColRemoteProcess"
+        Me.ColRemoteProcess.ReadOnly = True
+        Me.ColRemoteProcess.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.ColRemoteProcess.Width = 150
         '
         'ColLog
         '
@@ -175,13 +155,94 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ColAlerts.ToolTipText = "True or False. Indicates if the log entry triggered an alert from this program."
         Me.ColAlerts.Width = 50
         '
-        'ColRemoteProcess
+        'ColFileName
         '
-        Me.ColRemoteProcess.HeaderText = "Remote Process"
-        Me.ColRemoteProcess.Name = "ColRemoteProcess"
-        Me.ColRemoteProcess.ReadOnly = True
-        Me.ColRemoteProcess.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
-        Me.ColRemoteProcess.Width = 150
+        Me.ColFileName.HeaderText = "File Name"
+        Me.ColFileName.Name = "ColFileName"
+        Me.ColFileName.ReadOnly = True
+        Me.ColFileName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic
+        Me.ColFileName.Visible = False
+        Me.ColFileName.Width = 150
+        '
+        'LogsContextMenu
+        '
+        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.OpenLogForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
+        Me.LogsContextMenu.Name = "LogsContextMenu"
+        Me.LogsContextMenu.Size = New System.Drawing.Size(211, 158)
+        '
+        'CopyLogTextToolStripMenuItem
+        '
+        Me.CopyLogTextToolStripMenuItem.Name = "CopyLogTextToolStripMenuItem"
+        Me.CopyLogTextToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.CopyLogTextToolStripMenuItem.Text = "Copy Log Text"
+        '
+        'CopyRawLogTextToolStripMenuItem
+        '
+        Me.CopyRawLogTextToolStripMenuItem.Name = "CopyRawLogTextToolStripMenuItem"
+        Me.CopyRawLogTextToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.CopyRawLogTextToolStripMenuItem.Text = "Copy Raw Log Text"
+        '
+        'CreateAlertToolStripMenuItem
+        '
+        Me.CreateAlertToolStripMenuItem.Name = "CreateAlertToolStripMenuItem"
+        Me.CreateAlertToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.CreateAlertToolStripMenuItem.Text = "Create Alert"
+        '
+        'OpenLogFileForViewingToolStripMenuItem
+        '
+        Me.OpenLogFileForViewingToolStripMenuItem.Name = "OpenLogFileForViewingToolStripMenuItem"
+        Me.OpenLogFileForViewingToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.OpenLogFileForViewingToolStripMenuItem.Text = "Open Log File for Viewing"
+        Me.OpenLogFileForViewingToolStripMenuItem.Visible = False
+        '
+        'OpenLogForViewingToolStripMenuItem
+        '
+        Me.OpenLogForViewingToolStripMenuItem.Name = "OpenLogForViewingToolStripMenuItem"
+        Me.OpenLogForViewingToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.OpenLogForViewingToolStripMenuItem.Text = "Open Log for Viewing"
+        '
+        'ExportSelectedLogsToolStripMenuItem
+        '
+        Me.ExportSelectedLogsToolStripMenuItem.Name = "ExportSelectedLogsToolStripMenuItem"
+        Me.ExportSelectedLogsToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.ExportSelectedLogsToolStripMenuItem.Text = "Export Selected Logs"
+        '
+        'ViewIgnoredLogPatternToolStripMenuItem
+        '
+        Me.ViewIgnoredLogPatternToolStripMenuItem.Name = "ViewIgnoredLogPatternToolStripMenuItem"
+        Me.ViewIgnoredLogPatternToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.ViewIgnoredLogPatternToolStripMenuItem.Text = "View Ignored Log Pattern"
+        '
+        'StatusStrip1
+        '
+        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LblCount, Me.LogsLoadedInLabel, Me.ToolStripSelectedItems})
+        Me.StatusStrip1.Location = New System.Drawing.Point(0, 403)
+        Me.StatusStrip1.Name = "StatusStrip1"
+        Me.StatusStrip1.Size = New System.Drawing.Size(1563, 22)
+        Me.StatusStrip1.TabIndex = 5
+        Me.StatusStrip1.Text = "StatusStrip1"
+        '
+        'LblCount
+        '
+        Me.LblCount.Name = "LblCount"
+        Me.LblCount.Size = New System.Drawing.Size(53, 17)
+        Me.LblCount.Text = "lblCount"
+        '
+        'LogsLoadedInLabel
+        '
+        Me.LogsLoadedInLabel.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
+        Me.LogsLoadedInLabel.Name = "LogsLoadedInLabel"
+        Me.LogsLoadedInLabel.Size = New System.Drawing.Size(90, 17)
+        Me.LogsLoadedInLabel.Text = "Logs Loaded In:"
+        Me.LogsLoadedInLabel.Visible = False
+        '
+        'ToolStripSelectedItems
+        '
+        Me.ToolStripSelectedItems.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
+        Me.ToolStripSelectedItems.Name = "ToolStripSelectedItems"
+        Me.ToolStripSelectedItems.Size = New System.Drawing.Size(91, 17)
+        Me.ToolStripSelectedItems.Text = "Selected Logs: 0"
+        Me.ToolStripSelectedItems.Visible = False
         '
         'BtnExport
         '
@@ -204,24 +265,6 @@ Partial Class IgnoredLogsAndSearchResults
         Me.BtnClearIgnoredLogs.UseVisualStyleBackColor = True
         Me.BtnClearIgnoredLogs.Visible = False
         '
-        'LogsContextMenu
-        '
-        Me.LogsContextMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyLogTextToolStripMenuItem, Me.CopyRawLogTextToolStripMenuItem, Me.CreateAlertToolStripMenuItem, Me.OpenLogFileForViewingToolStripMenuItem, Me.OpenLogForViewingToolStripMenuItem, Me.ExportSelectedLogsToolStripMenuItem, Me.ViewIgnoredLogPatternToolStripMenuItem})
-        Me.LogsContextMenu.Name = "LogsContextMenu"
-        Me.LogsContextMenu.Size = New System.Drawing.Size(211, 158)
-        '
-        'CopyLogTextToolStripMenuItem
-        '
-        Me.CopyLogTextToolStripMenuItem.Name = "CopyLogTextToolStripMenuItem"
-        Me.CopyLogTextToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
-        Me.CopyLogTextToolStripMenuItem.Text = "Copy Log Text"
-        '
-        'CopyRawLogTextToolStripMenuItem
-        '
-        Me.CopyRawLogTextToolStripMenuItem.Name = "CopyRawLogTextToolStripMenuItem"
-        Me.CopyRawLogTextToolStripMenuItem.Size = New System.Drawing.Size(182, 22)
-        Me.CopyRawLogTextToolStripMenuItem.Text = "Copy Raw Log Text"
-        '
         'BtnViewMainWindow
         '
         Me.BtnViewMainWindow.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -233,12 +276,6 @@ Partial Class IgnoredLogsAndSearchResults
         Me.BtnViewMainWindow.Text = "View Main Window"
         Me.BtnViewMainWindow.UseVisualStyleBackColor = True
         Me.BtnViewMainWindow.Visible = False
-        '
-        'CreateAlertToolStripMenuItem
-        '
-        Me.CreateAlertToolStripMenuItem.Name = "CreateAlertToolStripMenuItem"
-        Me.CreateAlertToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
-        Me.CreateAlertToolStripMenuItem.Text = "Create Alert"
         '
         'ChkCaseInsensitiveSearch
         '
@@ -308,48 +345,15 @@ Partial Class IgnoredLogsAndSearchResults
         Me.LblSearchLabel.Text = "Search Logs"
         Me.LblSearchLabel.Visible = False
         '
-        'OpenLogFileForViewingToolStripMenuItem
-        '
-        Me.OpenLogFileForViewingToolStripMenuItem.Name = "OpenLogFileForViewingToolStripMenuItem"
-        Me.OpenLogFileForViewingToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
-        Me.OpenLogFileForViewingToolStripMenuItem.Text = "Open Log File for Viewing"
-        Me.OpenLogFileForViewingToolStripMenuItem.Visible = False
-        '
-        'ExportSelectedLogsToolStripMenuItem
-        '
-        Me.ExportSelectedLogsToolStripMenuItem.Name = "ExportSelectedLogsToolStripMenuItem"
-        Me.ExportSelectedLogsToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
-        Me.ExportSelectedLogsToolStripMenuItem.Text = "Export Selected Logs"
-        '
-        'LogsLoadedInLabel
-        '
-        Me.LogsLoadedInLabel.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
-        Me.LogsLoadedInLabel.Name = "LogsLoadedInLabel"
-        Me.LogsLoadedInLabel.Size = New System.Drawing.Size(90, 17)
-        Me.LogsLoadedInLabel.Text = "Logs Loaded In:"
-        Me.LogsLoadedInLabel.Visible = False
-        '
         'LoadingProgressBar
         '
-        Me.LoadingProgressBar.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.LoadingProgressBar.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.LoadingProgressBar.Location = New System.Drawing.Point(727, 376)
-        Me.LoadingProgressBar.Maximum = 100
         Me.LoadingProgressBar.Name = "LoadingProgressBar"
         Me.LoadingProgressBar.Size = New System.Drawing.Size(601, 23)
         Me.LoadingProgressBar.TabIndex = 30
         Me.LoadingProgressBar.Visible = False
-        '
-        'ViewIgnoredLogPatternToolStripMenuItem
-        '
-        Me.ViewIgnoredLogPatternToolStripMenuItem.Name = "ViewIgnoredLogPatternToolStripMenuItem"
-        Me.ViewIgnoredLogPatternToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
-        Me.ViewIgnoredLogPatternToolStripMenuItem.Text = "View Ignored Log Pattern"
-        '
-        'OpenLogForViewingToolStripMenuItem
-        '
-        Me.OpenLogForViewingToolStripMenuItem.Name = "OpenLogForViewingToolStripMenuItem"
-        Me.OpenLogForViewingToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
-        Me.OpenLogForViewingToolStripMenuItem.Text = "Open Log for Viewing"
         '
         'ChkAutoScroll
         '
@@ -372,14 +376,6 @@ Partial Class IgnoredLogsAndSearchResults
         Me.ChkKeepIgnoredLogsPastUserLimit.TabIndex = 32
         Me.ChkKeepIgnoredLogsPastUserLimit.Text = "Keep Ignored Logs Past User-Set Limit"
         Me.ChkKeepIgnoredLogsPastUserLimit.UseVisualStyleBackColor = True
-        '
-        'ToolStripSelectedItems
-        '
-        Me.ToolStripSelectedItems.Margin = New System.Windows.Forms.Padding(50, 3, 0, 2)
-        Me.ToolStripSelectedItems.Name = "ToolStripSelectedItems"
-        Me.ToolStripSelectedItems.Size = New System.Drawing.Size(91, 17)
-        Me.ToolStripSelectedItems.Text = "Selected Logs: 0"
-        Me.ToolStripSelectedItems.Visible = False
         '
         'IgnoredLogsAndSearchResults
         '
@@ -404,10 +400,10 @@ Partial Class IgnoredLogsAndSearchResults
         Me.MinimumSize = New System.Drawing.Size(1579, 464)
         Me.Name = "IgnoredLogsAndSearchResults"
         Me.Text = "Ignored Logs"
-        Me.StatusStrip1.ResumeLayout(False)
-        Me.StatusStrip1.PerformLayout()
         CType(Me.Logs, System.ComponentModel.ISupportInitialize).EndInit()
         Me.LogsContextMenu.ResumeLayout(False)
+        Me.StatusStrip1.ResumeLayout(False)
+        Me.StatusStrip1.PerformLayout()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/Free SysLog/Windows/Ignored Logs and Search Results.resx
+++ b/Free SysLog/Windows/Ignored Logs and Search Results.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="FileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="LogsContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>263, 17</value>
   </metadata>
@@ -128,14 +125,5 @@
   </metadata>
   <metadata name="SaveFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>133, 17</value>
-  </metadata>
-  <metadata name="colTime.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colIPAddress.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colLog.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
   </metadata>
 </root>

--- a/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
+++ b/Free SysLog/Windows/Ignored Words and Phrases.Designer.vb
@@ -35,9 +35,11 @@ Partial Class IgnoredWordsAndPhrases
         Me.colDateCreated = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.colDateOfLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.colSinceLastEvent = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
+        Me.colRecord = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
         Me.ListViewMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.EnableDisableToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ResetHitsToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.EnableDisableRecordingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnEdit = New System.Windows.Forms.Button()
         Me.BtnEnableDisable = New System.Windows.Forms.Button()
         Me.BtnImport = New System.Windows.Forms.Button()
@@ -62,16 +64,14 @@ Partial Class IgnoredWordsAndPhrases
         Me.btnUpdateHits = New System.Windows.Forms.Button()
         Me.ChkAutoRefresh = New System.Windows.Forms.CheckBox()
         Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
-        Me.ChkRefreshOnlyIfActive = New System.Windows.Forms.CheckBox()
-        Me.colRecord = CType(New System.Windows.Forms.ColumnHeader(), System.Windows.Forms.ColumnHeader)
-        Me.EnableDisableRecordingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ChkRecord = New System.Windows.Forms.CheckBox()
+        Me.ChkRefreshOnlyIfActive = New System.Windows.Forms.CheckBox()
         Me.StatusStrip = New System.Windows.Forms.StatusStrip()
         Me.lblTotalRules = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblActiveRules = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblInactiveRules = New System.Windows.Forms.ToolStripStatusLabel()
-        Me.StatusStrip.SuspendLayout()
         Me.ListViewMenu.SuspendLayout()
+        Me.StatusStrip.SuspendLayout()
         Me.SuspendLayout()
         '
         'BtnAdd
@@ -157,6 +157,10 @@ Partial Class IgnoredWordsAndPhrases
         Me.colSinceLastEvent.Text = "Since Last Event"
         Me.colSinceLastEvent.Width = 100
         '
+        'colRecord
+        '
+        Me.colRecord.Text = "Record?"
+        '
         'ListViewMenu
         '
         Me.ListViewMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.EnableDisableToolStripMenuItem, Me.ResetHitsToolStripMenuItem, Me.EnableDisableRecordingToolStripMenuItem})
@@ -174,6 +178,14 @@ Partial Class IgnoredWordsAndPhrases
         Me.ResetHitsToolStripMenuItem.Name = "ResetHitsToolStripMenuItem"
         Me.ResetHitsToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
         Me.ResetHitsToolStripMenuItem.Text = "Reset Hit"
+        '
+        'EnableDisableRecordingToolStripMenuItem
+        '
+        Me.EnableDisableRecordingToolStripMenuItem.Name = "EnableDisableRecordingToolStripMenuItem"
+        Me.EnableDisableRecordingToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
+        Me.EnableDisableRecordingToolStripMenuItem.Text = "Enable/Disable Recording"
+        Me.EnableDisableRecordingToolStripMenuItem.ToolTipText = "Makes it so that even if the log is ignored, the log text is still recorded in pr" &
+    "ogram memory and not written to disk."
         '
         'BtnEdit
         '
@@ -383,6 +395,13 @@ Partial Class IgnoredWordsAndPhrases
         Me.lblCommentLabel.TabIndex = 50
         Me.lblCommentLabel.Text = "Comment"
         '
+        'lblTotalHits
+        '
+        Me.lblTotalHits.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
+        Me.lblTotalHits.Name = "lblTotalHits"
+        Me.lblTotalHits.Size = New System.Drawing.Size(113, 17)
+        Me.lblTotalHits.Text = "Total Ignored Hits: 0"
+        '
         'btnUpdateHits
         '
         Me.btnUpdateHits.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -407,21 +426,6 @@ Partial Class IgnoredWordsAndPhrases
         " pressed down.")
         Me.ChkAutoRefresh.UseVisualStyleBackColor = True
         '
-        'ChkRefreshOnlyIfActive
-        '
-        Me.ChkRefreshOnlyIfActive.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.ChkRefreshOnlyIfActive.AutoSize = True
-        Me.ChkRefreshOnlyIfActive.Location = New System.Drawing.Point(686, 244)
-        Me.ChkRefreshOnlyIfActive.Name = "ChkRefreshOnlyIfActive"
-        Me.ChkRefreshOnlyIfActive.Size = New System.Drawing.Size(131, 17)
-        Me.ChkRefreshOnlyIfActive.TabIndex = 54
-        Me.ChkRefreshOnlyIfActive.Text = "Only If Active Window"
-        Me.ChkRefreshOnlyIfActive.UseVisualStyleBackColor = True
-        '
-        'colRecord
-        '
-        Me.colRecord.Text = "Record?"
-        '
         'ChkRecord
         '
         Me.ChkRecord.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -435,13 +439,16 @@ Partial Class IgnoredWordsAndPhrases
         "ogram memory and not written to disk.")
         Me.ChkRecord.UseVisualStyleBackColor = True
         '
-        'EnableDisableRecordingToolStripMenuItem
+        'ChkRefreshOnlyIfActive
         '
-        Me.EnableDisableRecordingToolStripMenuItem.Name = "EnableDisableRecordingToolStripMenuItem"
-        Me.EnableDisableRecordingToolStripMenuItem.Size = New System.Drawing.Size(209, 22)
-        Me.EnableDisableRecordingToolStripMenuItem.Text = "Enable/Disable Recording"
-        Me.EnableDisableRecordingToolStripMenuItem.ToolTipText = "Makes it so that even if the log is ignored, the log text is still recorded in pr" &
-    "ogram memory and not written to disk."
+        Me.ChkRefreshOnlyIfActive.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkRefreshOnlyIfActive.AutoSize = True
+        Me.ChkRefreshOnlyIfActive.Location = New System.Drawing.Point(686, 244)
+        Me.ChkRefreshOnlyIfActive.Name = "ChkRefreshOnlyIfActive"
+        Me.ChkRefreshOnlyIfActive.Size = New System.Drawing.Size(131, 17)
+        Me.ChkRefreshOnlyIfActive.TabIndex = 54
+        Me.ChkRefreshOnlyIfActive.Text = "Only If Active Window"
+        Me.ChkRefreshOnlyIfActive.UseVisualStyleBackColor = True
         '
         'StatusStrip
         '
@@ -451,13 +458,6 @@ Partial Class IgnoredWordsAndPhrases
         Me.StatusStrip.Size = New System.Drawing.Size(1118, 22)
         Me.StatusStrip.TabIndex = 56
         Me.StatusStrip.Text = "StatusStrip"
-        '
-        'lblTotalHits
-        '
-        Me.lblTotalHits.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
-        Me.lblTotalHits.Name = "lblTotalHits"
-        Me.lblTotalHits.Size = New System.Drawing.Size(113, 17)
-        Me.lblTotalHits.Text = "Total Ignored Hits: 0"
         '
         'lblTotalRules
         '

--- a/Free SysLog/Windows/Ignored Words and Phrases.resx
+++ b/Free SysLog/Windows/Ignored Words and Phrases.resx
@@ -118,9 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="ListViewMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>127, 17</value>
   </metadata>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>145, 17</value>
+    <value>255, 17</value>
+  </metadata>
+  <metadata name="StatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/Free SysLog/Windows/Replacements.resx
+++ b/Free SysLog/Windows/Replacements.resx
@@ -117,10 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ListViewMenu.TrayLocation" type="System.Drawing.Point, System.Drawing">
+  <metadata name="ListViewMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </data>
+  </metadata>
   <data name="lblReplacementNotes.Text" xml:space="preserve">
     <value>In the With field, you can reference the value of the Replace field by using $replace. You can also use RegEx back-references as well. If you do so, remember to tick the RegEx checkbox below.
 You can also modify the value of $replace using commands such as: UPPER(), UPPERCASE(), LOWER(), LOWERCASE(), and TRIM(). You can also use RegEx backreferences.</value>

--- a/Free SysLog/Windows/ViewLogBackups.Designer.vb
+++ b/Free SysLog/Windows/ViewLogBackups.Designer.vb
@@ -27,9 +27,18 @@ Partial Class ViewLogBackups
         Me.ColFileName = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColFileDate = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ColFileSize = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.colEntryCount = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.colHidden = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ContextMenuStrip1 = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.DeleteToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ViewToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.HideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.RenameToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.RefreshToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.UnhideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.GZIPCompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.UncompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.BtnView = New System.Windows.Forms.Button()
         Me.BtnDelete = New System.Windows.Forms.Button()
         Me.ChkShowCompressionSizeDifference = New System.Windows.Forms.CheckBox()
@@ -38,36 +47,27 @@ Partial Class ViewLogBackups
         Me.lblTimeTakenToLoadData = New System.Windows.Forms.ToolStripStatusLabel()
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.lblNumberOfFiles = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.lblNumberOfHiddenFiles = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.lblTotalNumberOfLogs = New System.Windows.Forms.ToolStripStatusLabel()
+        Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
         Me.ChkCaseInsensitiveSearch = New System.Windows.Forms.CheckBox()
         Me.ChkRegExSearch = New System.Windows.Forms.CheckBox()
         Me.BtnSearch = New System.Windows.Forms.Button()
         Me.TxtSearchTerms = New System.Windows.Forms.TextBox()
         Me.LblSearchLabel = New System.Windows.Forms.Label()
-        Me.lblTotalNumberOfLogs = New System.Windows.Forms.ToolStripStatusLabel()
         Me.ChkShowHidden = New System.Windows.Forms.CheckBox()
-        Me.colHidden = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.colEntryCount = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.HideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.UnhideToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolTip = New System.Windows.Forms.ToolTip(Me.components)
         Me.ChkIgnoreSearchResultsLimits = New System.Windows.Forms.CheckBox()
         Me.btnClearDateLimit = New System.Windows.Forms.Button()
         Me.ChkLogFileDeletions = New System.Windows.Forms.CheckBox()
-        Me.lblNumberOfHiddenFiles = New System.Windows.Forms.ToolStripStatusLabel()
-        Me.LblTotalDiskSpace = New System.Windows.Forms.ToolStripStatusLabel()
         Me.lblLimitBy = New System.Windows.Forms.Label()
         Me.boxLimitBy = New System.Windows.Forms.ComboBox()
-        Me.GZIPCompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.UncompressFileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.RefreshToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.boxLimiter = New System.Windows.Forms.ComboBox()
         Me.btnViewLogsWithLimits = New System.Windows.Forms.Button()
-        Me.ShowInWindowsExplorerToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.RenameToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.btnLimitByDate = New System.Windows.Forms.Button()
+        CType(Me.FileList, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.ContextMenuStrip1.SuspendLayout()
         Me.StatusStrip1.SuspendLayout()
-        CType(Me.FileList, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'FileList
@@ -118,11 +118,18 @@ Partial Class ViewLogBackups
         Me.colEntryCount.ReadOnly = True
         Me.colEntryCount.Width = 125
         '
+        'colHidden
+        '
+        Me.colHidden.HeaderText = "Hidden?"
+        Me.colHidden.Name = "colHidden"
+        Me.colHidden.ReadOnly = True
+        Me.colHidden.Width = 60
+        '
         'ContextMenuStrip1
         '
         Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DeleteToolStripMenuItem, Me.ViewToolStripMenuItem, Me.HideToolStripMenuItem, Me.RenameToolStripMenuItem, Me.RefreshToolStripMenuItem, Me.ShowInWindowsExplorerToolStripMenuItem, Me.UnhideToolStripMenuItem, Me.GZIPCompressFileToolStripMenuItem, Me.UncompressFileToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 180)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 202)
         '
         'DeleteToolStripMenuItem
         '
@@ -142,11 +149,41 @@ Partial Class ViewLogBackups
         Me.HideToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.HideToolStripMenuItem.Text = "Hide"
         '
+        'RenameToolStripMenuItem
+        '
+        Me.RenameToolStripMenuItem.Name = "RenameToolStripMenuItem"
+        Me.RenameToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.RenameToolStripMenuItem.Text = "Rename"
+        '
+        'RefreshToolStripMenuItem
+        '
+        Me.RefreshToolStripMenuItem.Name = "RefreshToolStripMenuItem"
+        Me.RefreshToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.RefreshToolStripMenuItem.Text = "Refresh File List"
+        '
+        'ShowInWindowsExplorerToolStripMenuItem
+        '
+        Me.ShowInWindowsExplorerToolStripMenuItem.Name = "ShowInWindowsExplorerToolStripMenuItem"
+        Me.ShowInWindowsExplorerToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.ShowInWindowsExplorerToolStripMenuItem.Text = "Show in Windows Explorer"
+        '
         'UnhideToolStripMenuItem
         '
         Me.UnhideToolStripMenuItem.Name = "UnhideToolStripMenuItem"
         Me.UnhideToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
         Me.UnhideToolStripMenuItem.Text = "Unhide/Show"
+        '
+        'GZIPCompressFileToolStripMenuItem
+        '
+        Me.GZIPCompressFileToolStripMenuItem.Name = "GZIPCompressFileToolStripMenuItem"
+        Me.GZIPCompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.GZIPCompressFileToolStripMenuItem.Text = "Compress File"
+        '
+        'UncompressFileToolStripMenuItem
+        '
+        Me.UncompressFileToolStripMenuItem.Name = "UncompressFileToolStripMenuItem"
+        Me.UncompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
+        Me.UncompressFileToolStripMenuItem.Text = "Uncompress File"
         '
         'BtnView
         '
@@ -170,73 +207,6 @@ Partial Class ViewLogBackups
         Me.BtnDelete.Text = "&Delete"
         Me.BtnDelete.UseVisualStyleBackColor = True
         '
-        'BtnRefresh
-        '
-        Me.BtnRefresh.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.BtnRefresh.Location = New System.Drawing.Point(174, 261)
-        Me.BtnRefresh.Name = "BtnRefresh"
-        Me.BtnRefresh.Size = New System.Drawing.Size(95, 23)
-        Me.BtnRefresh.TabIndex = 4
-        Me.BtnRefresh.Text = "Re&fresh (F5)"
-        Me.BtnRefresh.UseVisualStyleBackColor = True
-        '
-        'StatusStrip1
-        '
-        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.LblTotalDiskSpace, Me.lblTimeTakenToLoadData})
-        Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
-        Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(979, 22)
-        Me.StatusStrip1.TabIndex = 5
-        Me.StatusStrip1.Text = "StatusStrip1"
-        '
-        'lblNumberOfFiles
-        '
-        Me.lblNumberOfFiles.Name = "lblNumberOfFiles"
-        Me.lblNumberOfFiles.Size = New System.Drawing.Size(94, 17)
-        Me.lblNumberOfFiles.Text = "Number of Files:"
-        '
-        'ChkCaseInsensitiveSearch
-        '
-        Me.ChkCaseInsensitiveSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.ChkCaseInsensitiveSearch.AutoSize = True
-        Me.ChkCaseInsensitiveSearch.Checked = True
-        Me.ChkCaseInsensitiveSearch.CheckState = System.Windows.Forms.CheckState.Checked
-        Me.ChkCaseInsensitiveSearch.Location = New System.Drawing.Point(388, 319)
-        Me.ChkCaseInsensitiveSearch.Name = "ChkCaseInsensitiveSearch"
-        Me.ChkCaseInsensitiveSearch.Size = New System.Drawing.Size(109, 17)
-        Me.ChkCaseInsensitiveSearch.TabIndex = 33
-        Me.ChkCaseInsensitiveSearch.Text = "Case Insensitive?"
-        Me.ChkCaseInsensitiveSearch.UseVisualStyleBackColor = True
-        '
-        'GZIPCompressFileToolStripMenuItem
-        '
-        Me.GZIPCompressFileToolStripMenuItem.Name = "GZIPCompressFileToolStripMenuItem"
-        Me.GZIPCompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.GZIPCompressFileToolStripMenuItem.Text = "Compress File"
-        '
-        'UncompressFileToolStripMenuItem
-        '
-        Me.UncompressFileToolStripMenuItem.Name = "UncompressFileToolStripMenuItem"
-        Me.UncompressFileToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.UncompressFileToolStripMenuItem.Text = "Uncompress File"
-        '
-        'RefreshToolStripMenuItem
-        '
-        Me.RefreshToolStripMenuItem.Name = "RefreshToolStripMenuItem"
-        Me.RefreshToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.RefreshToolStripMenuItem.Text = "Refresh File List"
-        '
-        'ChkRegExSearch
-        '
-        Me.ChkRegExSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.ChkRegExSearch.AutoSize = True
-        Me.ChkRegExSearch.Location = New System.Drawing.Point(319, 319)
-        Me.ChkRegExSearch.Name = "ChkRegExSearch"
-        Me.ChkRegExSearch.Size = New System.Drawing.Size(63, 17)
-        Me.ChkRegExSearch.TabIndex = 32
-        Me.ChkRegExSearch.Text = "Regex?"
-        Me.ChkRegExSearch.UseVisualStyleBackColor = True
-        '
         'ChkShowCompressionSizeDifference
         '
         Me.ChkShowCompressionSizeDifference.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -259,6 +229,84 @@ Partial Class ViewLogBackups
         Me.ChkShowCompressionSizeDifferencePercentage.Text = "Show Compression Size Difference Percentages"
         Me.ChkShowCompressionSizeDifferencePercentage.UseVisualStyleBackColor = True
         '
+        'BtnRefresh
+        '
+        Me.BtnRefresh.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.BtnRefresh.Location = New System.Drawing.Point(174, 261)
+        Me.BtnRefresh.Name = "BtnRefresh"
+        Me.BtnRefresh.Size = New System.Drawing.Size(95, 23)
+        Me.BtnRefresh.TabIndex = 4
+        Me.BtnRefresh.Text = "Re&fresh (F5)"
+        Me.BtnRefresh.UseVisualStyleBackColor = True
+        '
+        'lblTimeTakenToLoadData
+        '
+        Me.lblTimeTakenToLoadData.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
+        Me.lblTimeTakenToLoadData.Name = "lblTimeTakenToLoadData"
+        Me.lblTimeTakenToLoadData.Size = New System.Drawing.Size(141, 17)
+        Me.lblTimeTakenToLoadData.Text = "Time Taken to Load Data:"
+        '
+        'StatusStrip1
+        '
+        Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.lblNumberOfFiles, Me.lblNumberOfHiddenFiles, Me.lblTotalNumberOfLogs, Me.LblTotalDiskSpace, Me.lblTimeTakenToLoadData})
+        Me.StatusStrip1.Location = New System.Drawing.Point(0, 342)
+        Me.StatusStrip1.Name = "StatusStrip1"
+        Me.StatusStrip1.Size = New System.Drawing.Size(979, 22)
+        Me.StatusStrip1.TabIndex = 5
+        Me.StatusStrip1.Text = "StatusStrip1"
+        '
+        'lblNumberOfFiles
+        '
+        Me.lblNumberOfFiles.Name = "lblNumberOfFiles"
+        Me.lblNumberOfFiles.Size = New System.Drawing.Size(94, 17)
+        Me.lblNumberOfFiles.Text = "Number of Files:"
+        '
+        'lblNumberOfHiddenFiles
+        '
+        Me.lblNumberOfHiddenFiles.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
+        Me.lblNumberOfHiddenFiles.Name = "lblNumberOfHiddenFiles"
+        Me.lblNumberOfHiddenFiles.Size = New System.Drawing.Size(136, 17)
+        Me.lblNumberOfHiddenFiles.Text = "Number of Hidden Files:"
+        Me.lblNumberOfHiddenFiles.Visible = False
+        '
+        'lblTotalNumberOfLogs
+        '
+        Me.lblTotalNumberOfLogs.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
+        Me.lblTotalNumberOfLogs.Name = "lblTotalNumberOfLogs"
+        Me.lblTotalNumberOfLogs.Size = New System.Drawing.Size(125, 17)
+        Me.lblTotalNumberOfLogs.Text = "Total Number of Logs:"
+        '
+        'LblTotalDiskSpace
+        '
+        Me.LblTotalDiskSpace.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
+        Me.LblTotalDiskSpace.Name = "LblTotalDiskSpace"
+        Me.LblTotalDiskSpace.Size = New System.Drawing.Size(124, 17)
+        Me.LblTotalDiskSpace.Text = "Total Disk Space Used:"
+        '
+        'ChkCaseInsensitiveSearch
+        '
+        Me.ChkCaseInsensitiveSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkCaseInsensitiveSearch.AutoSize = True
+        Me.ChkCaseInsensitiveSearch.Checked = True
+        Me.ChkCaseInsensitiveSearch.CheckState = System.Windows.Forms.CheckState.Checked
+        Me.ChkCaseInsensitiveSearch.Location = New System.Drawing.Point(388, 319)
+        Me.ChkCaseInsensitiveSearch.Name = "ChkCaseInsensitiveSearch"
+        Me.ChkCaseInsensitiveSearch.Size = New System.Drawing.Size(109, 17)
+        Me.ChkCaseInsensitiveSearch.TabIndex = 33
+        Me.ChkCaseInsensitiveSearch.Text = "Case Insensitive?"
+        Me.ChkCaseInsensitiveSearch.UseVisualStyleBackColor = True
+        '
+        'ChkRegExSearch
+        '
+        Me.ChkRegExSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.ChkRegExSearch.AutoSize = True
+        Me.ChkRegExSearch.Location = New System.Drawing.Point(319, 319)
+        Me.ChkRegExSearch.Name = "ChkRegExSearch"
+        Me.ChkRegExSearch.Size = New System.Drawing.Size(63, 17)
+        Me.ChkRegExSearch.TabIndex = 32
+        Me.ChkRegExSearch.Text = "Regex?"
+        Me.ChkRegExSearch.UseVisualStyleBackColor = True
+        '
         'BtnSearch
         '
         Me.BtnSearch.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -268,13 +316,6 @@ Partial Class ViewLogBackups
         Me.BtnSearch.TabIndex = 31
         Me.BtnSearch.Text = "&Search"
         Me.BtnSearch.UseVisualStyleBackColor = True
-        '
-        'lblTimeTakenToLoadData
-        '
-        Me.lblTimeTakenToLoadData.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
-        Me.lblTimeTakenToLoadData.Name = "lblTimeTakenToLoadData"
-        Me.lblTimeTakenToLoadData.Size = New System.Drawing.Size(141, 17)
-        Me.lblTimeTakenToLoadData.Text = "Time Taken to Load Data:"
         '
         'TxtSearchTerms
         '
@@ -294,13 +335,6 @@ Partial Class ViewLogBackups
         Me.LblSearchLabel.TabIndex = 29
         Me.LblSearchLabel.Text = "Search All Logs"
         '
-        'lblTotalNumberOfLogs
-        '
-        Me.lblTotalNumberOfLogs.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
-        Me.lblTotalNumberOfLogs.Name = "lblTotalNumberOfLogs"
-        Me.lblTotalNumberOfLogs.Size = New System.Drawing.Size(125, 17)
-        Me.lblTotalNumberOfLogs.Text = "Total Number of Logs:"
-        '
         'ChkShowHidden
         '
         Me.ChkShowHidden.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -311,28 +345,6 @@ Partial Class ViewLogBackups
         Me.ChkShowHidden.TabIndex = 34
         Me.ChkShowHidden.Text = "Show Hidden Files"
         Me.ChkShowHidden.UseVisualStyleBackColor = True
-        '
-        'colHidden
-        '
-        Me.colHidden.HeaderText = "Hidden?"
-        Me.colHidden.Name = "colHidden"
-        Me.colHidden.ReadOnly = True
-        Me.colHidden.Width = 60
-        '
-        'lblNumberOfHiddenFiles
-        '
-        Me.lblNumberOfHiddenFiles.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
-        Me.lblNumberOfHiddenFiles.Name = "lblNumberOfHiddenFiles"
-        Me.lblNumberOfHiddenFiles.Size = New System.Drawing.Size(136, 17)
-        Me.lblNumberOfHiddenFiles.Text = "Number of Hidden Files:"
-        Me.lblNumberOfHiddenFiles.Visible = False
-        '
-        'LblTotalDiskSpace
-        '
-        Me.LblTotalDiskSpace.Margin = New System.Windows.Forms.Padding(25, 3, 0, 2)
-        Me.LblTotalDiskSpace.Name = "LblTotalDiskSpace"
-        Me.LblTotalDiskSpace.Size = New System.Drawing.Size(124, 17)
-        Me.LblTotalDiskSpace.Text = "Total Disk Space Used:"
         '
         'ChkIgnoreSearchResultsLimits
         '
@@ -346,11 +358,16 @@ Partial Class ViewLogBackups
         Me.ToolTip.SetToolTip(Me.ChkIgnoreSearchResultsLimits, "Warning: Enabling this could cause performance issues.")
         Me.ChkIgnoreSearchResultsLimits.UseVisualStyleBackColor = True
         '
-        'RenameToolStripMenuItem
+        'btnClearDateLimit
         '
-        Me.RenameToolStripMenuItem.Name = "RenameToolStripMenuItem"
-        Me.RenameToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.RenameToolStripMenuItem.Text = "Rename"
+        Me.btnClearDateLimit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.btnClearDateLimit.Enabled = False
+        Me.btnClearDateLimit.Location = New System.Drawing.Point(438, 261)
+        Me.btnClearDateLimit.Name = "btnClearDateLimit"
+        Me.btnClearDateLimit.Size = New System.Drawing.Size(110, 23)
+        Me.btnClearDateLimit.TabIndex = 46
+        Me.btnClearDateLimit.Text = "Clear Date Limit"
+        Me.btnClearDateLimit.UseVisualStyleBackColor = True
         '
         'ChkLogFileDeletions
         '
@@ -375,26 +392,24 @@ Partial Class ViewLogBackups
         '
         'boxLimitBy
         '
-        Me.boxLimitBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.boxLimitBy.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
+        Me.boxLimitBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.boxLimitBy.FormattingEnabled = True
         Me.boxLimitBy.Items.AddRange(New Object() {"(Not Specified)", "Log Type", "Remote Process", "Source Hostname", "Source IP Address"})
         Me.boxLimitBy.Location = New System.Drawing.Point(55, 290)
         Me.boxLimitBy.Name = "boxLimitBy"
         Me.boxLimitBy.Size = New System.Drawing.Size(121, 21)
-        Me.boxLimitBy.Text = "(Not Specified)"
         Me.boxLimitBy.TabIndex = 40
         '
         'boxLimiter
         '
+        Me.boxLimiter.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.boxLimiter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.boxLimiter.Enabled = False
-        Me.boxLimiter.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.boxLimiter.FormattingEnabled = True
         Me.boxLimiter.Location = New System.Drawing.Point(182, 290)
         Me.boxLimiter.Name = "boxLimiter"
         Me.boxLimiter.Size = New System.Drawing.Size(250, 21)
-        Me.boxLimiter.Text = "(Not Specified)"
         Me.boxLimiter.TabIndex = 41
         '
         'btnViewLogsWithLimits
@@ -408,12 +423,6 @@ Partial Class ViewLogBackups
         Me.btnViewLogsWithLimits.Text = "View All with Limits"
         Me.btnViewLogsWithLimits.UseVisualStyleBackColor = True
         '
-        'ShowInWindowsExplorerToolStripMenuItem
-        '
-        Me.ShowInWindowsExplorerToolStripMenuItem.Name = "ShowInWindowsExplorerToolStripMenuItem"
-        Me.ShowInWindowsExplorerToolStripMenuItem.Size = New System.Drawing.Size(213, 22)
-        Me.ShowInWindowsExplorerToolStripMenuItem.Text = "Show in Windows Explorer"
-        '
         'btnLimitByDate
         '
         Me.btnLimitByDate.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
@@ -423,17 +432,6 @@ Partial Class ViewLogBackups
         Me.btnLimitByDate.TabIndex = 45
         Me.btnLimitByDate.Text = "Limit by Date"
         Me.btnLimitByDate.UseVisualStyleBackColor = True
-        '
-        'btnClearDateLimit
-        '
-        Me.btnClearDateLimit.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.btnClearDateLimit.Enabled = False
-        Me.btnClearDateLimit.Location = New System.Drawing.Point(438, 261)
-        Me.btnClearDateLimit.Name = "btnClearDateLimit"
-        Me.btnClearDateLimit.Size = New System.Drawing.Size(110, 23)
-        Me.btnClearDateLimit.TabIndex = 46
-        Me.btnClearDateLimit.Text = "Clear Date Limit"
-        Me.btnClearDateLimit.UseVisualStyleBackColor = True
         '
         'ViewLogBackups
         '
@@ -467,10 +465,10 @@ Partial Class ViewLogBackups
         Me.MinimumSize = New System.Drawing.Size(995, 403)
         Me.Name = "ViewLogBackups"
         Me.Text = "View Log Backups"
+        CType(Me.FileList, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ContextMenuStrip1.ResumeLayout(False)
         Me.StatusStrip1.ResumeLayout(False)
         Me.StatusStrip1.PerformLayout()
-        CType(Me.FileList, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/Free SysLog/Windows/ViewLogBackups.resx
+++ b/Free SysLog/Windows/ViewLogBackups.resx
@@ -117,23 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="colHidden.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="ContextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>133, 17</value>
   </metadata>
   <metadata name="StatusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="colFileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colFileDate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colFileSize.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="colHidden.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
   </metadata>
   <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>290, 17</value>

--- a/Free SysLog/app.config
+++ b/Free SysLog/app.config
@@ -365,6 +365,9 @@
             <setting name="ColorPickerDialogSize" serializeAs="String">
                 <value>733, 326</value>
             </setting>
+            <setting name="ShowAsAlertedEvenIfLimitedByTime" serializeAs="String">
+                <value>False</value>
+            </setting>
         </Free_SysLog.My.MySettings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>


### PR DESCRIPTION
- If an alert wasn't shown because the alert was time limited, it's now indicated as not alerted in the saved logs. 5dda1d1f9eb71dbcea033f81471766cd03826f6b
- Now the notification limiting clean-up code is only ran when saving the current logs to disk. c0f26975a04fcde1055b2f83b0abdcf38058c511
- Made it so that if the log entry didn't result in an alert due to being limited by time, the alert text isn't saved. e1f8b18d3d2a23a4372871e06d43515f4c7685b2

And some other under-the-hood changes to the code.