### PR TITLE
Version 5.7 Build 11

### DIFF
--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -12,8 +12,44 @@ Namespace My
     Partial Friend Class MyApplication
         Private _reportCrash As ReportCrash
 
+        ' This function parses the command line arguments passed to the program and returns a dictionary of key-value pairs.
+        ' The keys are the argument names and the values are the argument values. If an argument is a boolean flag
+        ' (i.e., it doesn't have a value), then the value is set to True.
+        Private Function ParseArguments(args As ObjectModel.ReadOnlyCollection(Of String)) As Dictionary(Of String, Object)
+            ' This dictionary will hold the parsed arguments. We use StringComparer.OrdinalIgnoreCase to make the keys case-insensitive.
+            Dim parsedArguments As New Dictionary(Of String, Object)(StringComparer.OrdinalIgnoreCase)
+            Dim strValue As String
+
+            ' This loops through each argument passed to the program and parses it into a key-value pair.
+            ' If the argument is a boolean flag, then the value is set to True.
+            For Each strArgument As String In args
+                ' This checks to see if the argument starts with "--". If it does then we parse it into a key-value pair.
+                If strArgument.StartsWith("--") Or strArgument.StartsWith("/") Then
+                    ' This splits the argument into a key and a value. If the argument doesn't have a value, then the value is set to True.
+                    Dim splitArg As String() = strArgument.Substring(2).Split(New Char() {"="c}, 2)
+                    Dim key As String = splitArg(0)
+
+                    If splitArg.Length = 2 Then
+                        ' Argument with a value
+                        strValue = splitArg(1)
+                        parsedArguments(key) = strValue
+                    Else
+                        ' Boolean flag
+                        parsedArguments(key) = True
+                    End If
+                Else
+                    ' This tells the user that the argument format is unrecognized and we skip it.
+                    Console.WriteLine($"Unrecognized argument format: {strArgument}")
+                End If
+            Next
+
+            Return parsedArguments
+        End Function
+
         Private Sub MyApplication_Startup(sender As Object, e As StartupEventArgs) Handles Me.Startup
-            If e.CommandLine.Count > 0 AndAlso e.CommandLine(0).Equals("/wait", StringComparison.OrdinalIgnoreCase) Then
+            Dim commandLineArgs As Dictionary(Of String, Object) = ParseArguments(e.CommandLine)
+
+            If commandLineArgs.ContainsKey("wait") Then
                 Threading.Thread.Sleep(1000)
             End If
 

--- a/Free SysLog/ApplicationEvents.vb
+++ b/Free SysLog/ApplicationEvents.vb
@@ -13,13 +13,17 @@ Namespace My
         Private _reportCrash As ReportCrash
 
         Private Sub MyApplication_Startup(sender As Object, e As StartupEventArgs) Handles Me.Startup
+            If e.CommandLine.Count > 0 AndAlso e.CommandLine(0).Equals("/wait", StringComparison.OrdinalIgnoreCase) Then
+                Threading.Thread.Sleep(1000)
+            End If
+
             If My.Settings.FirstRun Then
                 Try
                     ' Check if backup file exists
                     If IO.File.Exists(strPathToConfigBackupFile) Then
                         ' Attempt to load the settings from the backup file
                         If Not SaveAppSettings.LoadApplicationSettingsFromFile(strPathToConfigBackupFile, "Free Syslog") Then
-	                        MsgBox("There was an error loading the previous configuration, the program will launch with a clean config.", MsgBoxStyle.Critical, "Error Loading Configuration")
+                            MsgBox("There was an error loading the previous configuration, the program will launch with a clean config.", MsgBoxStyle.Critical, "Error Loading Configuration")
                         End If
                     End If
                 Catch ex As Exception

--- a/Free SysLog/My Project/AssemblyInfo.vb
+++ b/Free SysLog/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("5.7.10.138")>
+<Assembly: AssemblyFileVersion("5.7.11.139")>

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -800,7 +800,7 @@ Public Class Form1
 
                 MsgBox("Free SysLog will now close and restart itself for the imported settings to take effect.", MsgBoxStyle.Information, Text)
 
-                Dim myNewProcess As New Process() With {.StartInfo = New ProcessStartInfo(strEXEPath) With {.Arguments = "/wait"}}
+                Dim myNewProcess As New Process() With {.StartInfo = New ProcessStartInfo(strEXEPath) With {.Arguments = "--wait"}}
                 myNewProcess.Start()
 
                 Process.GetCurrentProcess.Kill()

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -785,15 +785,23 @@ Public Class Form1
 
                 WriteLogsToDisk()
 
-                Threading.Thread.Sleep(500)
-
-                MsgBox("Free SysLog will now close And restart itself For the imported settings To take effect.", MsgBoxStyle.Information, Text)
-                Process.Start(strEXEPath)
-
                 Try
-                    mutex.ReleaseMutex()
+                    If boolDoWeOwnTheMutex Then
+                        mutex.ReleaseMutex()
+                        mutex.Dispose()
+
+                        SendMessageToSysLogServer(strTerminate, My.Settings.sysLogPort)
+                        If My.Settings.EnableTCPServer Then SendMessageToTCPSysLogServer(strTerminate, My.Settings.sysLogPort)
+
+                        Threading.Thread.Sleep(500)
+                    End If
                 Catch ex As ApplicationException
                 End Try
+
+                MsgBox("Free SysLog will now close and restart itself for the imported settings to take effect.", MsgBoxStyle.Information, Text)
+
+                Dim myNewProcess As New Process() With {.StartInfo = New ProcessStartInfo(strEXEPath) With {.Arguments = "/wait"}}
+                myNewProcess.Start()
 
                 Process.GetCurrentProcess.Kill()
             End If

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -1670,7 +1670,7 @@ Public Class Form1
                                                                        ProxiedSysLogData = New ProxiedSysLogData() With {.ip = strSourceIP, .log = strReceivedData}
                                                                        Dim strDataToSend As String = strProxiedString & Newtonsoft.Json.JsonConvert.SerializeObject(ProxiedSysLogData)
 
-                                                                       For Each item As SysLogProxyServer In serversList.GetSnapshot
+                                                                       For Each item As SysLogProxyServer In serversList.GetSnapshot.Where(Function(LINQitem As SysLogProxyServer) LINQitem.boolEnabled)
                                                                            SendMessageToSysLogServer(strDataToSend, item.ip, item.port)
                                                                        Next
 

--- a/Free SysLog/Windows/Form1.vb
+++ b/Free SysLog/Windows/Form1.vb
@@ -783,6 +783,8 @@ Public Class Form1
             If OpenFileDialog.ShowDialog = DialogResult.OK AndAlso SaveAppSettings.LoadApplicationSettingsFromFile(OpenFileDialog.FileName, Text) Then
                 My.Settings.Save()
 
+                WriteLogsToDisk()
+
                 Threading.Thread.Sleep(500)
 
                 MsgBox("Free SysLog will now close And restart itself For the imported settings To take effect.", MsgBoxStyle.Information, Text)


### PR DESCRIPTION
- Forgot a call to WriteLogsToDisk() when importing program settings from file. 9491249419c419a18720d5b1dc74a05c6b77ccad
- Modified code to send messages only to enabled remote Free Syslog instances by filtering serversList.GetSnapshot with LINQ's Where method on boolEnabled. Previously, all items were iterated regardless of their enabled state. 6fa31290d120a108059bbc578d55dc492081a304
- Fixed relaunching the program after importing settings. d03e96c53d544028300fc09a3b134e0440e72752